### PR TITLE
Update __init__.py

### DIFF
--- a/plugins.v2/cloudstrmcompanion/__init__.py
+++ b/plugins.v2/cloudstrmcompanion/__init__.py
@@ -302,7 +302,7 @@ class CloudStrmCompanion(_PluginBase):
 
         if event:
             event_data = event.event_data
-            if not event_data or event_data.get("action") != "cloudStrmCompanion":
+            if not event_data or event_data.get("action") != "CloudStrmCompanion":
                 return
             logger.info("收到命令，开始云盘Strm助手同步生成 ...")
             self.post_message(channel=event.event_data.get("channel"),


### PR DESCRIPTION
event_data.get("action") != "`cloudStrmCompanion`" 和 插件命令的 action`CloudStrmCompanion` 首字母大小写不一致导致无法进入命令执行