### PR TITLE
修复 embymetarefresh 缓存序列化错误问题

### DIFF
--- a/package.v2.json
+++ b/package.v2.json
@@ -21,11 +21,12 @@
     "name": "Emby元数据刷新",
     "description": "定时刷新Emby媒体库元数据，演职人员中文。",
     "labels": "Emby",
-    "version": "2.3.1",
+    "version": "2.3.2",
     "icon": "https://raw.githubusercontent.com/thsrite/MoviePilot-Plugins/main/icons/emby-icon.png",
     "author": "thsrite",
     "level": 1,
     "history": {
+      "v2.3.2": "修复缓存序列化错误问题",
       "v2.3.1": "doumao yyds",
       "v2.3.0": "优化内存占用",
       "v2.2.8": "修复按照历史记录刷新，auto默认为true",


### PR DESCRIPTION
当未启用 Redis 缓存时，FileCache 获取到的实例对象为 FileBackend，FileBackend 的 set 方法只支持缓存字符串或二进制，且 FileBackend 的 get 方法固定返回为二进制，故当使用 FileBackend 存储 tv_info dict 时报错 `a bytes-like object is required, not 'dict'`。

此处将 tv_info 转为 bytes 后再进行缓存（未选择转为 str 类型是因为 tv_info dict 中存在某些自定义类未实现序列化方式），同时兼容 Redis 与 FileBackend 两种缓存方式。