### PR TITLE
feat: 完成第四批 MoviePilot V3 插件迁移

### DIFF
--- a/package.json
+++ b/package.json
@@ -798,6 +798,7 @@
     "author": "thsrite",
     "level": 1,
     "v2": true,
+    "v3": false,
     "history": {
       "v1.0.2": "修复问题",
       "v1.0.1": "支持Lucky最新版本获取ipv4。",

--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
     "author": "thsrite",
     "level": 1,
     "v2": true,
+    "v3": false,
     "history": {
       "v1.3": "新增参数title、content、url",
       "v1.2": "修改配置描述",

--- a/package.json
+++ b/package.json
@@ -538,6 +538,7 @@
     "author": "thsrite",
     "level": 1,
     "v2": true,
+    "v3": false,
     "history": {
       "v2.1": "修复 MoviePilot v2.14 定时任务未传递热门订阅参数的问题",
       "v2.0": "适配 MoviePilot v2.14 订阅统计接口",

--- a/package.json
+++ b/package.json
@@ -260,6 +260,7 @@
     "author": "thsrite",
     "level": 2,
     "v2": true,
+    "v3": false,
     "history": {
       "v2.1.1": "尝试修复未匹配到演员的bug",
       "v2.1": "逻辑优化",

--- a/package.json
+++ b/package.json
@@ -659,6 +659,7 @@
     "author": "thsrite",
     "level": 2,
     "v2": true,
+    "v3": false,
     "history": {
       "v1.6.2": "修复云盘删除检查空文件夹",
       "v1.6.1": "移除不必要的参数",

--- a/package.json
+++ b/package.json
@@ -688,6 +688,7 @@
     "author": "thsrite",
     "level": 2,
     "v2": true,
+    "v3": false,
     "history": {
       "v1.1": "无评分默认评分0",
       "v1.0": "获取TMDB演员作品，并自动添加到订阅"

--- a/package.v3.json
+++ b/package.v3.json
@@ -181,6 +181,20 @@
       "v2.0.0": "适配 V3 SDK、外部 API 错误边界和明确响应模型。"
     }
   },
+  "SynologyNotify": {
+    "name": "群辉Webhook通知",
+    "description": "接收群辉webhook通知并推送。",
+    "labels": "消息通知",
+    "version": "2.0.0",
+    "icon": "https://raw.githubusercontent.com/thsrite/MoviePilot-Plugins/main/icons/synology.png",
+    "author": "thsrite",
+    "level": 1,
+    "release": true,
+    "system_version": ">=3.0.0",
+    "history": {
+      "v2.0.0": "适配 V3 SDK，迁移 Webhook 通知与消息类型合同。"
+    }
+  },
   "AutoBackup": {
     "name": "自动备份",
     "description": "自动备份数据和配置文件。",

--- a/package.v3.json
+++ b/package.v3.json
@@ -139,6 +139,20 @@
       "v3.0.0": "适配 V3 事件、异步网络和订阅数据访问合同。"
     }
   },
+  "ActorSubscribePlus": {
+    "name": "演员作品订阅",
+    "description": "获取TMDB演员作品，并自动添加到订阅。",
+    "labels": "订阅",
+    "version": "2.0.0",
+    "icon": "https://raw.githubusercontent.com/thsrite/MoviePilot-Plugins/main/icons/actorsubscribeplus.png",
+    "author": "thsrite",
+    "level": 2,
+    "release": true,
+    "system_version": ">=3.0.0",
+    "history": {
+      "v2.0.0": "适配 V3 SDK、统一媒体身份并迁移演员订阅历史。"
+    }
+  },
   "AutoBackup": {
     "name": "自动备份",
     "description": "自动备份数据和配置文件。",

--- a/package.v3.json
+++ b/package.v3.json
@@ -167,6 +167,20 @@
       "v2.0.0": "适配 V3 SDK、统一媒体身份并迁移演员订阅历史。"
     }
   },
+  "Lucky": {
+    "name": "Lucky",
+    "description": "Lucky HomePage自定义API。",
+    "labels": "工具",
+    "version": "2.0.0",
+    "icon": "Lucky_A.png",
+    "author": "thsrite",
+    "level": 1,
+    "release": true,
+    "system_version": ">=3.0.0",
+    "history": {
+      "v2.0.0": "适配 V3 SDK、外部 API 错误边界和明确响应模型。"
+    }
+  },
   "AutoBackup": {
     "name": "自动备份",
     "description": "自动备份数据和配置文件。",

--- a/package.v3.json
+++ b/package.v3.json
@@ -125,6 +125,20 @@
       "v2.0.0": "适配 V3 SDK、迁移 Emby 标签和音频标签处理链路。"
     }
   },
+  "PopularSubscribe": {
+    "name": "热门媒体订阅",
+    "description": "自动添加热门电影、电视剧、动漫到订阅。",
+    "labels": "订阅",
+    "version": "3.0.0",
+    "icon": "https://raw.githubusercontent.com/thsrite/MoviePilot-Plugins/main/icons/popular.png",
+    "author": "thsrite",
+    "level": 1,
+    "release": true,
+    "system_version": ">=3.0.0",
+    "history": {
+      "v3.0.0": "适配 V3 SDK、统一媒体身份、统计读取与订阅历史。"
+    }
+  },
   "WeChatForward": {
     "name": "微信消息转发",
     "description": "根据正则转发通知到其他WeChat应用。",

--- a/package.v3.json
+++ b/package.v3.json
@@ -195,6 +195,20 @@
       "v2.0.0": "适配 V3 SDK，迁移 Webhook 通知与消息类型合同。"
     }
   },
+  "CloudSyncDel": {
+    "name": "云盘同步删除",
+    "description": "媒体库删除软连接/strm文件后，同步删除云盘文件。",
+    "labels": "云盘",
+    "version": "2.0.0",
+    "icon": "clouddisk.png",
+    "author": "thsrite",
+    "level": 2,
+    "release": true,
+    "system_version": ">=3.0.0",
+    "history": {
+      "v2.0.0": "适配 V3 SDK、统一媒体身份并收紧路径删除边界。"
+    }
+  },
   "AutoBackup": {
     "name": "自动备份",
     "description": "自动备份数据和配置文件。",

--- a/package.v3.json
+++ b/package.v3.json
@@ -97,6 +97,20 @@
       "v2.0.0": "适配 V3 SDK、统一媒体身份并迁移订阅链路。"
     }
   },
+  "ActorSubscribe": {
+    "name": "演员订阅",
+    "description": "自动订阅指定演员热映电影、电视剧。",
+    "labels": "订阅",
+    "version": "3.0.0",
+    "icon": "Mdcng_A.png",
+    "author": "thsrite",
+    "level": 2,
+    "release": true,
+    "system_version": ">=3.0.0",
+    "history": {
+      "v3.0.0": "适配 V3 SDK、统一媒体身份并迁移演员订阅历史。"
+    }
+  },
   "EmbyMetaTag": {
     "name": "Emby媒体标签",
     "description": "自动给媒体库媒体添加标签。",

--- a/plugins.v3/actorsubscribe/__init__.py
+++ b/plugins.v3/actorsubscribe/__init__.py
@@ -1,0 +1,959 @@
+import time
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytz
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+from app import schemas
+from app.chain.douban import DoubanChain
+from app.chain.download import DownloadChain
+from app.chain.subscribe import SubscribeChain
+from app.chain.tmdb import TmdbChain
+from app.plugins import _PluginBase
+from app.schemas.types import MediaSource, MediaType
+from app.sdk.config import settings
+from app.sdk.logging import logger
+from app.sdk.media import MediaInfo, MetaInfo, build_media_key, resolve_media_identity
+
+
+class ActorSubscribe(_PluginBase):
+    """从热门榜单中筛选指定演员并创建订阅。"""
+
+    plugin_name = "演员订阅"
+    plugin_desc = "自动订阅指定演员热映电影、电视剧。"
+    plugin_icon = "Mdcng_A.png"
+    plugin_version = "3.0.0"
+    plugin_author = "thsrite"
+    author_url = "https://github.com/thsrite"
+    plugin_config_prefix = "actorsubscribe_"
+    plugin_order = 25
+    auth_level = 2
+
+    # 质量选择框数据
+    _quality_options = {
+        "全部": "",
+        "蓝光原盘": "Blu-?Ray.+VC-?1|Blu-?Ray.+AVC|UHD.+blu-?ray.+HEVC|MiniBD",
+        "Remux": "Remux",
+        "BluRay": "Blu-?Ray",
+        "UHD": "UHD|UltraHD",
+        "WEB-DL": "WEB-?DL|WEB-?RIP",
+        "HDTV": "HDTV",
+        "H265": "[Hx].?265|HEVC",
+        "H264": "[Hx].?264|AVC",
+    }
+
+    # 分辨率选择框数据
+    _resolution_options = {
+        "全部": "",
+        "4k": "4K|2160p|x2160",
+        "1080p": "1080[pi]|x1080",
+        "720p": "720[pi]|x720",
+    }
+
+    # 特效选择框数据
+    _effect_options = {
+        "全部": "",
+        "杜比视界": "Dolby[\\s.]+Vision|DOVI|[\\s.]+DV[\\s.]+",
+        "杜比全景声": "Dolby[\\s.]*\\+?Atmos|Atmos",
+        "HDR": "[\\s.]+HDR[\\s.]+|HDR10|HDR10\\+",
+        "SDR": "[\\s.]+SDR[\\s.]+",
+    }
+
+    def __init__(self):
+        """初始化热重载隔离的配置、调度器和业务链状态。"""
+        super().__init__()
+        self._enabled = False
+        self._onlyonce = False
+        self._cron = ""
+        self._actors = ""
+        self._quality = ""
+        self._resolution = ""
+        self._effect = ""
+        self._username = "演员订阅"
+        self._clear = False
+        self._clear_already_handle = False
+        self._source: List[str] = ["douban_showing"]
+        self._scheduler: Optional[BackgroundScheduler] = None
+        self.doubanchain: Optional[DoubanChain] = None
+        self.tmdbchain: Optional[TmdbChain] = None
+        self.subscribechain: Optional[SubscribeChain] = None
+        self.downloadchain: Optional[DownloadChain] = None
+
+    def init_plugin(self, config: dict = None):
+        """重建链实例、迁移历史并按配置注册定时任务。"""
+        self.stop_service()
+        self.doubanchain = DoubanChain()
+        self.tmdbchain = TmdbChain()
+        self.downloadchain = DownloadChain()
+        self.subscribechain = SubscribeChain()
+        self.__migrate_history_identity()
+
+        config = config or {}
+        self._enabled = bool(config.get("enabled", False))
+        self._onlyonce = bool(config.get("onlyonce", False))
+        self._cron = config.get("cron") or ""
+        self._actors = config.get("actors") or ""
+        self._quality = config.get("quality") or ""
+        self._resolution = config.get("resolution") or ""
+        self._effect = config.get("effect") or ""
+        self._clear = bool(config.get("clear", False))
+        self._clear_already_handle = bool(config.get("clear_already_handle", False))
+        source = config.get("source")
+        if isinstance(source, (list, tuple)):
+            self._source = [str(item) for item in source if str(item).strip()]
+        elif source:
+            self._source = [str(source)]
+        else:
+            self._source = ["douban_showing"]
+        self._username = config.get("username") or "演员订阅"
+
+        if self._clear:
+            self.del_data(key="history")
+            self._clear = False
+            self.__update_config()
+            logger.info("订阅历史清理完成")
+
+        if self._clear_already_handle:
+            self.del_data(key="already_handle")
+            self._clear_already_handle = False
+            self.__update_config()
+            logger.info("已处理历史清理完成")
+
+        if not (self._enabled or self._onlyonce):
+            return
+
+        self._scheduler = BackgroundScheduler(timezone=settings.TZ)
+        if self._onlyonce:
+            logger.info("明星热映订阅服务启动，立即运行一次")
+            self._scheduler.add_job(
+                self.__actor_subscribe,
+                "date",
+                run_date=datetime.now(tz=pytz.timezone(settings.TZ)) + timedelta(seconds=3),
+                name="明星热映订阅",
+            )
+            self._onlyonce = False
+            self.__update_config()
+
+        if self._cron:
+            try:
+                self._scheduler.add_job(
+                    func=self.__actor_subscribe,
+                    trigger=CronTrigger.from_crontab(self._cron),
+                    name="明星热映订阅",
+                )
+            except Exception as err:
+                logger.error(f"定时任务配置错误：{err}")
+                self.systemmessage.put(f"执行周期配置错误：{err}")
+
+        if self._scheduler.get_jobs():
+            self._scheduler.print_jobs()
+            self._scheduler.start()
+
+    @staticmethod
+    def __history_unique(title: str, media_source: MediaSource, media_id: str) -> str:
+        """为订阅历史构造包含来源和原生 ID 的稳定键。"""
+        return f"actorsubscribe: {title} ({build_media_key(media_source, media_id)})"
+
+    @staticmethod
+    def __detail_link(
+        media_source: Optional[MediaSource],
+        media_id: Optional[str],
+        media_type: Optional[str],
+    ) -> str:
+        """构造历史详情页的来源链接。"""
+        media_source, media_id = resolve_media_identity(
+            media_source=media_source,
+            media_id=media_id,
+        )
+        if not media_source or not media_id:
+            return ""
+        if media_source == MediaSource.TMDB:
+            path = "movie" if media_type in {MediaType.MOVIE.value, "movie"} else "tv"
+            return f"https://www.themoviedb.org/{path}/{media_id}"
+        if media_source == MediaSource.Douban:
+            return f"https://movie.douban.com/subject/{media_id}"
+        if media_source == MediaSource.Bangumi:
+            return f"https://bgm.tv/subject/{media_id}"
+        if media_source == MediaSource.AniList:
+            return f"https://anilist.co/anime/{media_id}"
+        if media_source == MediaSource.IMDb:
+            return f"https://www.imdb.com/title/{media_id}"
+        if media_source == MediaSource.TVDB:
+            return f"https://thetvdb.com/search?query={media_id}"
+        return ""
+
+    def __migrate_history_identity(self) -> None:
+        """将存量历史中的来源专有 ID 幂等迁移为统一媒体身份。"""
+        history = self.get_data("history")
+        if not isinstance(history, list):
+            return
+
+        changed = False
+        for item in history:
+            if not isinstance(item, dict):
+                continue
+
+            media_source, media_id = resolve_media_identity(
+                media_source=item.get("media_source"),
+                media_id=item.get("media_id"),
+            )
+            if not media_source:
+                for legacy_source, legacy_key in (
+                    (MediaSource.TMDB, "tmdbid"),
+                    (MediaSource.Douban, "doubanid"),
+                ):
+                    media_source, media_id = resolve_media_identity(
+                        media_source=legacy_source,
+                        media_id=item.get(legacy_key),
+                    )
+                    if media_source:
+                        break
+            if not media_source:
+                continue
+
+            migrated = {
+                key: value
+                for key, value in item.items()
+                if key not in {"tmdbid", "doubanid"}
+            }
+            migrated["media_source"] = media_source.value
+            migrated["media_id"] = media_id
+            migrated["detail_link"] = migrated.get("detail_link") or self.__detail_link(
+                media_source=media_source,
+                media_id=media_id,
+                media_type=migrated.get("type"),
+            )
+            migrated["unique"] = self.__history_unique(
+                title=migrated.get("title") or "",
+                media_source=media_source,
+                media_id=media_id,
+            )
+            if migrated != item:
+                item.clear()
+                item.update(migrated)
+                changed = True
+
+        if changed:
+            self.save_data("history", history)
+
+    @staticmethod
+    def __media_type(mediainfo: MediaInfo) -> Optional[MediaType]:
+        """将链返回的媒体类型规范化为宿主枚举。"""
+        if isinstance(mediainfo.type, MediaType):
+            return mediainfo.type
+        try:
+            return MediaType(mediainfo.type)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def __people_names(people: Any) -> List[str]:
+        """提取标准演职员字典或兼容字符串中的姓名。"""
+        names = []
+        for person in people or []:
+            if isinstance(person, str):
+                name = person.strip()
+            elif isinstance(person, dict):
+                name = str(person.get("name") or person.get("original_name") or "").strip()
+            else:
+                name = str(getattr(person, "name", "") or "").strip()
+            if name and name not in names:
+                names.append(name)
+        return names
+
+    def __get_douban_actors(self, mediainfo: MediaInfo, season: int = None) -> List[str]:
+        """当榜单缺少演职员时，从豆瓣详情补充中文姓名。"""
+        sleep_time = 3 + int(time.time()) % 7
+        logger.debug(f"随机休眠 {sleep_time}秒 ...")
+        time.sleep(sleep_time)
+
+        if self.doubanchain is None:
+            self.doubanchain = DoubanChain()
+        media_source, media_id = resolve_media_identity(media=mediainfo)
+        if media_source == MediaSource.Douban and media_id:
+            doubanitem = self.doubanchain.douban_info(media_id, mtype=mediainfo.type) or {}
+        else:
+            doubaninfo = self.doubanchain.match_doubaninfo(
+                name=mediainfo.title,
+                imdbid=mediainfo.imdb_id,
+                mtype=mediainfo.type,
+                year=mediainfo.year,
+                season=season,
+            )
+            doubanitem = (
+                self.doubanchain.douban_info(doubaninfo.get("id"), mtype=mediainfo.type) or {}
+                if doubaninfo and doubaninfo.get("id")
+                else {}
+            )
+
+        if not doubanitem:
+            logger.debug(f"未找到豆瓣信息：{mediainfo.title_year}")
+            return []
+        return self.__people_names(
+            (doubanitem.get("actors") or []) + (doubanitem.get("directors") or [])
+        )
+
+    @staticmethod
+    def __source_result(result: Any, label: str) -> List[MediaInfo]:
+        """将来源链返回值规范化为媒体列表并记录数量。"""
+        medias = result if isinstance(result, list) else []
+        if medias:
+            logger.info(f"获取到{label} {len(medias)} 部")
+        return medias
+
+    def __douban_movie_showing(self) -> List[MediaInfo]:
+        return self.__source_result(self.doubanchain.movie_showing(page=1, count=30), "豆瓣正在热映")
+
+    def __douban_movies(self) -> List[MediaInfo]:
+        return self.__source_result(
+            self.doubanchain.douban_discover(
+                mtype=MediaType.MOVIE, sort="R", tags="", page=1, count=30
+            ),
+            "豆瓣电影",
+        )
+
+    def __douban_tvs(self) -> List[MediaInfo]:
+        return self.__source_result(
+            self.doubanchain.douban_discover(
+                mtype=MediaType.TV, sort="R", tags="", page=1, count=30
+            ),
+            "豆瓣剧集",
+        )
+
+    def __douban_movie_top250(self) -> List[MediaInfo]:
+        return self.__source_result(self.doubanchain.movie_top250(page=1, count=30), "豆瓣电影TOP250")
+
+    def __douban_tv_weekly_chinese(self) -> List[MediaInfo]:
+        return self.__source_result(
+            self.doubanchain.tv_weekly_chinese(page=1, count=30), "豆瓣国产剧集周榜"
+        )
+
+    def __douban_tv_weekly_global(self) -> List[MediaInfo]:
+        return self.__source_result(
+            self.doubanchain.tv_weekly_global(page=1, count=30), "豆瓣全球剧集周榜"
+        )
+
+    def __douban_tv_animation(self) -> List[MediaInfo]:
+        return self.__source_result(self.doubanchain.tv_animation(page=1, count=30), "豆瓣动画剧集")
+
+    def __douban_movie_hot(self) -> List[MediaInfo]:
+        return self.__source_result(self.doubanchain.movie_hot(page=1, count=30), "豆瓣热门电影")
+
+    def __douban_tv_hot(self) -> List[MediaInfo]:
+        return self.__source_result(self.doubanchain.tv_hot(page=1, count=30), "豆瓣热门电视剧")
+
+    def __tmdb_movies(self) -> List[MediaInfo]:
+        return self.__source_result(
+            self.tmdbchain.tmdb_discover(
+                mtype=MediaType.MOVIE,
+                sort_by="popularity.desc",
+                with_genres="",
+                with_original_language="",
+                with_keywords="",
+                with_watch_providers="",
+                vote_average=0,
+                vote_count=0,
+                release_date="",
+                page=1,
+            ),
+            "TMDB电影",
+        )
+
+    def __tmdb_tvs(self) -> List[MediaInfo]:
+        return self.__source_result(
+            self.tmdbchain.tmdb_discover(
+                mtype=MediaType.TV,
+                sort_by="popularity.desc",
+                with_genres="",
+                with_original_language="",
+                with_keywords="",
+                with_watch_providers="",
+                vote_average=0,
+                vote_count=0,
+                release_date="",
+                page=1,
+            ),
+            "TMDB剧集",
+        )
+
+    def __tmdb_trending(self) -> List[MediaInfo]:
+        return self.__source_result(self.tmdbchain.tmdb_trending(page=1), "TMDB流行趋势")
+
+    def __source_medias(self, source: str) -> List[MediaInfo]:
+        """按配置调用来源查询，单一来源失败不影响本轮其它来源。"""
+        handlers = {
+            "douban_showing": self.__douban_movie_showing,
+            "douban_movies": self.__douban_movies,
+            "douban_tvs": self.__douban_tvs,
+            "douban_movie_top250": self.__douban_movie_top250,
+            "douban_tv_weekly_chinese": self.__douban_tv_weekly_chinese,
+            "douban_tv_weekly_global": self.__douban_tv_weekly_global,
+            "douban_tv_animation": self.__douban_tv_animation,
+            "douban_movie_hot": self.__douban_movie_hot,
+            "douban_tv_hot": self.__douban_tv_hot,
+            "tmdb_movies": self.__tmdb_movies,
+            "tmdb_tvs": self.__tmdb_tvs,
+            "tmdb_trending": self.__tmdb_trending,
+        }
+        handler = handlers.get(source)
+        if not handler:
+            logger.warning(f"未知的订阅源：{source}")
+            return []
+        try:
+            return handler()
+        except Exception as err:
+            logger.error(f"订阅源 {source} 查询失败：{err}")
+            return []
+
+    def __save_progress(self, history: List[dict], already_handle: List[str]) -> None:
+        """持久化本轮进度，避免后续候选失败时丢失成功结果。"""
+        self.save_data("history", history)
+        self.save_data("already_handle", already_handle)
+
+    def __actor_subscribe(self):
+        """查询配置来源并为命中演员的媒体创建订阅。"""
+        if not self._actors:
+            logger.warning("暂无订阅明星，停止运行")
+            return
+
+        history = self.get_data("history") or []
+        already_handle = self.get_data("already_handle") or []
+        if not isinstance(history, list):
+            history = []
+        if not isinstance(already_handle, list):
+            already_handle = []
+        subscribe_actors = {
+            actor.strip() for actor in str(self._actors).split(",") if actor.strip()
+        }
+        seen_keys = set()
+
+        try:
+            for configured_source in self._source or []:
+                source = str(configured_source).strip()
+                if not source:
+                    continue
+                for mediainfo in self.__source_medias(source):
+                    media_source, media_id = resolve_media_identity(media=mediainfo)
+                    media_key = build_media_key(media_source, media_id)
+                    if not media_key:
+                        logger.warning("媒体候选缺少有效 media_source/media_id，跳过")
+                        continue
+                    if media_key in seen_keys:
+                        continue
+                    seen_keys.add(media_key)
+
+                    media_type = self.__media_type(mediainfo)
+                    if media_type not in {MediaType.MOVIE, MediaType.TV}:
+                        logger.warning(f"{mediainfo.title or media_key} 媒体类型无效，跳过")
+                        continue
+                    if not mediainfo.title:
+                        logger.warning(f"{media_key} 缺少媒体标题，跳过")
+                        continue
+                    title_year = mediainfo.title_year
+                    if media_key in already_handle:
+                        logger.warning(f"{media_type.value} {title_year} 已被处理，跳过")
+                        continue
+                    if title_year in already_handle:
+                        normalized_handle = []
+                        for handled_key in already_handle:
+                            handled_key = media_key if handled_key == title_year else handled_key
+                            if handled_key not in normalized_handle:
+                                normalized_handle.append(handled_key)
+                        already_handle[:] = normalized_handle
+                        self.__save_progress(history, already_handle)
+                        logger.warning(f"{media_type.value} {title_year} 已被处理，跳过")
+                        continue
+
+                    try:
+                        media_actors = self.__people_names(mediainfo.actors)
+                        media_actors.extend(
+                            actor for actor in self.__people_names(mediainfo.directors)
+                            if actor not in media_actors
+                        )
+                        if not media_actors:
+                            media_actors = self.__get_douban_actors(mediainfo)
+                    except Exception as err:
+                        logger.error(f"{title_year} 获取演员信息失败：{err}")
+                        continue
+
+                    if not media_actors:
+                        logger.warning(f"未识别到演员信息：{title_year}")
+                        continue
+                    logger.info(f"获取到 {mediainfo.title} 演员：{media_actors}")
+                    matched_actor = next(
+                        (actor for actor in media_actors if actor in subscribe_actors),
+                        None,
+                    )
+                    if not matched_actor:
+                        already_handle.append(media_key)
+                        self.__save_progress(history, already_handle)
+                        logger.info(f"{media_type.value} {title_year} 未命中订阅演员，跳过")
+                        continue
+
+                    meta = MetaInfo(mediainfo.title)
+                    meta.type = media_type
+                    try:
+                        exist_flag, _ = self.downloadchain.get_no_exists_info(
+                            meta=meta,
+                            mediainfo=mediainfo,
+                        )
+                    except Exception as err:
+                        logger.error(f"{title_year} 查询媒体库失败：{err}")
+                        continue
+                    if exist_flag:
+                        already_handle.append(media_key)
+                        self.__save_progress(history, already_handle)
+                        logger.warning(f"{title_year} 媒体库中已存在")
+                        continue
+
+                    try:
+                        subscribed = self.subscribechain.exists(mediainfo=mediainfo)
+                    except Exception as err:
+                        logger.error(f"{title_year} 查询订阅失败：{err}")
+                        continue
+                    if subscribed:
+                        already_handle.append(media_key)
+                        self.__save_progress(history, already_handle)
+                        logger.warning(f"{title_year} 订阅已存在")
+                        continue
+
+                    logger.info(
+                        f"{media_type.value} {title_year} {media_key} 命中订阅演员 {matched_actor}，"
+                        f"开始订阅。订阅规则：{self._quality} {self._resolution} "
+                        f"{self._effect} {self._username}"
+                    )
+                    try:
+                        subscribe_id, error = self.subscribechain.add(
+                            title=mediainfo.title,
+                            year=str(mediainfo.year or ""),
+                            mtype=media_type,
+                            media_source=media_source,
+                            media_id=media_id,
+                            exist_ok=True,
+                            quality=self._quality,
+                            resolution=self._resolution,
+                            effect=self._effect,
+                            username=self._username,
+                        )
+                    except Exception as err:
+                        logger.error(f"{title_year} 添加订阅异常：{err}")
+                        continue
+                    if not subscribe_id:
+                        logger.error(f"{title_year} 添加订阅失败：{error or '未知错误'}")
+                        continue
+
+                    already_handle.append(media_key)
+                    detail_link = mediainfo.detail_link or self.__detail_link(
+                        media_source=media_source,
+                        media_id=media_id,
+                        media_type=media_type.value,
+                    )
+                    history.append(
+                        {
+                            "title": mediainfo.title,
+                            "type": media_type.value,
+                            "year": mediainfo.year,
+                            "poster": mediainfo.get_poster_image(),
+                            "overview": mediainfo.overview,
+                            "media_source": media_source.value,
+                            "media_id": media_id,
+                            "detail_link": detail_link,
+                            "time": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                            "unique": self.__history_unique(
+                                title=mediainfo.title,
+                                media_source=media_source,
+                                media_id=media_id,
+                            ),
+                        }
+                    )
+                    self.__save_progress(history, already_handle)
+        finally:
+            self.__save_progress(history, already_handle)
+        logger.info("演员订阅任务完成")
+
+    def __update_config(self) -> None:
+        """保存当前配置并清除一次性控制开关。"""
+        self.update_config(
+            {
+                "enabled": self._enabled,
+                "onlyonce": self._onlyonce,
+                "cron": self._cron,
+                "actors": self._actors,
+                "quality": self._quality,
+                "resolution": self._resolution,
+                "effect": self._effect,
+                "clear": self._clear,
+                "clear_already_handle": self._clear_already_handle,
+                "source": self._source,
+                "username": self._username,
+            }
+        )
+
+    def delete_history(self, key: str) -> schemas.Response[None]:
+        """删除详情页中指定的订阅历史记录。"""
+        history = self.get_data("history")
+        if not history:
+            return schemas.Response(success=False, message="未找到历史记录")
+        history = [item for item in history if item.get("unique") != key]
+        self.save_data("history", history)
+        return schemas.Response(success=True, message="删除成功")
+
+    def get_state(self) -> bool:
+        return self._enabled
+
+    @staticmethod
+    def get_command() -> List[Dict[str, Any]]:
+        return []
+
+    def get_api(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "path": "/delete_history",
+                "endpoint": self.delete_history,
+                "methods": ["GET"],
+                "auth": "bear",
+                "summary": "删除订阅历史记录",
+                "response_model": schemas.Response[None],
+            }
+        ]
+
+    def get_form(self) -> Tuple[List[dict], Dict[str, Any]]:
+        """返回插件配置页面描述和默认配置。"""
+        quality_options = [
+            {"title": title, "value": value}
+            for title, value in self._quality_options.items()
+        ]
+        resolution_options = [
+            {"title": title, "value": value}
+            for title, value in self._resolution_options.items()
+        ]
+        effect_options = [
+            {"title": title, "value": value}
+            for title, value in self._effect_options.items()
+        ]
+        return [
+            {
+                "component": "VForm",
+                "content": [
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 3},
+                                "content": [
+                                    {
+                                        "component": "VSwitch",
+                                        "props": {"model": "enabled", "label": "启用插件"},
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 3},
+                                "content": [
+                                    {
+                                        "component": "VSwitch",
+                                        "props": {"model": "onlyonce", "label": "立即运行一次"},
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 3},
+                                "content": [
+                                    {
+                                        "component": "VSwitch",
+                                        "props": {"model": "clear", "label": "清理订阅记录"},
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 3},
+                                "content": [
+                                    {
+                                        "component": "VSwitch",
+                                        "props": {
+                                            "model": "clear_already_handle",
+                                            "label": "清理已处理记录",
+                                        },
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 3},
+                                "content": [
+                                    {
+                                        "component": "VCronField",
+                                        "props": {
+                                            "model": "cron",
+                                            "label": "执行周期",
+                                            "placeholder": "5位cron表达式，留空自动",
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 9},
+                                "content": [
+                                    {
+                                        "component": "VTextField",
+                                        "props": {
+                                            "model": "actors",
+                                            "label": "明星",
+                                            "placeholder": "多个英文逗号分割",
+                                        },
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 3},
+                                "content": [
+                                    {
+                                        "component": "VSelect",
+                                        "props": {
+                                            "multiple": False,
+                                            "chips": True,
+                                            "model": "quality",
+                                            "label": "质量",
+                                            "items": quality_options,
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 3},
+                                "content": [
+                                    {
+                                        "component": "VSelect",
+                                        "props": {
+                                            "multiple": False,
+                                            "chips": True,
+                                            "model": "resolution",
+                                            "label": "分辨率",
+                                            "items": resolution_options,
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 3},
+                                "content": [
+                                    {
+                                        "component": "VSelect",
+                                        "props": {
+                                            "multiple": False,
+                                            "chips": True,
+                                            "model": "effect",
+                                            "label": "特效",
+                                            "items": effect_options,
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 3},
+                                "content": [
+                                    {
+                                        "component": "VTextField",
+                                        "props": {
+                                            "model": "username",
+                                            "label": "订阅用户",
+                                            "placeholder": "默认为`演员订阅`",
+                                        },
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12},
+                                "content": [
+                                    {
+                                        "component": "VSelect",
+                                        "props": {
+                                            "multiple": True,
+                                            "chips": True,
+                                            "model": "source",
+                                            "label": "订阅来源",
+                                            "items": [
+                                                {"title": "豆瓣正在热映", "value": "douban_showing"},
+                                                {"title": "豆瓣电影", "value": "douban_movies"},
+                                                {"title": "豆瓣剧集", "value": "douban_tvs"},
+                                                {"title": "豆瓣电影TOP250", "value": "douban_movie_top250"},
+                                                {"title": "豆瓣国产剧集周榜", "value": "douban_tv_weekly_chinese"},
+                                                {"title": "豆瓣全球剧集周榜", "value": "douban_tv_weekly_global"},
+                                                {"title": "豆瓣动画剧集", "value": "douban_tv_animation"},
+                                                {"title": "豆瓣热门电影", "value": "douban_movie_hot"},
+                                                {"title": "豆瓣热门电视剧", "value": "douban_tv_hot"},
+                                                {"title": "TMDB电影", "value": "tmdb_movies"},
+                                                {"title": "TMDB剧集", "value": "tmdb_tvs"},
+                                                {"title": "TMDB流行趋势", "value": "tmdb_trending"},
+                                            ],
+                                        },
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                ],
+            }
+        ], {
+            "enabled": False,
+            "onlyonce": False,
+            "cron": "5 1 * * *",
+            "actors": "",
+            "quality": "",
+            "resolution": "",
+            "effect": "",
+            "username": "演员订阅",
+            "clear": False,
+            "clear_already_handle": False,
+            "source": ["douban_showing"],
+        }
+
+    def get_page(self) -> List[dict]:
+        """构造插件详情页面，展示已创建订阅及其来源详情。"""
+        history = self.get_data("history")
+        if not history:
+            return [
+                {
+                    "component": "div",
+                    "text": "暂无数据",
+                    "props": {"class": "text-center"},
+                }
+            ]
+
+        contents = []
+        for item in sorted(history, key=lambda value: value.get("time") or "", reverse=True):
+            title = item.get("title")
+            media_type = item.get("type")
+            media_source, media_id = resolve_media_identity(
+                media_source=item.get("media_source"),
+                media_id=item.get("media_id"),
+            )
+            unique = item.get("unique") or (
+                self.__history_unique(title or "", media_source, media_id)
+                if media_source and media_id
+                else ""
+            )
+            detail_link = item.get("detail_link") or self.__detail_link(
+                media_source=media_source,
+                media_id=media_id,
+                media_type=media_type,
+            )
+            contents.append(
+                {
+                    "component": "VCard",
+                    "content": [
+                        {
+                            "component": "VDialogCloseBtn",
+                            "props": {"innerClass": "absolute top-0 right-0"},
+                            "events": {
+                                "click": {
+                                    "api": "plugin/ActorSubscribe/delete_history",
+                                    "method": "get",
+                                    "params": {"key": unique},
+                                }
+                            },
+                        },
+                        {
+                            "component": "div",
+                            "props": {
+                                "class": "d-flex justify-space-start flex-nowrap flex-row",
+                            },
+                            "content": [
+                                {
+                                    "component": "div",
+                                    "content": [
+                                        {
+                                            "component": "VImg",
+                                            "props": {
+                                                "src": item.get("poster"),
+                                                "height": 120,
+                                                "width": 80,
+                                                "aspect-ratio": "2/3",
+                                                "class": "object-cover shadow ring-gray-500",
+                                                "cover": True,
+                                            },
+                                        }
+                                    ],
+                                },
+                                {
+                                    "component": "div",
+                                    "content": [
+                                        {
+                                            "component": "VCardSubtitle",
+                                            "props": {
+                                                "class": "pa-2 font-bold break-words whitespace-break-spaces"
+                                            },
+                                            "content": [
+                                                {
+                                                    "component": "a",
+                                                    "props": {
+                                                        "href": detail_link,
+                                                        "target": "_blank",
+                                                    },
+                                                    "text": title,
+                                                }
+                                            ],
+                                        },
+                                        {
+                                            "component": "VCardText",
+                                            "props": {"class": "pa-0 px-2"},
+                                            "text": f"类型：{media_type}",
+                                        },
+                                        {
+                                            "component": "VCardText",
+                                            "props": {"class": "pa-0 px-2"},
+                                            "text": f"时间：{item.get('time')}",
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                }
+            )
+
+        return [
+            {
+                "component": "div",
+                "props": {"class": "grid gap-3 grid-info-card"},
+                "content": contents,
+            }
+        ]
+
+    def stop_service(self):
+        """停止插件的定时任务并释放调度器。"""
+        try:
+            if self._scheduler:
+                self._scheduler.remove_all_jobs()
+                if self._scheduler.running:
+                    self._scheduler.shutdown()
+                self._scheduler = None
+        except Exception as err:
+            logger.error(f"退出插件失败：{err}")

--- a/plugins.v3/actorsubscribeplus/__init__.py
+++ b/plugins.v3/actorsubscribeplus/__init__.py
@@ -1,0 +1,751 @@
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytz
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+from app import schemas
+from app.chain.download import DownloadChain
+from app.chain.media import MediaChain
+from app.chain.subscribe import SubscribeChain
+from app.chain.tmdb import TmdbChain
+from app.plugins import _PluginBase
+from app.schemas.types import MediaSource, MediaType
+from app.sdk.config import settings
+from app.sdk.logging import logger
+from app.sdk.media import MetaInfo, build_media_key, resolve_media_identity
+
+
+class ActorSubscribePlus(_PluginBase):
+    """按演员筛选影视作品并创建订阅。"""
+
+    # 插件名称
+    plugin_name = "演员作品订阅"
+    # 插件描述
+    plugin_desc = "获取TMDB演员作品，并自动添加到订阅。"
+    # 插件图标
+    plugin_icon = "https://raw.githubusercontent.com/thsrite/MoviePilot-Plugins/main/icons/actorsubscribeplus.png"
+    # 插件版本
+    plugin_version = "2.0.0"
+    # 插件作者
+    plugin_author = "thsrite"
+    # 作者主页
+    author_url = "https://github.com/thsrite"
+    # 插件配置项ID前缀
+    plugin_config_prefix = "actorsubscribeplus_"
+    # 加载顺序
+    plugin_order = 26
+    # 可使用的用户级别
+    auth_level = 2
+
+    _enabled: bool = False
+    _onlyonce: bool = False
+    _cron: str = ""
+    _actors: Optional[str] = None
+    _scheduler: Optional[BackgroundScheduler] = None
+    _clear: bool = False
+    _clear_already_handle: bool = False
+    _mtype: List[str] = [MediaType.MOVIE.value, MediaType.TV.value]
+    _year: int = 2000
+    _last: int = 30
+    _vate: float = 0
+    mediachain: Optional[MediaChain] = None
+    tmdbchain: Optional[TmdbChain] = None
+    subscribechain: Optional[SubscribeChain] = None
+    downloadchain: Optional[DownloadChain] = None
+
+    def init_plugin(self, config: dict = None):
+        """重建链实例、迁移历史并根据配置注册定时任务。"""
+        self.stop_service()
+        self.mediachain = MediaChain()
+        self.tmdbchain = TmdbChain()
+        self.downloadchain = DownloadChain()
+        self.subscribechain = SubscribeChain()
+        self.__migrate_history_identity()
+
+        config = config or {}
+        self._enabled = bool(config.get("enabled", False))
+        self._onlyonce = bool(config.get("onlyonce", False))
+        self._cron = config.get("cron") or ""
+        self._actors = config.get("actors") or ""
+        self._clear = bool(config.get("clear", False))
+        self._clear_already_handle = bool(config.get("clear_already_handle", False))
+        self._mtype = config.get("mtype") or [MediaType.MOVIE.value, MediaType.TV.value]
+        self._year = config.get("year", 2000)
+        self._last = config.get("last", 30)
+        self._vate = config.get("vate", 0)
+
+        if self._clear:
+            self.del_data(key="history")
+            self._clear = False
+            self.__update_config()
+            logger.info("订阅历史清理完成")
+
+        if self._clear_already_handle:
+            self.del_data(key="already_handle")
+            self._clear_already_handle = False
+            self.__update_config()
+            logger.info("已处理历史清理完成")
+
+        if not (self._enabled or self._onlyonce):
+            return
+
+        self._scheduler = BackgroundScheduler(timezone=settings.TZ)
+        if self._onlyonce:
+            logger.info("演员作品订阅服务启动，立即运行一次")
+            self._scheduler.add_job(
+                self.__actor_subscribe,
+                "date",
+                run_date=datetime.now(tz=pytz.timezone(settings.TZ)) + timedelta(seconds=3),
+                name="演员作品订阅",
+            )
+            self._onlyonce = False
+            self.__update_config()
+
+        if self._cron:
+            try:
+                self._scheduler.add_job(
+                    func=self.__actor_subscribe,
+                    trigger=CronTrigger.from_crontab(self._cron),
+                    name="演员作品订阅",
+                )
+            except Exception as err:
+                logger.error(f"定时任务配置错误：{err}")
+                self.systemmessage.put(f"执行周期配置错误：{err}")
+
+        if self._scheduler.get_jobs():
+            self._scheduler.print_jobs()
+            self._scheduler.start()
+
+    @staticmethod
+    def __history_unique(title: str, media_source: MediaSource, media_id: str) -> str:
+        """构造同时包含来源和来源原生 ID 的稳定历史键。"""
+        return f"actorsubscribeplus: {title} ({build_media_key(media_source, media_id)})"
+
+    @staticmethod
+    def __detail_link(
+        media_source: Optional[MediaSource],
+        media_id: Optional[str],
+        media_type: Optional[str],
+    ) -> str:
+        """构造历史详情页的来源链接。"""
+        media_source, media_id = resolve_media_identity(
+            media_source=media_source,
+            media_id=media_id,
+        )
+        if not media_source or not media_id:
+            return ""
+        if media_source == MediaSource.TMDB:
+            path = "movie" if media_type in {MediaType.MOVIE.value, "movie"} else "tv"
+            return f"https://www.themoviedb.org/{path}/{media_id}"
+        if media_source == MediaSource.Douban:
+            return f"https://movie.douban.com/subject/{media_id}"
+        if media_source == MediaSource.Bangumi:
+            return f"https://bgm.tv/subject/{media_id}"
+        if media_source == MediaSource.AniList:
+            return f"https://anilist.co/anime/{media_id}"
+        if media_source == MediaSource.IMDb:
+            return f"https://www.imdb.com/title/{media_id}"
+        if media_source == MediaSource.TVDB:
+            return f"https://thetvdb.com/search?query={media_id}"
+        return ""
+
+    def __migrate_history_identity(self) -> None:
+        """将存量历史中的来源专有 ID 幂等迁移为统一媒体身份。"""
+        history = self.get_data("history")
+        if not isinstance(history, list):
+            return
+
+        changed = False
+        for item in history:
+            if not isinstance(item, dict):
+                continue
+
+            media_source, media_id = resolve_media_identity(
+                media_source=item.get("media_source"),
+                media_id=item.get("media_id"),
+            )
+            if not media_source:
+                for legacy_source, legacy_key in (
+                    (MediaSource.TMDB, "tmdbid"),
+                    (MediaSource.Douban, "doubanid"),
+                ):
+                    media_source, media_id = resolve_media_identity(
+                        media_source=legacy_source,
+                        media_id=item.get(legacy_key),
+                    )
+                    if media_source:
+                        break
+            if not media_source:
+                continue
+
+            migrated = {
+                key: value
+                for key, value in item.items()
+                if key not in {"tmdbid", "doubanid"}
+            }
+            migrated["media_source"] = media_source.value
+            migrated["media_id"] = media_id
+            migrated["detail_link"] = migrated.get("detail_link") or self.__detail_link(
+                media_source=media_source,
+                media_id=media_id,
+                media_type=migrated.get("type"),
+            )
+            migrated["unique"] = self.__history_unique(
+                title=migrated.get("title") or "",
+                media_source=media_source,
+                media_id=media_id,
+            )
+            if migrated != item:
+                item.clear()
+                item.update(migrated)
+                changed = True
+
+        if changed:
+            self.save_data("history", history)
+
+    @staticmethod
+    def __media_type(mediainfo: Any) -> Optional[MediaType]:
+        """把链返回的媒体类型规范化为宿主枚举。"""
+        if isinstance(mediainfo.type, MediaType):
+            return mediainfo.type
+        try:
+            return MediaType(mediainfo.type)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def __release_date(mediainfo: Any) -> Optional[datetime]:
+        """解析电影上映日期或电视剧首播日期，非法日期按缺失处理。"""
+        release_date = mediainfo.first_air_date or mediainfo.release_date
+        if not release_date:
+            return None
+        try:
+            return datetime.strptime(str(release_date), "%Y-%m-%d")
+        except (TypeError, ValueError):
+            return None
+
+    def __save_progress(self, history: List[dict], already_handle: List[str]) -> None:
+        """持久化已完成候选，避免后续候选失败时丢失本轮进度。"""
+        self.save_data("history", history)
+        self.save_data("already_handle", already_handle)
+
+    def __actor_subscribe(self):
+        """查询配置演员的 TMDB 作品并创建符合筛选条件的订阅。"""
+        if not self._actors:
+            logger.warning("暂无订阅明星，停止运行")
+            return
+
+        history: List[dict] = self.get_data("history") or []
+        already_handle: List[str] = self.get_data("already_handle") or []
+        subscribe_actors = [actor.strip() for actor in str(self._actors).split(",") if actor.strip()]
+
+        try:
+            minimum_year = int(self._year)
+        except (TypeError, ValueError):
+            minimum_year = 2000
+        try:
+            recent_days = int(self._last)
+        except (TypeError, ValueError):
+            recent_days = 30
+        try:
+            minimum_vote = float(self._vate)
+        except (TypeError, ValueError):
+            minimum_vote = 0
+
+        for actor in subscribe_actors:
+            logger.info(f"开始订阅演员 {actor} 的作品")
+            persons = self.mediachain.search_persons(
+                name=actor,
+                media_source=MediaSource.TMDB,
+            )
+            if not persons:
+                logger.warning(f"未找到TMDB演员 {actor}")
+                continue
+
+            person_id = next(
+                (
+                    person.id
+                    for person in persons
+                    if person.source == MediaSource.TMDB.value and person.id
+                ),
+                None,
+            )
+            if not person_id:
+                logger.warning(f"未找到演员 {actor} 的Person ID")
+                continue
+
+            logger.info(f"正在获取演员 {actor} Person ID {person_id}")
+            actor_medias = []
+            for page in range(1, 10):
+                medias = self.tmdbchain.person_credits(person_id=person_id, page=page)
+                if not medias:
+                    break
+                actor_medias.extend(medias)
+
+            if not actor_medias:
+                logger.warning(f"未找到演员 {actor} 的作品")
+                continue
+
+            logger.info(f"获取到演员 {actor} 的作品 {len(actor_medias)} 部")
+            for mediainfo in actor_medias:
+                media_source, media_id = resolve_media_identity(media=mediainfo)
+                if not media_source or not media_id:
+                    logger.warning("演员作品缺少有效媒体身份，跳过")
+                    continue
+
+                media_type = self.__media_type(mediainfo)
+                if not media_type or media_type.value not in self._mtype:
+                    logger.warning(f"{mediainfo.title_year} 类型不在订阅列表中，跳过")
+                    continue
+
+                if not mediainfo.year:
+                    logger.warning(f"{mediainfo.title} 缺少年份，跳过")
+                    continue
+                try:
+                    media_year = int(mediainfo.year)
+                except (TypeError, ValueError):
+                    logger.warning(f"{mediainfo.title} 年份无法识别，跳过")
+                    continue
+                if media_year < minimum_year:
+                    logger.warning(f"{mediainfo.title_year} 年份不在订阅列表中，跳过")
+                    continue
+
+                release_date = self.__release_date(mediainfo)
+                if not release_date:
+                    logger.warning(f"{mediainfo.title_year} 缺少有效上映时间，跳过")
+                    continue
+                now = datetime.now()
+                if release_date > now and (release_date - now).days > recent_days:
+                    logger.warning(f"{mediainfo.title_year} 最近上映时间不在时间范围内，跳过")
+                    continue
+
+                try:
+                    vote_average = float(mediainfo.vote_average or 0)
+                except (TypeError, ValueError):
+                    logger.warning(f"{mediainfo.title_year} 评分无法识别，跳过")
+                    continue
+                if vote_average < minimum_vote:
+                    logger.warning(f"{mediainfo.title_year} 评分不足，跳过")
+                    continue
+
+                media_key = build_media_key(media_source, media_id)
+                if not media_key:
+                    logger.warning(f"{mediainfo.title_year} 媒体身份无效，跳过")
+                    continue
+                title_year = mediainfo.title_year
+                if media_key in already_handle or title_year in already_handle:
+                    logger.warning(f"{title_year} 已被处理，跳过")
+                    continue
+
+                logger.info(f"开始处理 {media_type.value} {title_year}")
+                meta = MetaInfo(mediainfo.title)
+                try:
+                    exist_flag, _ = self.downloadchain.get_no_exists_info(
+                        meta=meta,
+                        mediainfo=mediainfo,
+                    )
+                except Exception as err:
+                    logger.error(f"{title_year} 查询媒体库失败：{err}")
+                    continue
+                if exist_flag:
+                    logger.warning(f"{title_year} 媒体库中已存在")
+                    already_handle.append(media_key)
+                    self.__save_progress(history, already_handle)
+                    continue
+
+                try:
+                    subscribed = self.subscribechain.exists(mediainfo=mediainfo)
+                except Exception as err:
+                    logger.error(f"{title_year} 查询订阅失败：{err}")
+                    continue
+                if subscribed:
+                    logger.warning(f"{title_year} 订阅已存在")
+                    already_handle.append(media_key)
+                    self.__save_progress(history, already_handle)
+                    continue
+
+                logger.info(f"开始订阅 {actor} {media_type.value} {title_year} {media_key}")
+                try:
+                    subscribe_id, error = self.subscribechain.add(
+                        title=mediainfo.title,
+                        year=str(mediainfo.year),
+                        mtype=media_type,
+                        media_source=media_source,
+                        media_id=media_id,
+                        exist_ok=True,
+                        username="演员作品订阅",
+                    )
+                except Exception as err:
+                    logger.error(f"{title_year} 添加订阅异常：{err}")
+                    continue
+                if not subscribe_id:
+                    logger.error(f"{title_year} 添加订阅失败：{error or '未知错误'}")
+                    continue
+
+                already_handle.append(media_key)
+                detail_link = mediainfo.detail_link or self.__detail_link(
+                    media_source=media_source,
+                    media_id=media_id,
+                    media_type=media_type.value,
+                )
+                history.append(
+                    {
+                        "title": mediainfo.title,
+                        "type": media_type.value,
+                        "year": mediainfo.year,
+                        "poster": mediainfo.get_poster_image(),
+                        "overview": mediainfo.overview,
+                        "media_source": media_source.value,
+                        "media_id": media_id,
+                        "detail_link": detail_link,
+                        "time": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                        "unique": self.__history_unique(
+                            title=mediainfo.title,
+                            media_source=media_source,
+                            media_id=media_id,
+                        ),
+                    }
+                )
+                self.__save_progress(history, already_handle)
+            logger.info(f"演员 {actor} 订阅完成")
+
+        self.__save_progress(history, already_handle)
+        logger.info("演员订阅任务完成")
+
+    def __update_config(self):
+        """保存当前配置并清除一次性控制开关。"""
+        self.update_config(
+            {
+                "enabled": self._enabled,
+                "onlyonce": self._onlyonce,
+                "cron": self._cron,
+                "actors": self._actors,
+                "clear": self._clear,
+                "clear_already_handle": self._clear_already_handle,
+                "mtype": self._mtype,
+                "year": self._year,
+                "last": self._last,
+                "vate": self._vate,
+            }
+        )
+
+    def delete_history(self, key: str) -> schemas.Response[None]:
+        """删除详情页中指定的订阅历史记录。"""
+        history = self.get_data("history")
+        if not history:
+            return schemas.Response(success=False, message="未找到历史记录")
+        history = [item for item in history if item.get("unique") != key]
+        self.save_data("history", history)
+        return schemas.Response(success=True, message="删除成功")
+
+    def get_state(self) -> bool:
+        return self._enabled
+
+    @staticmethod
+    def get_command() -> List[Dict[str, Any]]:
+        return []
+
+    def get_api(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "path": "/delete_history",
+                "endpoint": self.delete_history,
+                "methods": ["GET"],
+                "auth": "bear",
+                "summary": "删除订阅历史记录",
+                "response_model": schemas.Response[None],
+            }
+        ]
+
+    def get_form(self) -> Tuple[List[dict], Dict[str, Any]]:
+        """返回插件配置页面描述和默认配置。"""
+        return [
+            {
+                "component": "VForm",
+                "content": [
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 3},
+                                "content": [
+                                    {
+                                        "component": "VSwitch",
+                                        "props": {"model": "enabled", "label": "启用插件"},
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 3},
+                                "content": [
+                                    {
+                                        "component": "VSwitch",
+                                        "props": {"model": "onlyonce", "label": "立即运行一次"},
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 3},
+                                "content": [
+                                    {
+                                        "component": "VSwitch",
+                                        "props": {"model": "clear", "label": "清理订阅记录"},
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 3},
+                                "content": [
+                                    {
+                                        "component": "VSwitch",
+                                        "props": {
+                                            "model": "clear_already_handle",
+                                            "label": "清理已处理记录",
+                                        },
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 3},
+                                "content": [
+                                    {
+                                        "component": "VTextField",
+                                        "props": {
+                                            "model": "cron",
+                                            "label": "执行周期",
+                                            "placeholder": "5位cron表达式，留空自动",
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 3},
+                                "content": [
+                                    {
+                                        "component": "VSelect",
+                                        "props": {
+                                            "multiple": True,
+                                            "chips": True,
+                                            "model": "mtype",
+                                            "label": "订阅类型",
+                                            "items": [
+                                                {"title": "电影", "value": "电影"},
+                                                {"title": "电视剧", "value": "电视剧"},
+                                            ],
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 3},
+                                "content": [
+                                    {
+                                        "component": "VTextField",
+                                        "props": {
+                                            "model": "year",
+                                            "label": "年份",
+                                            "placeholder": "大于该年份才会被订阅",
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 3},
+                                "content": [
+                                    {
+                                        "component": "VTextField",
+                                        "props": {
+                                            "model": "last",
+                                            "label": "最近多久上映",
+                                            "placeholder": "当前日期几天内上映的才会被订阅",
+                                        },
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 3},
+                                "content": [
+                                    {
+                                        "component": "VTextField",
+                                        "props": {
+                                            "model": "vate",
+                                            "label": "评分",
+                                            "placeholder": "大于该评分才会被订阅",
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 9},
+                                "content": [
+                                    {
+                                        "component": "VTextField",
+                                        "props": {
+                                            "model": "actors",
+                                            "label": "明星",
+                                            "placeholder": "多个英文逗号分割",
+                                        },
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            }
+        ], {
+            "enabled": False,
+            "onlyonce": False,
+            "cron": "5 1 * * *",
+            "actors": "",
+            "clear": False,
+            "year": 2000,
+            "last": 30,
+            "vate": 0,
+            "clear_already_handle": False,
+            "mtype": [MediaType.MOVIE.value, MediaType.TV.value],
+        }
+
+    def get_page(self) -> List[dict]:
+        """返回订阅历史详情页面描述。"""
+        history = self.get_data("history")
+        if not history:
+            return [
+                {
+                    "component": "div",
+                    "text": "暂无数据",
+                    "props": {"class": "text-center"},
+                }
+            ]
+
+        contents = []
+        for item in sorted(history, key=lambda value: value.get("time") or "", reverse=True):
+            title = item.get("title")
+            media_type = item.get("type")
+            media_source, media_id = resolve_media_identity(
+                media_source=item.get("media_source"),
+                media_id=item.get("media_id"),
+            )
+            unique = item.get("unique") or (
+                self.__history_unique(title or "", media_source, media_id)
+                if media_source and media_id
+                else ""
+            )
+            detail_link = item.get("detail_link") or self.__detail_link(
+                media_source=media_source,
+                media_id=media_id,
+                media_type=media_type,
+            )
+            contents.append(
+                {
+                    "component": "VCard",
+                    "content": [
+                        {
+                            "component": "VDialogCloseBtn",
+                            "props": {"innerClass": "absolute top-0 right-0"},
+                            "events": {
+                                "click": {
+                                    "api": "plugin/ActorSubscribePlus/delete_history",
+                                    "method": "get",
+                                    "params": {"key": unique},
+                                }
+                            },
+                        },
+                        {
+                            "component": "div",
+                            "props": {
+                                "class": "d-flex justify-space-start flex-nowrap flex-row",
+                            },
+                            "content": [
+                                {
+                                    "component": "div",
+                                    "content": [
+                                        {
+                                            "component": "VImg",
+                                            "props": {
+                                                "src": item.get("poster"),
+                                                "height": 120,
+                                                "width": 80,
+                                                "aspect-ratio": "2/3",
+                                                "class": "object-cover shadow ring-gray-500",
+                                                "cover": True,
+                                            },
+                                        }
+                                    ],
+                                },
+                                {
+                                    "component": "div",
+                                    "content": [
+                                        {
+                                            "component": "VCardSubtitle",
+                                            "props": {
+                                                "class": "pa-2 font-bold break-words whitespace-break-spaces"
+                                            },
+                                            "content": [
+                                                {
+                                                    "component": "a",
+                                                    "props": {
+                                                        "href": detail_link,
+                                                        "target": "_blank",
+                                                    },
+                                                    "text": title,
+                                                }
+                                            ],
+                                        },
+                                        {
+                                            "component": "VCardText",
+                                            "props": {"class": "pa-0 px-2"},
+                                            "text": f"类型：{media_type}",
+                                        },
+                                        {
+                                            "component": "VCardText",
+                                            "props": {"class": "pa-0 px-2"},
+                                            "text": f"时间：{item.get('time')}",
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                }
+            )
+
+        return [
+            {
+                "component": "div",
+                "props": {"class": "grid gap-3 grid-info-card"},
+                "content": contents,
+            }
+        ]
+
+    def stop_service(self):
+        """停止插件的定时任务并释放调度器。"""
+        try:
+            if self._scheduler:
+                self._scheduler.remove_all_jobs()
+                if self._scheduler.running:
+                    self._scheduler.shutdown()
+                self._scheduler = None
+        except Exception as err:
+            logger.error(f"退出插件失败：{err}")

--- a/plugins.v3/cloudsyncdel/__init__.py
+++ b/plugins.v3/cloudsyncdel/__init__.py
@@ -1,0 +1,689 @@
+"""云盘同步删除插件的 V3 实现。"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from app import schemas
+from app.plugins import _PluginBase
+from app.schemas.types import EventType, MediaImageType, MediaSource, MediaType, MessageType
+from app.sdk.config import settings
+from app.sdk.events import Event, eventmanager
+from app.sdk.logging import logger
+from app.sdk.media import build_media_key, resolve_media_identity
+from app.sdk.network import RequestUtils
+
+
+class CloudSyncDel(_PluginBase):
+    """媒体库删除后，在明确映射的云盘和本地目录中同步删除媒体文件。"""
+
+    plugin_name = "云盘同步删除"
+    plugin_desc = "媒体库删除软连接/strm文件后，同步删除云盘文件。"
+    plugin_icon = "clouddisk.png"
+    plugin_version = "2.0.0"
+    plugin_author = "thsrite"
+    author_url = "https://github.com/thsrite"
+    plugin_config_prefix = "cloudsyncdel_"
+    plugin_order = 9
+    auth_level = 2
+
+    _video_formats = (
+        ".mp4",
+        ".avi",
+        ".rmvb",
+        ".wmv",
+        ".mov",
+        ".mkv",
+        ".flv",
+        ".ts",
+        ".webm",
+        ".iso",
+        ".mpg",
+    )
+    _default_image = "https://emby.media/notificationicon.png"
+
+    def __init__(self):
+        """初始化实例级状态，避免热重载复用上一份路径映射。"""
+        super().__init__()
+        self._enabled = False
+        self._cloud_paths: Dict[str, str] = {}
+        self._local_paths: Dict[str, str] = {}
+        self._notify = False
+        self._url: Optional[str] = None
+        self._del_history = False
+
+    def init_plugin(self, config: dict = None):
+        """读取配置并重建本次运行所需的路径映射。"""
+        config = dict(config or {})
+        self._enabled = bool(config.get("enabled"))
+        self._notify = bool(config.get("notify"))
+        self._url = str(config.get("url") or "").strip() or None
+        self._del_history = bool(config.get("del_history"))
+        self._cloud_paths = self._parse_mappings(config.get("path"))
+        self._local_paths = self._parse_mappings(config.get("local_path"))
+
+        if self._del_history:
+            self.del_data(key="history")
+            self._del_history = False
+            self.update_config({
+                "enabled": self._enabled,
+                "notify": self._notify,
+                "path": config.get("path") or "",
+                "local_path": config.get("local_path") or "",
+                "url": self._url or "",
+                "del_history": False,
+            })
+        else:
+            self._migrate_history_identity()
+
+    def _migrate_history_identity(self) -> None:
+        """为可恢复的旧删除历史补齐规范媒体身份，并保留无法判断的记录。"""
+        history = self.get_data("history") or []
+        changed = False
+        for item in history:
+            if not isinstance(item, dict):
+                continue
+            media_source, media_id = resolve_media_identity(media=item)
+            if media_source and media_id:
+                normalized_source = media_source.value
+                if (
+                    item.get("media_source") != normalized_source
+                    or item.get("media_id") != media_id
+                ):
+                    item["media_source"] = normalized_source
+                    item["media_id"] = media_id
+                    changed = True
+                continue
+
+            title = str(item.get("title") or "").strip()
+            unique = str(item.get("unique") or "").strip()
+            legacy_prefix = f"{title} " if title else ""
+            legacy_id = unique[len(legacy_prefix):].strip() if unique.startswith(legacy_prefix) else ""
+            if legacy_id.isdigit() and legacy_id != "0":
+                item["media_source"] = MediaSource.TMDB.value
+                item["media_id"] = legacy_id
+                changed = True
+
+        if changed:
+            self.save_data("history", history)
+
+    @staticmethod
+    def _payload_value(payload: Any, key: str, default: Any = None) -> Any:
+        """读取插件动作的 dict 或类型化事件载荷字段。"""
+        if isinstance(payload, dict):
+            return payload.get(key, default)
+        return getattr(payload, key, default)
+
+    @staticmethod
+    def _parse_mappings(value: Any) -> Dict[str, str]:
+        """解析源路径到目标根的映射，并拒绝不完整或相对路径配置。"""
+        mappings: Dict[str, str] = {}
+        for raw_line in str(value or "").splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#") or ":" not in line:
+                continue
+            source, target = line.split(":", 1)
+            source = source.strip().replace("\\", "/")
+            target = target.strip().replace("\\", "/")
+            if not source or not target:
+                continue
+            if not Path(source).is_absolute() or not Path(target).is_absolute():
+                logger.warning("路径映射必须使用绝对路径，已忽略无效配置")
+                continue
+            mappings[os.path.normpath(source)] = os.path.normpath(target)
+        return mappings
+
+    @staticmethod
+    def _is_within(path: Path, root: Path, allow_root: bool = True) -> bool:
+        """使用真实路径校验边界，阻止路径穿越和符号链接逃逸。"""
+        path_real = os.path.realpath(os.path.abspath(str(path)))
+        root_real = os.path.realpath(os.path.abspath(str(root)))
+        try:
+            within = os.path.commonpath((path_real, root_real)) == root_real
+        except ValueError:
+            return False
+        return within and (allow_root or path_real != root_real)
+
+    @classmethod
+    def _locate_mapping(
+        cls,
+        mappings: Dict[str, str],
+        source_path: str,
+    ) -> Tuple[bool, Optional[Tuple[Path, Path]]]:
+        """区分路径映射未命中、安全命中和命中后越界三种结果。"""
+        if not source_path or not mappings:
+            return False, None
+
+        normalized_source_path = Path(os.path.abspath(os.path.normpath(source_path)))
+        # 最长源根优先，避免父级映射遮蔽更具体的目录映射。
+        candidates = sorted(mappings.items(), key=lambda item: len(item[0]), reverse=True)
+        for source_root_text, target_root_text in candidates:
+            source_root = Path(source_root_text)
+            try:
+                relative_path = normalized_source_path.relative_to(source_root)
+            except ValueError:
+                continue
+            target_root = Path(target_root_text)
+            target_path = target_root / relative_path
+            # 最终叶子符号链接只解除链接；中间目录符号链接越界仍必须拒绝。
+            if not cls._safe_delete_target(target_path, target_root):
+                logger.warning("路径映射目标超出配置根目录，已停止删除")
+                return True, None
+            return True, (target_path, target_root)
+        return False, None
+
+    @classmethod
+    def _resolve_mapping(
+        cls,
+        mappings: Dict[str, str],
+        source_path: str,
+    ) -> Optional[Tuple[Path, Path]]:
+        """将事件路径映射到安全目标；未命中或越界时返回空。"""
+        _, mapping = cls._locate_mapping(mappings, source_path)
+        return mapping
+
+    def __get_path(self, paths: Dict[str, str], file_path: str) -> Optional[str]:
+        """返回安全映射后的路径；映射失配时严格返回空值。"""
+        mapping = self._resolve_mapping(paths, file_path)
+        return str(mapping[0]) if mapping else None
+
+    @staticmethod
+    def _media_suffixes() -> set[str]:
+        """读取宿主声明的媒体扩展名，并统一大小写。"""
+        return {str(suffix).lower() for suffix in (settings.RMT_MEDIAEXT or ())}
+
+    @classmethod
+    def _is_media_file(cls, path: Path) -> bool:
+        """判断路径是否为宿主认定的媒体文件。"""
+        return path.suffix.lower() in cls._media_suffixes()
+
+    @classmethod
+    def _safe_delete_target(cls, path: Path, root: Path) -> bool:
+        """只允许删除根内目标；最终叶子符号链接按链接自身而非其指向校验。"""
+        path_absolute = os.path.abspath(str(path))
+        root_absolute = os.path.abspath(str(root))
+        if path_absolute == root_absolute:
+            return False
+        if path.is_symlink():
+            return cls._is_within(path.parent, root)
+        return cls._is_within(path, root, allow_root=False)
+
+    @classmethod
+    def _remove_empty_parents(cls, path: Path, root: Path) -> None:
+        """只沿映射目标根向上移除空目录，不触碰映射根或其父目录。"""
+        current = path
+        root_real = Path(os.path.realpath(os.path.abspath(str(root))))
+        while cls._is_within(current, root, allow_root=False):
+            current_real = Path(os.path.realpath(os.path.abspath(str(current))))
+            if current_real == root_real or current.is_symlink() or not current.is_dir():
+                break
+            try:
+                current.rmdir()
+            except OSError:
+                break
+            current = current.parent
+
+    @classmethod
+    def _matching_siblings(cls, path: Path, root: Path) -> List[Path]:
+        """查找同名媒体及 sidecar 文件，并限制在映射根内。"""
+        if not path.parent.is_dir() or not cls._is_within(path.parent, root, allow_root=False):
+            return []
+        siblings: List[Path] = []
+        for candidate in path.parent.iterdir():
+            if (
+                candidate.stem == path.stem
+                and candidate != path
+                and cls._safe_delete_target(candidate, root)
+                and (candidate.is_file() or candidate.is_symlink())
+            ):
+                siblings.append(candidate)
+        return sorted(siblings)
+
+    @classmethod
+    def _unlink_file(cls, path: Path, root: Path) -> bool:
+        """删除映射根内的单个文件或符号链接。"""
+        if not cls._safe_delete_target(path, root):
+            return False
+        if not (path.is_file() or path.is_symlink()):
+            return False
+        path.unlink(missing_ok=True)
+        cls._remove_empty_parents(path.parent, root)
+        return True
+
+    @classmethod
+    def _remove_directory(cls, path: Path, root: Path) -> bool:
+        """删除映射根内的目录；符号链接只解除链接，不跟随到根外。"""
+        if not cls._safe_delete_target(path, root):
+            return False
+        if path.is_symlink():
+            path.unlink(missing_ok=True)
+        elif path.is_dir():
+            shutil.rmtree(path)
+        else:
+            return False
+        cls._remove_empty_parents(path.parent, root)
+        return True
+
+    def _delete_local(
+        self,
+        mapped_path: Path,
+        mapped_root: Path,
+        media_data: Dict[str, Any],
+    ) -> bool:
+        """删除本地映射目标，并向媒体同步删除插件转发完整身份。"""
+        if not self._safe_delete_target(mapped_path, mapped_root):
+            return False
+
+        removed_paths: List[Path] = []
+        removed_directory = mapped_path.is_dir() and not mapped_path.is_file()
+        removed_directory_link = mapped_path.is_symlink() and not mapped_path.suffix
+        if mapped_path.is_dir() and not mapped_path.is_symlink():
+            if self._remove_directory(mapped_path, mapped_root):
+                removed_paths.append(mapped_path)
+        elif mapped_path.is_file() or mapped_path.is_symlink():
+            if self._unlink_file(mapped_path, mapped_root):
+                removed_paths.append(mapped_path)
+        elif mapped_path.suffix:
+            for sibling in self._matching_siblings(mapped_path, mapped_root):
+                if self._unlink_file(sibling, mapped_root):
+                    removed_paths.append(sibling)
+            thumb_file = mapped_path.parent / f"{mapped_path.stem}-thumb.jpg"
+            if self._unlink_file(thumb_file, mapped_root):
+                removed_paths.append(thumb_file)
+
+        if not removed_paths:
+            return False
+
+        media_path = next(
+            (removed_path for removed_path in removed_paths if self._is_media_file(removed_path)),
+            None,
+        )
+        if media_path or removed_directory or removed_directory_link:
+            self._send_media_sync_delete(media_path or mapped_path, media_data)
+        return True
+
+    def _send_media_sync_delete(self, media_path: Path, media_data: Dict[str, Any]) -> None:
+        """转发删除事件时始终保留来源与来源原生 ID。"""
+        self.eventmanager.send_event(EventType.PluginAction, {
+            "media_type": media_data.get("media_type"),
+            "media_name": media_data.get("media_name"),
+            "media_path": str(media_path),
+            "media_source": media_data["media_source"],
+            "media_id": media_data["media_id"],
+            "season_num": media_data.get("season_num"),
+            "episode_num": media_data.get("episode_num"),
+            "action": "media_sync_del",
+        })
+
+    def _delete_cloud(self, mapped_path: Path, mapped_root: Path) -> Optional[Path]:
+        """删除云盘映射目标，返回用于回调和通知的代表路径。"""
+        if not self._safe_delete_target(mapped_path, mapped_root):
+            return None
+
+        removed_paths: List[Path] = []
+        if mapped_path.is_dir() and not mapped_path.is_symlink():
+            if self._remove_directory(mapped_path, mapped_root):
+                removed_paths.append(mapped_path)
+        elif mapped_path.is_file() or mapped_path.is_symlink():
+            if self._unlink_file(mapped_path, mapped_root):
+                removed_paths.append(mapped_path)
+            if mapped_path.suffix:
+                for sibling in self._matching_siblings(mapped_path, mapped_root):
+                    if self._unlink_file(sibling, mapped_root):
+                        removed_paths.append(sibling)
+                thumb_file = mapped_path.parent / f"{mapped_path.stem}-thumb.jpg"
+                if self._unlink_file(thumb_file, mapped_root):
+                    removed_paths.append(thumb_file)
+        elif mapped_path.suffix:
+            for sibling in self._matching_siblings(mapped_path, mapped_root):
+                if self._unlink_file(sibling, mapped_root):
+                    removed_paths.append(sibling)
+            thumb_file = mapped_path.parent / f"{mapped_path.stem}-thumb.jpg"
+            if self._unlink_file(thumb_file, mapped_root):
+                removed_paths.append(thumb_file)
+
+        if not removed_paths:
+            return None
+        for removed_path in removed_paths:
+            if self._is_media_file(removed_path):
+                return removed_path
+        return removed_paths[0]
+
+    @eventmanager.register(EventType.PluginAction)
+    def clouddisk_del(self, event: Event = None):
+        """处理媒体同步删除事件，并在映射不明确时停止整个删除链路。"""
+        if not self._enabled or not event:
+            return
+
+        event_data = event.event_data or {}
+        action = self._payload_value(event_data, "action")
+        if action not in ("networkdisk_del", "cloudsyncdel"):
+            return
+
+        media_path = str(self._payload_value(event_data, "media_path") or "").strip()
+        if not media_path:
+            logger.error("未获取到删除媒体路径，跳过处理")
+            return
+
+        media_source, media_id = resolve_media_identity(media=event_data)
+        if not media_source or not media_id:
+            logger.error("删除事件缺少完整媒体身份，跳过处理")
+            return
+
+        media_data = {
+            "media_type": self._payload_value(event_data, "media_type"),
+            "media_name": self._payload_value(event_data, "media_name"),
+            "media_source": media_source.value,
+            "media_id": media_id,
+            "season_num": self._payload_value(event_data, "season_num"),
+            "episode_num": self._payload_value(event_data, "episode_num"),
+        }
+
+        local_matched, local_mapping = self._locate_mapping(self._local_paths, media_path)
+        if local_matched and not local_mapping:
+            return
+        if local_mapping:
+            local_path, local_root = local_mapping
+            if self._delete_local(local_path, local_root, media_data):
+                return
+
+        cloud_matched, cloud_mapping = self._locate_mapping(self._cloud_paths, media_path)
+        if not cloud_matched:
+            logger.warning("删除媒体路径未匹配云盘映射，跳过云盘删除")
+            return
+        if not cloud_mapping:
+            return
+
+        cloud_path, cloud_root = cloud_mapping
+        deleted_path = self._delete_cloud(cloud_path, cloud_root)
+        if not deleted_path:
+            return
+
+        self._notify_cloud_delete(deleted_path, media_data)
+        self._save_history(media_path, media_data)
+
+    def _notify_cloud_delete(self, deleted_path: Path, media_data: Dict[str, Any]) -> None:
+        """按配置回调外部同步服务并发送可选的 MoviePilot 通知。"""
+        if self._url and (not deleted_path.suffix or self._is_media_file(deleted_path)):
+            try:
+                RequestUtils(content_type="application/json").post(
+                    url=self._url,
+                    json={"path": str(deleted_path), "type": "del"},
+                )
+            except Exception as error:
+                logger.error("云盘删除回调失败：%s", error)
+
+        if not self._notify:
+            return
+
+        media_type = self._media_type(media_data.get("media_type"))
+        media_source = MediaSource(media_data["media_source"])
+        image = self._default_image
+        if media_source == MediaSource.TMDB:
+            image = self.chain.obtain_specific_image(
+                mediaid=media_data["media_id"],
+                mtype=media_type,
+                image_type=MediaImageType.Backdrop,
+                season=media_data.get("season_num"),
+                episode=media_data.get("episode_num"),
+            ) or image
+
+        media_name = media_data.get("media_name") or "未知媒体"
+        identity = build_media_key(media_source, media_data["media_id"])
+        season = media_data.get("season_num")
+        episode = media_data.get("episode_num")
+        if media_type == MediaType.MOVIE:
+            message = f"电影 {media_name} {identity}"
+        elif season and episode and str(episode).isdigit():
+            message = f"剧集 {media_name} S{season}E{episode} {identity}"
+        elif season:
+            message = f"剧集 {media_name} S{season} {identity}"
+        else:
+            message = f"剧集 {media_name} {identity}"
+
+        self.post_message(
+            mtype=MessageType.Plugin,
+            title="云盘同步删除任务完成",
+            image=image,
+            text=(
+                f"{message}\n"
+                f"时间 {time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())}"
+            ),
+        )
+
+    @staticmethod
+    def _media_type(value: Any) -> MediaType:
+        """将旧事件中的电影/剧集标记归一为 V3 媒体类型。"""
+        if value in ("Movie", "MOV", MediaType.MOVIE, MediaType.MOVIE.value):
+            return MediaType.MOVIE
+        return MediaType.TV
+
+    def _save_history(self, media_path: str, media_data: Dict[str, Any]) -> None:
+        """保存带完整媒体身份的删除历史。"""
+        media_source = MediaSource(media_data["media_source"])
+        media_type = self._media_type(media_data.get("media_type"))
+        image = self._default_image
+        if media_source == MediaSource.TMDB:
+            image = self.chain.obtain_specific_image(
+                mediaid=media_data["media_id"],
+                mtype=media_type,
+                image_type=MediaImageType.Poster,
+            ) or image
+
+        history = self.get_data("history") or []
+        now = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
+        history.append({
+            "type": media_type.value,
+            "title": media_data.get("media_name"),
+            "path": media_path,
+            "media_source": media_source.value,
+            "media_id": media_data["media_id"],
+            "season": (
+                media_data.get("season_num")
+                if media_data.get("season_num") and str(media_data.get("season_num")).isdigit()
+                else None
+            ),
+            "episode": (
+                media_data.get("episode_num")
+                if media_data.get("episode_num") and str(media_data.get("episode_num")).isdigit()
+                else None
+            ),
+            "image": image,
+            "del_time": now,
+            "unique": f"{media_data.get('media_name')}:{build_media_key(media_source, media_data['media_id'])}:{now}",
+        })
+        self.save_data("history", history)
+
+    def delete_history(self, key: str) -> schemas.Response[None]:
+        """删除详情页中指定的插件历史记录。"""
+        history = self.get_data("history")
+        if not history:
+            return schemas.Response(success=False, message="未找到历史记录")
+        self.save_data("history", [item for item in history if item.get("unique") != key])
+        return schemas.Response(success=True, message="删除成功")
+
+    def get_state(self) -> bool:
+        return self._enabled
+
+    @staticmethod
+    def get_command() -> List[Dict[str, Any]]:
+        """定义远程控制命令。"""
+        return [{
+            "cmd": "/cloudsyncdel",
+            "event": EventType.PluginAction,
+            "desc": "云盘同步删除",
+            "category": "",
+            "data": {"action": "cloudsyncdel"},
+        }]
+
+    def get_api(self) -> List[Dict[str, Any]]:
+        return [{
+            "path": "/delete_history",
+            "endpoint": self.delete_history,
+            "methods": ["GET"],
+            "auth": "bear",
+            "summary": "删除同步历史记录",
+            "response_model": schemas.Response[None],
+        }]
+
+    def get_form(self) -> Tuple[List[dict], Dict[str, Any]]:
+        """拼装插件配置页面和默认配置。"""
+        return [
+            {
+                "component": "VForm",
+                "content": [
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 4},
+                                "content": [{
+                                    "component": "VSwitch",
+                                    "props": {"model": "enabled", "label": "启用插件"},
+                                }],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 4},
+                                "content": [{
+                                    "component": "VSwitch",
+                                    "props": {"model": "notify", "label": "开启通知"},
+                                }],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 4},
+                                "content": [{
+                                    "component": "VSwitch",
+                                    "props": {"model": "del_history", "label": "清空历史"},
+                                }],
+                            },
+                        ],
+                    },
+                    {
+                        "component": "VTextarea",
+                        "props": {
+                            "model": "path",
+                            "rows": "2",
+                            "label": "媒体库路径映射（删除云盘文件）",
+                            "placeholder": "媒体服务器软连接/strm路径:MoviePilot云盘路径（一行一个）",
+                        },
+                    },
+                    {
+                        "component": "VTextarea",
+                        "props": {
+                            "model": "local_path",
+                            "rows": "2",
+                            "label": "本地路径映射（回调【媒体文件同步删除】插件删除本地文件）",
+                            "placeholder": "媒体服务器软连接/strm路径:MoviePilot本地文件路径（一行一个）",
+                        },
+                    },
+                    {
+                        "component": "VTextField",
+                        "props": {
+                            "model": "url",
+                            "label": "任务推送url",
+                            "placeholder": "post请求json方式推送path和type(del)字段",
+                        },
+                    },
+                    {
+                        "component": "VAlert",
+                        "props": {
+                            "type": "info",
+                            "variant": "tonal",
+                            "text": "需要开启媒体库删除插件且正确配置排除路径。路径映射必须使用绝对路径。",
+                        },
+                    },
+                ],
+            },
+        ], {
+            "enabled": False,
+            "path": "",
+            "url": "",
+            "local_path": "",
+            "notify": False,
+            "del_history": False,
+        }
+
+    def get_page(self) -> Optional[List[dict]]:
+        """拼装删除历史详情页。"""
+        history = self.get_data("history") or []
+        if not history:
+            return [{
+                "component": "div",
+                "text": "暂无数据",
+                "props": {"class": "text-center"},
+            }]
+
+        contents = []
+        for item in sorted(history, key=lambda value: value.get("del_time", ""), reverse=True):
+            unique = item.get("unique")
+            details = [
+                {"component": "VCardText", "text": f"类型：{item.get('type')}"},
+                {
+                    "component": "VCardText",
+                    "text": f"身份：{item.get('media_source')}:{item.get('media_id')}",
+                },
+            ]
+            if item.get("season"):
+                details.append({"component": "VCardText", "text": f"季：{item.get('season')}"})
+            if item.get("episode"):
+                details.append({"component": "VCardText", "text": f"集：{item.get('episode')}"})
+            details.append({"component": "VCardText", "text": f"时间：{item.get('del_time')}"})
+            contents.append({
+                "component": "VCard",
+                "content": [
+                    {
+                        "component": "VDialogCloseBtn",
+                        "props": {"innerClass": "absolute top-0 right-0"},
+                        "events": {
+                            "click": {
+                                "api": "plugin/CloudSyncDel/delete_history",
+                                "method": "get",
+                                "params": {"key": unique},
+                            }
+                        },
+                    },
+                    {
+                        "component": "div",
+                        "props": {"class": "d-flex justify-space-start flex-nowrap flex-row pa-2"},
+                        "content": [
+                            {
+                                "component": "VImg",
+                                "props": {
+                                    "src": item.get("image") or self._default_image,
+                                    "height": 120,
+                                    "width": 80,
+                                    "aspect-ratio": "2/3",
+                                    "class": "object-cover shadow ring-gray-500",
+                                    "cover": True,
+                                },
+                            },
+                            {
+                                "component": "div",
+                                "content": [
+                                    {
+                                        "component": "VCardTitle",
+                                        "text": item.get("title") or "未知媒体",
+                                    },
+                                    *details,
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            })
+        return [{
+            "component": "div",
+            "props": {"class": "grid gap-3 grid-info-card"},
+            "content": contents,
+        }]
+
+    def stop_service(self):
+        """插件无常驻任务。"""
+        return None

--- a/plugins.v3/lucky/__init__.py
+++ b/plugins.v3/lucky/__init__.py
@@ -1,0 +1,779 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.plugins import _PluginBase
+from app.sdk.logging import logger
+from app.sdk.network import RequestUtils
+from app.sdk.utilities import StringUtils
+
+
+class LuckyStatusData(BaseModel):
+    """Lucky HomePage 接口返回的状态数据。"""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    total_cnt: int = Field(description="反向代理规则总数")
+    enabled_cnt: int = Field(description="已启用的反向代理规则数")
+    closed_cnt: int = Field(description="已停用的反向代理规则数")
+    ipaddr: Optional[str] = Field(default=None, description="DDNS 当前 IPv4 地址")
+    expire_time: Optional[str] = Field(default=None, description="首个证书的到期日期")
+    connections: int = Field(description="当前连接总数")
+    traffic_in: str = Field(alias="trafficIn", description="格式化后的入站流量")
+    traffic_out: str = Field(alias="trafficOut", description="格式化后的出站流量")
+
+
+class Lucky(_PluginBase):
+    # 插件名称
+    plugin_name = "Lucky"
+    # 插件描述
+    plugin_desc = "Lucky HomePage自定义API。"
+    # 插件图标
+    plugin_icon = "Lucky_A.png"
+    # 插件版本
+    plugin_version = "2.0.0"
+    # 插件作者
+    plugin_author = "thsrite"
+    # 作者主页
+    author_url = "https://github.com/thsrite"
+    # 插件配置项ID前缀
+    plugin_config_prefix = "lucky_"
+    # 加载顺序
+    plugin_order = 30
+    # 可使用的用户级别
+    auth_level = 1
+
+    # 任务执行间隔
+    _enabled = False
+    _open_token: Optional[str] = None
+    _base_url: Optional[str] = None
+    _request: Optional[RequestUtils] = None
+
+    def init_plugin(self, config: dict = None):
+        """读取配置并重建外部请求客户端，避免热重载沿用旧凭据。"""
+        config = config or {}
+        self._enabled = bool(config.get("enabled"))
+        self._base_url = (
+            str(config.get("baseUrl") or "").strip().rstrip("/") or None
+        )
+        self._open_token = str(config.get("openToken") or "").strip() or None
+        self._request = RequestUtils(timeout=20) if self._base_url and self._open_token else None
+
+    def _request_json(self, path: str) -> Optional[dict]:
+        """请求 Lucky OpenToken API，并拒绝失败或非对象响应。"""
+        if not self._request or not self._base_url or not self._open_token:
+            logger.warning("Lucky 地址或 OpenToken 未配置完整")
+            return None
+
+        try:
+            with self._request.response_manager(
+                "GET",
+                f"{self._base_url}{path}",
+                params={"_": int(time.time() * 1000), "openToken": self._open_token},
+                raise_exception=True,
+            ) as response:
+                if response is None:
+                    return None
+                response.raise_for_status()
+                payload = response.json()
+        except Exception as error:
+            logger.warning("Lucky API 请求失败：%s", type(error).__name__)
+            return None
+
+        if not isinstance(payload, dict):
+            logger.warning("Lucky API 返回了非对象响应")
+            return None
+        if payload.get("ret") != 0:
+            logger.warning("Lucky API 返回失败状态：%s", payload.get("ret"))
+            return None
+        return payload
+
+    def get_rules(self) -> Tuple[List[dict], int, int, int]:
+        """汇总 Lucky 反向代理规则和连接流量统计。"""
+        rules = []
+        connections = 0
+        traffic_in = 0
+        traffic_out = 0
+        payload = self._request_json("/api/webservice/rules") or {}
+        for rule in payload.get("ruleList") or []:
+            if not isinstance(rule, dict):
+                continue
+            proxy_list = rule.get("ProxyList")
+            if isinstance(proxy_list, list):
+                rules.extend(item for item in proxy_list if isinstance(item, dict))
+        statistics = payload.get("statistics")
+        if isinstance(statistics, dict):
+            for statistic in statistics.values():
+                if not isinstance(statistic, dict):
+                    continue
+                connections += self._as_int(statistic.get("Connections"))
+                traffic_in += self._as_int(statistic.get("TrafficIn"))
+                traffic_out += self._as_int(statistic.get("TrafficOut"))
+        return rules, connections, traffic_in, traffic_out
+
+    def get_ip(self) -> Optional[str]:
+        """返回 Lucky 第一个 DDNS 任务的 IPv4 地址。"""
+        payload = self._request_json("/api/ddnstasklist") or {}
+        data = payload.get("data")
+        if not isinstance(data, list) or not data or not isinstance(data[0], dict):
+            return None
+        return data[0].get("IpAddr") or data[0].get("Ipv4Addr")
+
+    def get_ssl(self) -> Optional[str]:
+        """返回 Lucky 第一个证书的到期时间。"""
+        payload = self._request_json("/api/ssl") or {}
+        certificates = payload.get("list")
+        if (
+            not isinstance(certificates, list)
+            or not certificates
+            or not isinstance(certificates[0], dict)
+        ):
+            return None
+        cert_info = certificates[0].get("CertsInfo")
+        if isinstance(cert_info, list):
+            cert_info = cert_info[0] if cert_info else None
+        return cert_info.get("NotAfterTime") if isinstance(cert_info, dict) else None
+
+    @staticmethod
+    def _as_int(value: Any) -> int:
+        """将 Lucky 统计字段归一化为非负整数。"""
+        try:
+            return max(0, int(value or 0))
+        except (TypeError, ValueError):
+            return 0
+
+    def get_state(self) -> bool:
+        return self._enabled
+
+    def lucky(self) -> Dict[str, Any]:
+        """
+        返回 Lucky 反向代理、连接、流量、DDNS 和证书状态。
+        """
+        rules, connections, traffic_in, traffic_out = self.get_rules()
+        enabled_cnt = 0
+        closed_cnt = 0
+        for rule in rules:
+            if rule.get('Enable'):
+                enabled_cnt += 1
+            else:
+                closed_cnt += 1
+
+        ipaddr = self.get_ip()
+        expire_time = self.get_ssl()
+        if expire_time:
+            expire_time = expire_time.split(' ')[0].replace('-', '')
+
+        logger.info(
+            f"Proxy Rules Total: {len(rules)}\n"
+            f"Proxy Rules Enabled: {enabled_cnt}\n"
+            f"Proxy Rules Closed: {closed_cnt}\n"
+            f"Connections: {connections}\n"
+            f"TrafficIn: {traffic_in}\n"
+            f"TrafficOut: {traffic_out}\n"
+            f"Lucky IP: {ipaddr}\n"
+            f"SSL Expire Time: {expire_time}\n")
+
+        return {
+            'total_cnt': len(rules),
+            'enabled_cnt': enabled_cnt,
+            'closed_cnt': closed_cnt,
+            'ipaddr': ipaddr,
+            'expire_time': expire_time,
+            'connections': connections,
+            'trafficIn': StringUtils.str_filesize(traffic_in),
+            'trafficOut': StringUtils.str_filesize(traffic_out)
+        }
+
+    @staticmethod
+    def get_command() -> List[Dict[str, Any]]:
+        """当前插件不注册远程命令。"""
+        return []
+
+    def get_api(self) -> List[Dict[str, Any]]:
+        """
+        获取插件API
+        [{
+            "path": "/xx",
+            "endpoint": self.xxx,
+            "methods": ["GET", "POST"],
+            "summary": "API说明"
+        }]
+        """
+        return [{
+            "path": "/lucky",
+            "endpoint": self.lucky,
+            "methods": ["GET"],
+            "summary": "Lucky HomePage自定义API",
+            "description": "Lucky",
+            "auth": "apikey",
+            "response_model": LuckyStatusData,
+        }]
+
+    def get_form(self) -> Tuple[List[dict], Dict[str, Any]]:
+        """
+        拼装插件配置页面，需要返回两块数据：1、页面配置；2、数据结构
+        """
+        return [
+            {
+                'component': 'VForm',
+                'content': [
+                    {
+                        'component': 'VRow',
+                        'content': [
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 6
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VSwitch',
+                                        'props': {
+                                            'model': 'enabled',
+                                            'label': '启用插件',
+                                        }
+                                    }
+                                ]
+                            },
+                        ]
+                    },
+                    {
+                        'component': 'VRow',
+                        'content': [
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 6
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VTextField',
+                                        'props': {
+                                            'model': 'baseUrl',
+                                            'label': 'Lucky地址',
+                                            'placeholder': 'http://localhost:16601 (结尾没有/)'
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 6
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VTextField',
+                                        'props': {
+                                            'model': 'openToken',
+                                            'label': 'openToken',
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        'component': 'VRow',
+                        'content': [
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VAlert',
+                                        'props': {
+                                            'type': 'success',
+                                            'variant': 'tonal'
+                                        },
+                                        'content': [
+                                            {
+                                                'component': 'a',
+                                                'props': {
+                                                    'href': 'https://raw.githubusercontent.com/thsrite/MoviePilot-Plugins/main/docs/Lucky.md',
+                                                    'target': '_blank'
+                                                },
+                                                'text': '需自行前往Lucky设置开启OpenToken并重启Lucky。'
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        'component': 'VRow',
+                        'content': [
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VAlert',
+                                        'props': {
+                                            'type': 'info',
+                                            'variant': 'tonal',
+                                            'text': '如安装完启用插件后，HomePage提示404，重启MoviePilot即可。'
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ], {
+            "enabled": False,
+            "baseUrl": "",
+            "openToken": "",
+        }
+
+    def get_page(self) -> List[dict]:
+        data = self.lucky()
+        # 拼装页面
+        return [
+            {
+                'component': 'VRow',
+                'content': [
+                    {
+                        'component': 'VCol',
+                        'props': {
+                            'cols': 12,
+                            'md': 3,
+                            'sm': 6
+                        },
+                        'content': [
+                            {
+                                'component': 'VCard',
+                                'props': {
+                                    'variant': 'tonal',
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VCardText',
+                                        'props': {
+                                            'class': 'd-flex align-center',
+                                        },
+                                        'content': [
+                                            {
+                                                'component': 'div',
+                                                'content': [
+                                                    {
+                                                        'component': 'span',
+                                                        'props': {
+                                                            'class': 'text-caption'
+                                                        },
+                                                        'text': '总配置数量'
+                                                    },
+                                                    {
+                                                        'component': 'div',
+                                                        'props': {
+                                                            'class': 'd-flex align-center flex-wrap'
+                                                        },
+                                                        'content': [
+                                                            {
+                                                                'component': 'span',
+                                                                'props': {
+                                                                    'class': 'text-h6'
+                                                                },
+                                                                'text': data.get('total_cnt')
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                        ]
+                    },
+                    {
+                        'component': 'VCol',
+                        'props': {
+                            'cols': 12,
+                            'md': 3,
+                            'sm': 6
+                        },
+                        'content': [
+                            {
+                                'component': 'VCard',
+                                'props': {
+                                    'variant': 'tonal',
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VCardText',
+                                        'props': {
+                                            'class': 'd-flex align-center',
+                                        },
+                                        'content': [
+                                            {
+                                                'component': 'div',
+                                                'content': [
+                                                    {
+                                                        'component': 'span',
+                                                        'props': {
+                                                            'class': 'text-caption'
+                                                        },
+                                                        'text': '启用配置数量'
+                                                    },
+                                                    {
+                                                        'component': 'div',
+                                                        'props': {
+                                                            'class': 'd-flex align-center flex-wrap'
+                                                        },
+                                                        'content': [
+                                                            {
+                                                                'component': 'span',
+                                                                'props': {
+                                                                    'class': 'text-h6'
+                                                                },
+                                                                'text': data.get('enabled_cnt')
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                        ]
+                    },
+                    {
+                        'component': 'VCol',
+                        'props': {
+                            'cols': 12,
+                            'md': 3,
+                            'sm': 6
+                        },
+                        'content': [
+                            {
+                                'component': 'VCard',
+                                'props': {
+                                    'variant': 'tonal',
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VCardText',
+                                        'props': {
+                                            'class': 'd-flex align-center',
+                                        },
+                                        'content': [
+                                            {
+                                                'component': 'div',
+                                                'content': [
+                                                    {
+                                                        'component': 'span',
+                                                        'props': {
+                                                            'class': 'text-caption'
+                                                        },
+                                                        'text': '关闭配置数量'
+                                                    },
+                                                    {
+                                                        'component': 'div',
+                                                        'props': {
+                                                            'class': 'd-flex align-center flex-wrap'
+                                                        },
+                                                        'content': [
+                                                            {
+                                                                'component': 'span',
+                                                                'props': {
+                                                                    'class': 'text-h6'
+                                                                },
+                                                                'text': data.get('closed_cnt')
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                        ]
+                    },
+                    {
+                        'component': 'VCol',
+                        'props': {
+                            'cols': 12,
+                            'md': 3,
+                            'sm': 6
+                        },
+                        'content': [
+                            {
+                                'component': 'VCard',
+                                'props': {
+                                    'variant': 'tonal',
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VCardText',
+                                        'props': {
+                                            'class': 'd-flex align-center',
+                                        },
+                                        'content': [
+                                            {
+                                                'component': 'div',
+                                                'content': [
+                                                    {
+                                                        'component': 'span',
+                                                        'props': {
+                                                            'class': 'text-caption'
+                                                        },
+                                                        'text': '公网ip地址'
+                                                    },
+                                                    {
+                                                        'component': 'div',
+                                                        'props': {
+                                                            'class': 'd-flex align-center flex-wrap'
+                                                        },
+                                                        'content': [
+                                                            {
+                                                                'component': 'span',
+                                                                'props': {
+                                                                    'class': 'text-h6'
+                                                                },
+                                                                'text': data.get('ipaddr')
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                        ]
+                    },
+                    {
+                        'component': 'VCol',
+                        'props': {
+                            'cols': 12,
+                            'md': 3,
+                            'sm': 6
+                        },
+                        'content': [
+                            {
+                                'component': 'VCard',
+                                'props': {
+                                    'variant': 'tonal',
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VCardText',
+                                        'props': {
+                                            'class': 'd-flex align-center',
+                                        },
+                                        'content': [
+                                            {
+                                                'component': 'div',
+                                                'content': [
+                                                    {
+                                                        'component': 'span',
+                                                        'props': {
+                                                            'class': 'text-caption'
+                                                        },
+                                                        'text': '证书过期日期'
+                                                    },
+                                                    {
+                                                        'component': 'div',
+                                                        'props': {
+                                                            'class': 'd-flex align-center flex-wrap'
+                                                        },
+                                                        'content': [
+                                                            {
+                                                                'component': 'span',
+                                                                'props': {
+                                                                    'class': 'text-h6'
+                                                                },
+                                                                'text': data.get('expire_time')
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                        ]
+                    },
+                    {
+                        'component': 'VCol',
+                        'props': {
+                            'cols': 12,
+                            'md': 3,
+                            'sm': 6
+                        },
+                        'content': [
+                            {
+                                'component': 'VCard',
+                                'props': {
+                                    'variant': 'tonal',
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VCardText',
+                                        'props': {
+                                            'class': 'd-flex align-center',
+                                        },
+                                        'content': [
+                                            {
+                                                'component': 'div',
+                                                'content': [
+                                                    {
+                                                        'component': 'span',
+                                                        'props': {
+                                                            'class': 'text-caption'
+                                                        },
+                                                        'text': '链接数'
+                                                    },
+                                                    {
+                                                        'component': 'div',
+                                                        'props': {
+                                                            'class': 'd-flex align-center flex-wrap'
+                                                        },
+                                                        'content': [
+                                                            {
+                                                                'component': 'span',
+                                                                'props': {
+                                                                    'class': 'text-h6'
+                                                                },
+                                                                'text': data.get('connections')
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                        ]
+                    },
+                    {
+                        'component': 'VCol',
+                        'props': {
+                            'cols': 12,
+                            'md': 3,
+                            'sm': 6
+                        },
+                        'content': [
+                            {
+                                'component': 'VCard',
+                                'props': {
+                                    'variant': 'tonal',
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VCardText',
+                                        'props': {
+                                            'class': 'd-flex align-center',
+                                        },
+                                        'content': [
+                                            {
+                                                'component': 'div',
+                                                'content': [
+                                                    {
+                                                        'component': 'span',
+                                                        'props': {
+                                                            'class': 'text-caption'
+                                                        },
+                                                        'text': '流量In'
+                                                    },
+                                                    {
+                                                        'component': 'div',
+                                                        'props': {
+                                                            'class': 'd-flex align-center flex-wrap'
+                                                        },
+                                                        'content': [
+                                                            {
+                                                                'component': 'span',
+                                                                'props': {
+                                                                    'class': 'text-h6'
+                                                                },
+                                                                'text': data.get('trafficIn')
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        'component': 'VCol',
+                        'props': {
+                            'cols': 12,
+                            'md': 3,
+                            'sm': 6
+                        },
+                        'content': [
+                            {
+                                'component': 'VCard',
+                                'props': {
+                                    'variant': 'tonal',
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VCardText',
+                                        'props': {
+                                            'class': 'd-flex align-center',
+                                        },
+                                        'content': [
+                                            {
+                                                'component': 'div',
+                                                'content': [
+                                                    {
+                                                        'component': 'span',
+                                                        'props': {
+                                                            'class': 'text-caption'
+                                                        },
+                                                        'text': '流量Out'
+                                                    },
+                                                    {
+                                                        'component': 'div',
+                                                        'props': {
+                                                            'class': 'd-flex align-center flex-wrap'
+                                                        },
+                                                        'content': [
+                                                            {
+                                                                'component': 'span',
+                                                                'props': {
+                                                                    'class': 'text-h6'
+                                                                },
+                                                                'text': data.get('trafficOut')
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                ]
+            }]
+
+    def stop_service(self):
+        """
+        退出插件
+        """
+        pass

--- a/plugins.v3/popularsubscribe/__init__.py
+++ b/plugins.v3/popularsubscribe/__init__.py
@@ -1,0 +1,1084 @@
+import threading
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional, Tuple
+
+import cn2an
+import pytz
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+from app import schemas
+from app.chain.download import DownloadChain
+from app.chain.media import MediaChain
+from app.chain.subscribe import SubscribeChain
+from app.plugins import _PluginBase
+from app.schemas.types import MediaSource, MediaType
+from app.sdk.config import settings
+from app.sdk.logging import logger
+from app.sdk.media import MediaInfo, MetaInfo, build_media_key, resolve_media_identity
+from app.sdk.network import RequestUtils
+
+
+class PopularSubscribe(_PluginBase):
+    """
+    热门媒体订阅：按热度自动订阅电影、电视剧、动漫。
+    数据来源于 MoviePilot 服务端的订阅统计接口，需在系统设置中开启订阅统计共享。
+    """
+
+    # 插件名称
+    plugin_name = "热门媒体订阅"
+    # 插件描述
+    plugin_desc = "自动添加热门电影、电视剧、动漫到订阅。"
+    # 插件图标
+    plugin_icon = "https://raw.githubusercontent.com/thsrite/MoviePilot-Plugins/main/icons/popular.png"
+    # 插件版本
+    plugin_version = "3.0.0"
+    # 插件作者
+    plugin_author = "thsrite"
+    # 作者主页
+    author_url = "https://github.com/thsrite"
+    # 插件配置项ID前缀
+    plugin_config_prefix = "popularsubscribe_"
+    # 加载顺序
+    plugin_order = 25
+    # 可使用的用户级别
+    auth_level = 2
+
+    # 电影类型
+    _TYPE_MOVIE = "电影"
+    # 电视剧类型
+    _TYPE_TV = "电视剧"
+    # 动漫类型
+    _TYPE_ANIME = "动漫"
+    # MoviePilot Server 的订阅统计接口是外部服务协议，不属于宿主内部模块。
+    _SUBSCRIBE_STATISTIC_PATH = "/subscribe/statistic"
+
+    # 电影开关
+    _movie_enabled: bool = False
+    # 电视剧开关
+    _tv_enabled: bool = False
+    # 动漫开关
+    _anime_enabled: bool = False
+    # 获取条数
+    _movie_page_cnt: int = 30
+    _tv_page_cnt: int = 30
+    _anime_page_cnt: int = 30
+    # 订阅人次门槛
+    _movie_popular_cnt: int = 0
+    _tv_popular_cnt: int = 0
+    _anime_popular_cnt: int = 0
+    # cron 表达式
+    _movie_cron: str = ""
+    _tv_cron: str = ""
+    _anime_cron: str = ""
+    # 一次性开关与历史清理
+    _onlyonce: bool = False
+    _clear: bool = False
+    _clear_already_handle: bool = False
+    # 订阅用户名
+    _username: Optional[str] = None
+
+    # 依赖组件
+    downloadchain: Optional[DownloadChain] = None
+    subscribechain: Optional[SubscribeChain] = None
+    mediachain: Optional[MediaChain] = None
+    # 一次性任务调度器
+    _scheduler: Optional[BackgroundScheduler] = None
+    # 保护 history / already_handle 并发读改写
+    _history_lock: threading.Lock = threading.Lock()
+
+    def init_plugin(self, config: dict = None):
+        """
+        生效插件配置：加载参数、处理清理动作、按需触发立即运行。
+        """
+        self.downloadchain = DownloadChain()
+        self.subscribechain = SubscribeChain()
+        self.mediachain = MediaChain()
+        # 停止已有的一次性调度器
+        self.stop_service()
+        self.__migrate_history_identity()
+
+        config = config or {}
+        self._movie_enabled = bool(config.get("movie_enabled"))
+        self._tv_enabled = bool(config.get("tv_enabled"))
+        self._anime_enabled = bool(config.get("anime_enabled"))
+        self._movie_cron = config.get("movie_cron") or ""
+        self._tv_cron = config.get("tv_cron") or ""
+        self._anime_cron = config.get("anime_cron") or ""
+        self._movie_page_cnt = self.__to_int(config.get("movie_page_cnt"), 30)
+        self._tv_page_cnt = self.__to_int(config.get("tv_page_cnt"), 30)
+        self._anime_page_cnt = self.__to_int(config.get("anime_page_cnt"), 30)
+        self._movie_popular_cnt = self.__to_int(config.get("movie_popular_cnt"), 0)
+        self._tv_popular_cnt = self.__to_int(config.get("tv_popular_cnt"), 0)
+        self._anime_popular_cnt = self.__to_int(config.get("anime_popular_cnt"), 0)
+        self._clear = bool(config.get("clear"))
+        self._clear_already_handle = bool(config.get("clear_already_handle"))
+        self._onlyonce = bool(config.get("onlyonce"))
+        self._username = (config.get("username") or "").strip() or "热门订阅"
+
+        if not config:
+            return
+
+        # 清理订阅历史
+        if self._clear:
+            self.del_data(key="history")
+            self._clear = False
+            logger.info("热门订阅历史清理完成")
+
+        # 清理已处理历史
+        if self._clear_already_handle:
+            self.del_data(key="already_handle")
+            self._clear_already_handle = False
+            logger.info("热门订阅已处理记录清理完成")
+
+        # 立即运行一次
+        if self._onlyonce:
+            self._scheduler = BackgroundScheduler(timezone=settings.TZ)
+            run_date = datetime.now(tz=pytz.timezone(settings.TZ)) + timedelta(seconds=3)
+
+            # 三种类型合并为一个作业顺序执行，避免并发写入 history 相互覆盖
+            self._scheduler.add_job(
+                self.__run_all_enabled,
+                trigger="date",
+                run_date=run_date,
+                name="热门订阅（立即运行一次）",
+            )
+
+            self._onlyonce = False
+            if self._scheduler.get_jobs():
+                self._scheduler.print_jobs()
+                self._scheduler.start()
+
+        # 持久化关闭一次性开关与清理标记
+        self.__update_config()
+
+    def get_state(self) -> bool:
+        """
+        插件是否启用：任意一个媒体类型开启即视为启用。
+        """
+        return self._movie_enabled or self._tv_enabled or self._anime_enabled
+
+    @staticmethod
+    def get_command() -> List[Dict[str, Any]]:
+        """
+        本插件不注册远程命令。
+        """
+        return []
+
+    def get_api(self) -> List[Dict[str, Any]]:
+        """
+        注册删除历史记录的 API。
+        """
+        return [
+            {
+                "path": "/delete_history",
+                "endpoint": self.delete_history,
+                "methods": ["GET"],
+                "auth": "bear",
+                "summary": "删除订阅历史记录",
+                "response_model": schemas.Response[None],
+            }
+        ]
+
+    def get_service(self) -> List[Dict[str, Any]]:
+        """
+        注册周期性订阅任务，由 MoviePilot 服务框架统一调度。
+        """
+        services: List[Dict[str, Any]] = []
+        if self._movie_enabled and self._movie_cron:
+            service = self.__build_service(
+                sid="PopularSubscribeMovie",
+                name="电影热门订阅",
+                cron=self._movie_cron,
+                stype=self._TYPE_MOVIE,
+                page_cnt=self._movie_page_cnt,
+                popular_cnt=self._movie_popular_cnt,
+            )
+            if service:
+                services.append(service)
+        if self._tv_enabled and self._tv_cron:
+            service = self.__build_service(
+                sid="PopularSubscribeTv",
+                name="电视剧热门订阅",
+                cron=self._tv_cron,
+                stype=self._TYPE_TV,
+                page_cnt=self._tv_page_cnt,
+                popular_cnt=self._tv_popular_cnt,
+            )
+            if service:
+                services.append(service)
+        if self._anime_enabled and self._anime_cron:
+            service = self.__build_service(
+                sid="PopularSubscribeAnime",
+                name="动漫热门订阅",
+                cron=self._anime_cron,
+                stype=self._TYPE_ANIME,
+                page_cnt=self._anime_page_cnt,
+                popular_cnt=self._anime_popular_cnt,
+            )
+            if service:
+                services.append(service)
+        return services
+
+    def __build_service(self, sid: str, name: str, cron: str,
+                        stype: str, page_cnt: int, popular_cnt: int) -> Optional[Dict[str, Any]]:
+        """
+        构造单个媒体类型的定时任务定义，cron 解析失败会向系统消息推送告警。
+        """
+        try:
+            trigger = CronTrigger.from_crontab(cron)
+        except Exception as err:
+            logger.error(f"{name}定时任务配置错误：{err}")
+            self.systemmessage.put(f"{name}执行周期配置错误：{err}")
+            return None
+        return {
+            "id": sid,
+            "name": name,
+            "trigger": trigger,
+            "func": self.__popular_subscribe,
+            "func_kwargs": {
+                "stype": stype,
+                "page_cnt": page_cnt,
+                "popular_cnt": popular_cnt,
+            },
+        }
+
+    def __update_config(self):
+        """
+        将当前配置写回持久化存储。
+        """
+        self.update_config({
+            "movie_enabled": self._movie_enabled,
+            "tv_enabled": self._tv_enabled,
+            "anime_enabled": self._anime_enabled,
+            "movie_cron": self._movie_cron,
+            "tv_cron": self._tv_cron,
+            "anime_cron": self._anime_cron,
+            "movie_page_cnt": self._movie_page_cnt,
+            "tv_page_cnt": self._tv_page_cnt,
+            "anime_page_cnt": self._anime_page_cnt,
+            "movie_popular_cnt": self._movie_popular_cnt,
+            "tv_popular_cnt": self._tv_popular_cnt,
+            "anime_popular_cnt": self._anime_popular_cnt,
+            "clear": self._clear,
+            "clear_already_handle": self._clear_already_handle,
+            "onlyonce": self._onlyonce,
+            "username": self._username,
+        })
+
+    @staticmethod
+    def __to_int(value: Any, default: int) -> int:
+        """
+        将配置项安全转成整数，失败回退到默认值。
+        """
+        if value is None or value == "":
+            return default
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return default
+
+    @classmethod
+    def __get_subscribe_statistic(cls, stype: str, count: int) -> List[dict]:
+        """从 MoviePilot Server 读取热门订阅统计，并将响应收敛为字典列表。"""
+        if not settings.SUBSCRIBE_STATISTIC_SHARE:
+            return []
+
+        server_host = (settings.MP_SERVER_HOST or "").strip().rstrip("/")
+        if not server_host:
+            logger.warning("MoviePilot Server 地址为空，无法读取热门订阅数据")
+            return []
+
+        try:
+            response = RequestUtils(
+                proxies=settings.PROXY,
+                timeout=15,
+                ua=settings.USER_AGENT,
+            ).get_res(
+                f"{server_host}{cls._SUBSCRIBE_STATISTIC_PATH}",
+                params={"stype": stype, "page": 1, "count": max(int(count), 1)},
+            )
+        except Exception as err:
+            logger.warning(f"读取{stype}热门订阅数据失败：{err}")
+            return []
+
+        if response is None or response.status_code != 200:
+            logger.warning(f"读取{stype}热门订阅数据失败：服务端响应异常")
+            return []
+
+        try:
+            payload = response.json()
+        except (TypeError, ValueError):
+            logger.warning(f"读取{stype}热门订阅数据失败：响应不是有效 JSON")
+            return []
+
+        # 外部服务当前返回裸列表，同时接受普通 envelope 以兼容服务端响应升级。
+        if isinstance(payload, dict):
+            if payload.get("success") is False:
+                return []
+            payload = payload.get("data")
+        if not isinstance(payload, list):
+            logger.warning(f"读取{stype}热门订阅数据失败：响应数据不是列表")
+            return []
+        return [item for item in payload if isinstance(item, dict)]
+
+    @staticmethod
+    def __parse_genre_ids(value: Any) -> set[int]:
+        """将服务端逗号分隔或数组形式的分类 ID 归一为整数集合。"""
+        if isinstance(value, str):
+            values = value.split(",")
+        elif isinstance(value, (list, tuple, set)):
+            values = value
+        elif isinstance(value, int) and not isinstance(value, bool):
+            values = [value]
+        else:
+            values = []
+
+        genre_ids = set()
+        for item in values:
+            try:
+                genre_ids.add(int(str(item).strip()))
+            except (TypeError, ValueError):
+                continue
+        return genre_ids
+
+    @staticmethod
+    def __history_unique(
+            title: str,
+            media_source: MediaSource,
+            media_id: str,
+            timestamp: str,
+    ) -> str:
+        """使用统一媒体身份构造订阅历史的稳定删除键。"""
+        return f"popularsubscribe:{title}:{build_media_key(media_source, media_id)}:{timestamp}"
+
+    @staticmethod
+    def __detail_link(
+            media_source: Optional[MediaSource],
+            media_id: Optional[str],
+            media_type: Optional[str],
+    ) -> str:
+        """按媒体来源生成历史详情页链接。"""
+        media_source, media_id = resolve_media_identity(
+            media_source=media_source,
+            media_id=media_id,
+        )
+        if not media_source or not media_id:
+            return ""
+        if media_source == MediaSource.TMDB:
+            path = "movie" if media_type in {PopularSubscribe._TYPE_MOVIE, "movie"} else "tv"
+            return f"https://www.themoviedb.org/{path}/{media_id}"
+        if media_source == MediaSource.Douban:
+            return f"https://movie.douban.com/subject/{media_id}"
+        if media_source == MediaSource.Bangumi:
+            return f"https://bgm.tv/subject/{media_id}"
+        if media_source == MediaSource.AniList:
+            return f"https://anilist.co/anime/{media_id}"
+        if media_source == MediaSource.IMDb:
+            return f"https://www.imdb.com/title/{media_id}"
+        if media_source == MediaSource.TVDB:
+            return f"https://thetvdb.com/search?query={media_id}"
+        return ""
+
+    def __migrate_history_identity(self) -> None:
+        """将存量历史中的来源专有 ID 幂等迁移为统一媒体身份。"""
+        history = self.get_data("history")
+        if not isinstance(history, list):
+            return
+
+        legacy_fields = (
+            (MediaSource.TMDB, "tmdbid"),
+            (MediaSource.Douban, "doubanid"),
+            (MediaSource.Bangumi, "bangumiid"),
+            (MediaSource.AniList, "anilistid"),
+            (MediaSource.IMDb, "imdbid"),
+            (MediaSource.TVDB, "tvdbid"),
+        )
+        legacy_keys = {key for _, key in legacy_fields}
+        changed = False
+        for item in history:
+            if not isinstance(item, dict):
+                continue
+
+            media_source, media_id = resolve_media_identity(
+                media_source=item.get("media_source"),
+                media_id=item.get("media_id"),
+            )
+            if not media_source:
+                for legacy_source, legacy_key in legacy_fields:
+                    media_source, media_id = resolve_media_identity(
+                        media_source=legacy_source,
+                        media_id=item.get(legacy_key),
+                    )
+                    if media_source:
+                        break
+            if not media_source or not media_id:
+                continue
+
+            migrated = {
+                key: value
+                for key, value in item.items()
+                if key not in legacy_keys
+            }
+            migrated["media_source"] = media_source.value
+            migrated["media_id"] = media_id
+            migrated["detail_link"] = migrated.get("detail_link") or self.__detail_link(
+                media_source=media_source,
+                media_id=media_id,
+                media_type=migrated.get("type"),
+            )
+            migrated["unique"] = self.__history_unique(
+                title=migrated.get("title") or "",
+                media_source=media_source,
+                media_id=media_id,
+                timestamp=migrated.get("time") or "",
+            )
+            if migrated != item:
+                item.clear()
+                item.update(migrated)
+                changed = True
+
+        if changed:
+            self.save_data("history", history)
+
+    def __save_progress(self, history: List[dict], already_handle: List[str]) -> None:
+        """持久化已完成候选，避免后续候选失败时丢失本轮进度。"""
+        self.save_data("history", history)
+        self.save_data("already_handle", already_handle)
+
+    def __popular_subscribe(self, stype: str, page_cnt: int, popular_cnt: int):
+        """
+        拉取热门订阅统计并添加到本地订阅：
+        - 电影/电视剧直接按 stype 查询；
+        - 动漫复用电视剧数据源，按 TMDB 分类过滤，最多消费到目标条数为止。
+        整体过程加锁，避免多个媒体类型并发写入历史记录时相互覆盖。
+        """
+        with self._history_lock:
+            self.__do_popular_subscribe(stype=stype,
+                                        page_cnt=page_cnt,
+                                        popular_cnt=popular_cnt)
+
+    def __run_all_enabled(self):
+        """
+        立即运行一次场景下的入口：按顺序执行三种媒体类型，避免并发。
+        """
+        if self._movie_enabled:
+            logger.info("电影热门订阅：立即运行一次")
+            self.__popular_subscribe(self._TYPE_MOVIE, self._movie_page_cnt, self._movie_popular_cnt)
+        if self._tv_enabled:
+            logger.info("电视剧热门订阅：立即运行一次")
+            self.__popular_subscribe(self._TYPE_TV, self._tv_page_cnt, self._tv_popular_cnt)
+        if self._anime_enabled:
+            logger.info("动漫热门订阅：立即运行一次")
+            self.__popular_subscribe(self._TYPE_ANIME, self._anime_page_cnt, self._anime_popular_cnt)
+
+    def __do_popular_subscribe(self, stype: str, page_cnt: int, popular_cnt: int):
+        """
+        执行单个媒体类型的热门订阅（调用方须持有 _history_lock）。
+        """
+        query_type = self._TYPE_TV if stype == self._TYPE_ANIME else stype
+        page_limit = max(self.__to_int(page_cnt, 30), 1)
+        # 动漫复用电视剧数据源，需要向服务端多要一些以便过滤
+        query_count = page_limit * 20 if stype == self._TYPE_ANIME else page_limit
+
+        subscribes = self.__get_subscribe_statistic(
+            stype=query_type,
+            count=query_count,
+        )
+        if not subscribes:
+            logger.warning(
+                f"未获取到{stype}热门订阅数据，请确认已开启‘订阅数据共享’或服务端可访问"
+            )
+            return
+
+        history_data = self.get_data("history")
+        history: List[dict] = history_data if isinstance(history_data, list) else []
+        already_handle_data = self.get_data("already_handle")
+        already_handle: List[str] = (
+            already_handle_data if isinstance(already_handle_data, list) else []
+        )
+
+        anime_genre_ids = self.__parse_genre_ids(settings.ANIME_GENREIDS)
+        matched_cnt = 0
+
+        for sub in subscribes:
+            if not isinstance(sub, dict):
+                continue
+            # 订阅人次门槛
+            sub_count = self.__to_int(sub.get("count"), 0)
+            if popular_cnt and sub_count < int(popular_cnt):
+                logger.info(
+                    f"{sub.get('name')} 订阅人次：{sub_count} 小于设定：{popular_cnt}，跳过"
+                )
+                continue
+
+            # 构造媒体信息
+            media = self.__build_media(sub)
+            if not media or not media.title:
+                continue
+            media_source, media_id = resolve_media_identity(media=media)
+            media_key = build_media_key(media_source, media_id)
+            if not media_source or not media_id or not media_key:
+                logger.warning(f"{media.title_year} 缺少有效媒体身份，跳过")
+                continue
+
+            # 电视剧/动漫分类过滤
+            if stype in (self._TYPE_TV, self._TYPE_ANIME):
+                if not self.__match_tv_or_anime(media=media,
+                                                target_type=stype,
+                                                anime_genre_ids=anime_genre_ids):
+                    continue
+                matched_cnt += 1
+                if matched_cnt > page_limit:
+                    break
+
+            # 已处理跳过
+            if media_key in already_handle or media.title_year in already_handle:
+                logger.info(f"{media.type.value} {media.title_year} 已被处理，跳过")
+                continue
+
+            # 标题（含季度）
+            season_str = None
+            title = media.title_year
+            if media.season and int(media.season) > 1:
+                season_str = f"第{cn2an.an2cn(media.season, 'low')}季"
+                title = f"{media.title_year} {season_str}"
+            logger.info(f"{title} 订阅人次：{sub_count} 达到门槛：{popular_cnt or 0}")
+
+            # 元数据
+            meta = MetaInfo(media.title)
+            meta.type = media.type
+            if media.season:
+                meta.begin_season = media.season
+                meta.type = MediaType.TV
+
+            # 媒体库/订阅存在性检查
+            try:
+                exist_flag, _ = self.downloadchain.get_no_exists_info(meta=meta, mediainfo=media)
+            except Exception as err:
+                logger.warning(f"{media.title_year} 库存判断失败：{err}")
+                continue
+            if exist_flag:
+                logger.info(f"{media.title_year} 媒体库中已存在，跳过")
+                if media_key not in already_handle:
+                    already_handle.append(media_key)
+                    self.__save_progress(history, already_handle)
+                continue
+            try:
+                subscribed = self.subscribechain.exists(mediainfo=media, meta=meta)
+            except Exception as err:
+                logger.warning(f"{media.title_year} 订阅判断失败：{err}")
+                continue
+            if subscribed:
+                logger.info(f"{media.title_year} 订阅已存在，跳过")
+                if media_key not in already_handle:
+                    already_handle.append(media_key)
+                    self.__save_progress(history, already_handle)
+                continue
+
+            now_str = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            history_item = {
+                "title": media.title,
+                "type": media.type.value if media.type else stype,
+                "year": media.year,
+                "season": season_str,
+                "poster": media.get_poster_image(),
+                "overview": media.overview,
+                "media_source": media_source.value,
+                "media_id": media_id,
+                "detail_link": media.detail_link,
+                "time": now_str,
+                "unique": self.__history_unique(
+                    title=media.title,
+                    media_source=media_source,
+                    media_id=media_id,
+                    timestamp=now_str,
+                ),
+            }
+
+            # 添加订阅
+            try:
+                sid, msg = self.subscribechain.add(
+                    title=media.title,
+                    year=media.year,
+                    mtype=media.type,
+                    media_source=media_source,
+                    media_id=media_id,
+                    season=media.season if media.type == MediaType.TV else None,
+                    exist_ok=True,
+                    username=self._username,
+                )
+            except Exception as err:
+                logger.error(f"{media.title_year} 添加订阅失败：{err}")
+                continue
+
+            if not sid:
+                logger.warning(f"{media.title_year} 添加订阅失败：{msg}")
+                continue
+            logger.info(f"{media.title_year} 订阅人次：{sub_count} 已添加订阅（{msg or '成功'}）")
+            if media_key not in already_handle:
+                already_handle.append(media_key)
+            history.append(history_item)
+            self.__save_progress(history, already_handle)
+
+        self.__save_progress(history, already_handle)
+        logger.info(f"{stype}热门订阅任务执行完成")
+
+    @staticmethod
+    def __build_media(sub: dict) -> Optional[MediaInfo]:
+        """
+        根据服务端返回的订阅统计条目构造 MediaInfo。
+        """
+        media_source, media_id = resolve_media_identity(
+            media_source=sub.get("media_source"),
+            media_id=sub.get("media_id"),
+        )
+        if not media_source or not media_id:
+            logger.warning(f"跳过缺少统一媒体身份的热门订阅：{sub.get('name')}")
+            return None
+
+        media = MediaInfo(media_source=media_source, media_id=media_id)
+        media.title = sub.get("name")
+        media.year = sub.get("year")
+        media.season = PopularSubscribe.__to_int(sub.get("season"), 0) or None
+        media.poster_path = sub.get("poster")
+        media.backdrop_path = sub.get("backdrop")
+        media.overview = sub.get("description")
+        media.vote_average = sub.get("vote")
+        media.genre_ids = list(PopularSubscribe.__parse_genre_ids(sub.get("genre_ids")))
+
+        raw_type = sub.get("type")
+        if isinstance(raw_type, MediaType):
+            media.type = raw_type
+        else:
+            media.type = {
+                "movie": MediaType.MOVIE,
+                "电影": MediaType.MOVIE,
+                "tv": MediaType.TV,
+                "电视剧": MediaType.TV,
+            }.get(str(raw_type or "").strip().casefold())
+        if not media.type:
+            logger.warning(f"跳过无法识别类型的热门订阅：{sub.get('name')}")
+            return None
+        return media
+
+    def __get_genre_ids(self, media: MediaInfo) -> set[int]:
+        """获取媒体分类；统计条目缺少分类时按统一身份补充 TMDB 信息。"""
+        genre_ids = self.__parse_genre_ids(media.genre_ids)
+        if genre_ids or not self.mediachain:
+            return genre_ids
+
+        tmdb_info = None
+        if media.media_source == MediaSource.TMDB:
+            try:
+                tmdb_id = int(str(media.media_id))
+            except (TypeError, ValueError):
+                tmdb_id = 0
+            if tmdb_id:
+                try:
+                    tmdb_info = self.mediachain.tmdb_info(
+                        tmdbid=tmdb_id,
+                        mtype=media.type,
+                        season=media.season,
+                    )
+                except Exception as err:
+                    logger.warning(f"{media.title_year} 获取 TMDB 分类失败：{err}")
+        if isinstance(tmdb_info, dict):
+            genre_ids = self.__parse_genre_ids(tmdb_info.get("genre_ids"))
+            if genre_ids:
+                media.genre_ids = list(genre_ids)
+                return genre_ids
+
+        try:
+            supplemented = self.mediachain.supplement_tmdb_info(media)
+        except Exception as err:
+            logger.warning(f"{media.title_year} 补充 TMDB 分类失败：{err}")
+            return set()
+        genre_ids = self.__parse_genre_ids(getattr(supplemented, "genre_ids", None))
+        if genre_ids:
+            media.genre_ids = list(genre_ids)
+        return genre_ids
+
+    def __match_tv_or_anime(self, media: MediaInfo, target_type: str,
+                            anime_genre_ids: set) -> bool:
+        """
+        通过统计条目携带的分类判断当前条目是否属于电视剧或动漫。
+        无法识别分类时仅保留普通电视剧，避免把未知条目误订为动漫。
+        """
+        genre_ids = self.__get_genre_ids(media)
+        if not genre_ids:
+            return target_type == self._TYPE_TV
+
+        is_anime = bool(genre_ids.intersection(anime_genre_ids))
+        if target_type == self._TYPE_ANIME and not is_anime:
+            logger.debug(f"{media.title_year} 不在动漫分类中，跳过")
+            return False
+        if target_type == self._TYPE_TV and is_anime:
+            logger.debug(f"{media.title_year} 属于动漫分类，从电视剧订阅中跳过")
+            return False
+        return True
+
+    def delete_history(self, key: str) -> schemas.Response[None]:
+        """
+        删除指定的历史记录条目。
+        """
+        historys = self.get_data("history")
+        if not historys:
+            return schemas.Response(success=False, message="未找到历史记录")
+        historys = [h for h in historys if h.get("unique") != key]
+        self.save_data("history", historys)
+        return schemas.Response(success=True, message="删除成功")
+
+    def get_form(self) -> Tuple[List[dict], Dict[str, Any]]:
+        """
+        构造插件配置页面（Vuetify）与默认值。
+        """
+        return [
+            {
+                "component": "VForm",
+                "content": [
+                    self.__form_row_for_type(
+                        enabled_key="movie_enabled", enabled_label="电影热门订阅",
+                        cron_key="movie_cron", cron_label="电影订阅周期",
+                        page_key="movie_page_cnt", page_label="电影获取条数",
+                        popular_key="movie_popular_cnt", popular_label="电影订阅人次",
+                    ),
+                    self.__form_row_for_type(
+                        enabled_key="tv_enabled", enabled_label="电视剧热门订阅",
+                        cron_key="tv_cron", cron_label="电视剧订阅周期",
+                        page_key="tv_page_cnt", page_label="电视剧获取条数",
+                        popular_key="tv_popular_cnt", popular_label="电视剧订阅人次",
+                    ),
+                    self.__form_row_for_type(
+                        enabled_key="anime_enabled", enabled_label="动漫热门订阅",
+                        cron_key="anime_cron", cron_label="动漫订阅周期",
+                        page_key="anime_page_cnt", page_label="动漫获取条数",
+                        popular_key="anime_popular_cnt", popular_label="动漫订阅人次",
+                    ),
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12},
+                                "content": [
+                                    {
+                                        "component": "VAlert",
+                                        "props": {
+                                            "type": "info",
+                                            "variant": "tonal",
+                                            "text": "数据来源于 MoviePilot 服务端订阅统计接口，需在‘设置-数据共享’中开启‘订阅数据共享’。"
+                                                    "获取指定条数的热门媒体，达到订阅人次门槛后自动添加订阅。",
+                                        },
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12},
+                                "content": [
+                                    {
+                                        "component": "VAlert",
+                                        "props": {
+                                            "type": "warning",
+                                            "variant": "tonal",
+                                            "text": "立即运行一次：会对已开启的电影/电视剧/动漫订阅立刻执行一次；周期任务仍以 cron 表达式为准。",
+                                        },
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 3},
+                                "content": [
+                                    {
+                                        "component": "VSwitch",
+                                        "props": {
+                                            "model": "onlyonce",
+                                            "label": "立即运行一次",
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 3},
+                                "content": [
+                                    {
+                                        "component": "VSwitch",
+                                        "props": {
+                                            "model": "clear",
+                                            "label": "清理订阅记录",
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 3},
+                                "content": [
+                                    {
+                                        "component": "VSwitch",
+                                        "props": {
+                                            "model": "clear_already_handle",
+                                            "label": "清理已处理记录",
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 3},
+                                "content": [
+                                    {
+                                        "component": "VTextField",
+                                        "props": {
+                                            "model": "username",
+                                            "label": "订阅用户",
+                                            "placeholder": "默认为`热门订阅`",
+                                        },
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            }
+        ], {
+            "movie_enabled": False,
+            "tv_enabled": False,
+            "anime_enabled": False,
+            "movie_cron": "5 1 * * *",
+            "tv_cron": "5 1 * * *",
+            "anime_cron": "5 1 * * *",
+            "movie_page_cnt": 30,
+            "tv_page_cnt": 30,
+            "anime_page_cnt": 30,
+            "movie_popular_cnt": 0,
+            "tv_popular_cnt": 0,
+            "anime_popular_cnt": 0,
+            "onlyonce": False,
+            "clear": False,
+            "clear_already_handle": False,
+            "username": "热门订阅",
+        }
+
+    @staticmethod
+    def __form_row_for_type(enabled_key: str, enabled_label: str,
+                            cron_key: str, cron_label: str,
+                            page_key: str, page_label: str,
+                            popular_key: str, popular_label: str) -> dict:
+        """
+        为单个媒体类型（电影/电视剧/动漫）生成一行 4 列的配置面板。
+        """
+        return {
+            "component": "VRow",
+            "content": [
+                {
+                    "component": "VCol",
+                    "props": {"cols": 12, "md": 3},
+                    "content": [
+                        {
+                            "component": "VSwitch",
+                            "props": {"model": enabled_key, "label": enabled_label},
+                        }
+                    ],
+                },
+                {
+                    "component": "VCol",
+                    "props": {"cols": 12, "md": 3},
+                    "content": [
+                        {
+                            "component": "VTextField",
+                            "props": {
+                                "model": cron_key,
+                                "label": cron_label,
+                                "placeholder": "5位cron表达式，如 5 1 * * *",
+                            },
+                        }
+                    ],
+                },
+                {
+                    "component": "VCol",
+                    "props": {"cols": 12, "md": 3},
+                    "content": [
+                        {
+                            "component": "VTextField",
+                            "props": {
+                                "model": page_key,
+                                "label": page_label,
+                                "placeholder": "30",
+                            },
+                        }
+                    ],
+                },
+                {
+                    "component": "VCol",
+                    "props": {"cols": 12, "md": 3},
+                    "content": [
+                        {
+                            "component": "VTextField",
+                            "props": {
+                                "model": popular_key,
+                                "label": popular_label,
+                                "placeholder": "0 表示不限制",
+                            },
+                        }
+                    ],
+                },
+            ],
+        }
+
+    def get_page(self) -> List[dict]:
+        """
+        订阅历史详情页，按时间倒序展示卡片，支持删除单条历史。
+        """
+        historys = self.get_data("history")
+        if not historys:
+            return [
+                {
+                    "component": "div",
+                    "text": "暂无数据",
+                    "props": {"class": "text-center"},
+                }
+            ]
+
+        historys = sorted(historys, key=lambda x: x.get("time") or "", reverse=True)
+        contents = [self.__build_history_card(item) for item in historys]
+        return [
+            {
+                "component": "div",
+                "props": {"class": "grid gap-3 grid-info-card"},
+                "content": contents,
+            }
+        ]
+
+    def __build_history_card(self, history: dict) -> dict:
+        """
+        为一条历史记录生成卡片元素。
+        """
+        title = history.get("title")
+        year = history.get("year")
+        season = history.get("season")
+        poster = history.get("poster")
+        mtype = history.get("type")
+        time_str = history.get("time")
+        media_source, media_id = resolve_media_identity(
+            media_source=history.get("media_source"),
+            media_id=history.get("media_id"),
+        )
+        detail_link = history.get("detail_link") or self.__detail_link(
+            media_source=media_source,
+            media_id=media_id,
+            media_type=mtype,
+        )
+        unique = history.get("unique") or (
+            self.__history_unique(
+                title=title or "",
+                media_source=media_source,
+                media_id=media_id,
+                timestamp=time_str or "",
+            )
+            if media_source and media_id
+            else ""
+        )
+
+        info_texts = [f"类型：{mtype}", f"年份：{year}"]
+        if season:
+            info_texts.append(f"季度：{season}")
+        info_texts.append(f"时间：{time_str}")
+
+        text_blocks = [
+            {
+                "component": "VCardText",
+                "props": {"class": "pa-0 px-2"},
+                "text": text,
+            }
+            for text in info_texts
+        ]
+
+        return {
+            "component": "VCard",
+            "content": [
+                {
+                    "component": "VDialogCloseBtn",
+                    "props": {"innerClass": "absolute top-0 right-0"},
+                    "events": {
+                        "click": {
+                            "api": "plugin/PopularSubscribe/delete_history",
+                            "method": "get",
+                            "params": {
+                                "key": unique,
+                            },
+                        }
+                    },
+                },
+                {
+                    "component": "div",
+                    "props": {"class": "d-flex justify-space-start flex-nowrap flex-row"},
+                    "content": [
+                        {
+                            "component": "div",
+                            "content": [
+                                {
+                                    "component": "VImg",
+                                    "props": {
+                                        "src": poster,
+                                        "height": 120,
+                                        "width": 80,
+                                        "aspect-ratio": "2/3",
+                                        "class": "object-cover shadow ring-gray-500",
+                                        "cover": True,
+                                    },
+                                }
+                            ],
+                        },
+                        {
+                            "component": "div",
+                            "content": [
+                                {
+                                    "component": "VCardSubtitle",
+                                    "props": {
+                                        "class": "pa-2 font-bold break-words whitespace-break-spaces"
+                                    },
+                                    "content": [
+                                        {
+                                            "component": "a",
+                                            "props": {
+                                                "href": detail_link,
+                                                "target": "_blank",
+                                            },
+                                            "text": title,
+                                        }
+                                    ],
+                                },
+                                *text_blocks,
+                            ],
+                        },
+                    ],
+                },
+            ],
+        }
+
+    def stop_service(self):
+        """
+        停止一次性调度器，周期任务由 MoviePilot 框架统一管理无需处理。
+        """
+        try:
+            if self._scheduler:
+                self._scheduler.remove_all_jobs()
+                if self._scheduler.running:
+                    self._scheduler.shutdown()
+                self._scheduler = None
+        except Exception as err:
+            logger.error(f"退出热门订阅插件失败：{err}")

--- a/plugins.v3/synologynotify/__init__.py
+++ b/plugins.v3/synologynotify/__init__.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from app import schemas
+from app.plugins import _PluginBase
+from app.schemas.types import MessageType
+from app.sdk.logging import logger
+
+
+class SynologyNotify(_PluginBase):
+    """接收群晖 Webhook 消息并转发到 MoviePilot 通知中心。"""
+
+    plugin_name = "群辉Webhook通知"
+    plugin_desc = "接收群辉webhook通知并推送。"
+    plugin_icon = "https://raw.githubusercontent.com/thsrite/MoviePilot-Plugins/main/icons/synology.png"
+    plugin_version = "2.0.0"
+    plugin_author = "thsrite"
+    author_url = "https://github.com/thsrite"
+    plugin_config_prefix = "synologynotify_"
+    plugin_order = 30
+    auth_level = 1
+
+    def __init__(self) -> None:
+        """初始化实例状态，避免热重载复用旧配置。"""
+        super().__init__()
+        self._enabled = False
+        self._notify = False
+        self._msgtype = ""
+
+    def init_plugin(self, config: Optional[dict] = None) -> None:
+        """读取 Webhook 转发开关和通知类型配置。"""
+        config = config or {}
+        self._enabled = bool(config.get("enabled"))
+        self._notify = bool(config.get("notify"))
+        self._msgtype = config.get("msgtype") or ""
+
+    def _get_message_type(self) -> MessageType:
+        """把配置中的消息类型名称解析为 V3 消息枚举。"""
+        if isinstance(self._msgtype, MessageType):
+            return self._msgtype
+        return MessageType.__members__.get(
+            str(self._msgtype), MessageType.Manual
+        )
+
+    def send_notify(
+        self,
+        text: Optional[str] = None,
+        title: Optional[str] = None,
+        content: Optional[str] = None,
+        url: Optional[str] = None,
+    ) -> schemas.Response[None]:
+        """接收 Synology Webhook 参数并按插件配置转发通知。"""
+        logger.info(
+            "收到群辉 webhook 消息，字段状态 text=%s title=%s content=%s url=%s",
+            bool(text),
+            bool(title),
+            bool(content),
+            bool(url),
+        )
+        if not text and not title and not content:
+            return schemas.Response(success=False, message="消息内容不能为空")
+
+        if self._enabled and self._notify:
+            message_text = text or content or ""
+            if not text and url:
+                message_text = f"{message_text}\n[查看详情]({url})"
+            self.post_message(
+                title="群辉通知" if text else title,
+                mtype=self._get_message_type(),
+                text=message_text,
+            )
+
+        return schemas.Response(success=True, message="发送成功")
+
+    def get_state(self) -> bool:
+        """返回插件是否启用。"""
+        return self._enabled
+
+    @staticmethod
+    def get_command() -> List[Dict[str, Any]]:
+        """当前插件不注册远程命令。"""
+        return []
+
+    def get_api(self) -> List[Dict[str, Any]]:
+        """注册供 Synology 调用的 Webhook API。"""
+        return [
+            {
+                "path": "/webhook",
+                "endpoint": self.send_notify,
+                "methods": ["GET"],
+                "auth": "apikey",
+                "summary": "群辉webhook",
+                "description": "接受群辉webhook通知并推送",
+                "response_model": schemas.Response[None],
+            }
+        ]
+
+    def get_form(self) -> Tuple[List[dict], Dict[str, Any]]:
+        """返回 Webhook 开关和通知类型配置表单。"""
+        message_type_options = [
+            {"title": item.value, "value": item.name} for item in MessageType
+        ]
+        return [
+            {
+                "component": "VForm",
+                "content": [
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 6},
+                                "content": [
+                                    {
+                                        "component": "VSwitch",
+                                        "props": {
+                                            "model": "enabled",
+                                            "label": "启用插件",
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 6},
+                                "content": [
+                                    {
+                                        "component": "VSwitch",
+                                        "props": {
+                                            "model": "notify",
+                                            "label": "开启通知",
+                                        },
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12},
+                                "content": [
+                                    {
+                                        "component": "VSelect",
+                                        "props": {
+                                            "multiple": False,
+                                            "chips": True,
+                                            "model": "msgtype",
+                                            "label": "消息类型",
+                                            "items": message_type_options,
+                                        },
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12},
+                                "content": [
+                                    {
+                                        "component": "VAlert",
+                                        "props": {
+                                            "type": "info",
+                                            "variant": "tonal",
+                                            "text": (
+                                                "群辉webhook配置"
+                                                "http://ip:3001/api/v1/plugin/SynologyNotify/webhook?apikey=*****&text=hello world。"
+                                                "text参数类型是消息内容。此插件安装完需要重启生效api。消息类型默认为手动处理通知。"
+                                            ),
+                                        },
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12},
+                                "content": [
+                                    {
+                                        "component": "VAlert",
+                                        "props": {
+                                            "type": "info",
+                                            "variant": "tonal",
+                                            "text": "如安装完插件后，群晖发送webhook提示404，重启MoviePilot即可。",
+                                        },
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                ],
+            }
+        ], {"enabled": False, "notify": False, "msgtype": ""}
+
+    def get_page(self) -> List[dict]:
+        """当前插件不提供详情页。"""
+        return []
+
+    def stop_service(self) -> None:
+        """当前插件没有需要停止的后台服务。"""
+        return None

--- a/tests/v3/actorsubscribe/test_actorsubscribe.py
+++ b/tests/v3/actorsubscribe/test_actorsubscribe.py
@@ -1,0 +1,404 @@
+from __future__ import annotations
+
+import ast
+import json
+import os
+import sys
+from copy import deepcopy
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+BACKEND_ROOT = Path(os.environ["MOVIEPILOT_BACKEND_PATH"])
+sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.testing.bootstrap import prepare_v3_backend
+
+prepare_v3_backend(REPOSITORY_ROOT)
+
+from app import schemas
+from app.application.chain.context import (
+    ChainRuntimeContext,
+    configure_chain_runtime_context_provider,
+)
+from app.application.chain.data import configure_chain_data_ports, get_chain_data_ports
+from app.plugins import actorsubscribe as actorsubscribe_module
+from app.plugins.actorsubscribe import ActorSubscribe
+from app.schemas.types import MediaSource, MediaType
+
+
+PLUGIN_PATH = REPOSITORY_ROOT / "plugins.v3" / "actorsubscribe" / "__init__.py"
+
+configure_chain_data_ports(
+    **{
+        name: lambda: Mock()
+        for name in (
+            "site",
+            "subscribe",
+            "workflow",
+            "download_history",
+            "transfer_history",
+            "transfer_execution",
+            "transfer_pending",
+            "media_server",
+            "download_failure",
+            "user",
+        )
+    }
+)
+
+
+@pytest.fixture(autouse=True)
+def _chain_runtime_context():
+    """为插件基类提供隔离 Chain 上下文。"""
+    configure_chain_runtime_context_provider(
+        lambda: ChainRuntimeContext(
+            module_manager=Mock(),
+            plugin_manager=Mock(),
+            event_manager=Mock(),
+            message_oper=Mock(),
+            message_helper=Mock(),
+            file_cache=Mock(),
+            async_file_cache=Mock(),
+            message_queue_factory=lambda _callback: Mock(),
+            module_dispatcher_factory=lambda **_kwargs: Mock(),
+            data_ports=get_chain_data_ports(),
+        )
+    )
+    yield
+    configure_chain_runtime_context_provider(None)
+
+
+@pytest.fixture(autouse=True)
+def _meta_info(monkeypatch: pytest.MonkeyPatch) -> None:
+    """隔离需要宿主识别配置的元数据解析器。"""
+    monkeypatch.setattr(
+        actorsubscribe_module,
+        "MetaInfo",
+        lambda title: SimpleNamespace(title=title, type=None),
+    )
+
+
+def _imports() -> set[str]:
+    """返回 V3 插件源码中的 from-import 模块集合。"""
+    tree = ast.parse(PLUGIN_PATH.read_text(encoding="utf-8"))
+    return {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module
+    }
+
+
+def _media_info(**overrides):
+    """构造带完整 V3 媒体身份和演员信息的影视信息。"""
+    values = {
+        "media_source": MediaSource.TMDB,
+        "media_id": "550",
+        "type": MediaType.MOVIE,
+        "title": "搏击俱乐部",
+        "title_year": "搏击俱乐部 (1999)",
+        "year": "1999",
+        "actors": [{"name": "演员"}],
+        "directors": [],
+        "imdb_id": None,
+        "overview": "简介",
+        "detail_link": "https://www.themoviedb.org/movie/550",
+        "get_poster_image": Mock(return_value="poster"),
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _saved_values(plugin: ActorSubscribe) -> dict[str, object]:
+    """读取插件本轮保存的数据快照。"""
+    return {
+        call.args[0]: call.args[1]
+        for call in plugin.save_data.call_args_list
+        if len(call.args) >= 2
+    }
+
+
+def _prepare_actor_run(
+    plugin: ActorSubscribe,
+    data: dict[str, object],
+    mediainfo,
+    source: str = "tmdb_movies",
+) -> None:
+    """注入演员订阅任务的链和隔离存储。"""
+    plugin._actors = "演员"
+    plugin._source = [source]
+    plugin._quality = "Remux"
+    plugin._resolution = "1080[pi]|x1080"
+    plugin._effect = ""
+    plugin._username = "演员订阅"
+    plugin.mediachain = Mock()
+    plugin.doubanchain = Mock()
+    plugin.tmdbchain = Mock()
+    plugin.downloadchain = Mock()
+    plugin.subscribechain = Mock()
+    if source == "tmdb_movies":
+        plugin.tmdbchain.tmdb_discover.return_value = [mediainfo]
+    else:
+        plugin.doubanchain.movie_showing.return_value = [mediainfo]
+    plugin.downloadchain.get_no_exists_info.return_value = (False, {})
+    plugin.subscribechain.exists.return_value = False
+    plugin.get_data = lambda key: data.get(key)
+    plugin.save_data = Mock()
+
+
+def test_v3_manifest_and_sdk_contract() -> None:
+    """V3 索引、旧代回退开关、版本和稳定 SDK 导入应保持一致。"""
+    manifest = json.loads(
+        (REPOSITORY_ROOT / "package.v3.json").read_text(encoding="utf-8")
+    )["ActorSubscribe"]
+    legacy_manifest = json.loads(
+        (REPOSITORY_ROOT / "package.json").read_text(encoding="utf-8")
+    )["ActorSubscribe"]
+
+    assert manifest["version"] == ActorSubscribe.plugin_version == "3.0.0"
+    assert manifest["release"] is True
+    assert manifest["system_version"] == ">=3.0.0"
+    assert list(manifest["history"]) == ["v3.0.0"]
+    assert legacy_manifest["v3"] is False
+
+    imports = _imports()
+    assert {"app.sdk.config", "app.sdk.logging", "app.sdk.media"}.issubset(imports)
+    forbidden_prefixes = (
+        "app.adapters",
+        "app.core",
+        "app.db.models",
+        "app.domain",
+        "app.foundation",
+        "app.helper",
+        "app.runtime",
+        "app.sdk._legacy",
+        "app.utils",
+    )
+    assert not any(module.startswith(forbidden_prefixes) for module in imports)
+    source = PLUGIN_PATH.read_text(encoding="utf-8")
+    assert "app.log" not in imports
+    assert "logger.warn(" not in source
+    assert "tmdbid=" not in source
+    assert "doubanid=" not in source
+    assert "apikey" not in source
+
+
+def test_plugin_initializes_v3_chains_and_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    """插件初始化应构造 V3 来源、下载和订阅链。"""
+    douban_chain = Mock()
+    tmdb_chain = Mock()
+    download_chain = Mock()
+    subscribe_chain = Mock()
+    monkeypatch.setattr(actorsubscribe_module, "DoubanChain", lambda: douban_chain)
+    monkeypatch.setattr(actorsubscribe_module, "TmdbChain", lambda: tmdb_chain)
+    monkeypatch.setattr(actorsubscribe_module, "DownloadChain", lambda: download_chain)
+    monkeypatch.setattr(actorsubscribe_module, "SubscribeChain", lambda: subscribe_chain)
+
+    plugin = ActorSubscribe()
+    plugin.get_data = Mock(return_value=[])
+    plugin.init_plugin({})
+
+    assert plugin.doubanchain is douban_chain
+    assert plugin.tmdbchain is tmdb_chain
+    assert plugin.downloadchain is download_chain
+    assert plugin.subscribechain is subscribe_chain
+    assert plugin.get_state() is False
+    assert plugin.get_command() == []
+    assert plugin.get_api()[0]["auth"] == "bear"
+    assert plugin.get_api()[0]["response_model"] is schemas.Response[None]
+    plugin.stop_service()
+
+
+def test_history_identity_migration_is_idempotent() -> None:
+    """存量 TMDB/豆瓣字段应迁移为统一 pair，并保留详情链接。"""
+    history = [
+        {
+            "title": "搏击俱乐部",
+            "type": "电影",
+            "tmdbid": 550,
+            "doubanid": "0",
+            "time": "2026-08-28 10:00:00",
+        }
+    ]
+    original = deepcopy(history)
+    saved = []
+    plugin = ActorSubscribe()
+    plugin.get_data = lambda _key: history
+    plugin.save_data = lambda key, value: saved.append((key, deepcopy(value)))
+
+    plugin._ActorSubscribe__migrate_history_identity()
+
+    item = history[0]
+    assert item["media_source"] == MediaSource.TMDB.value
+    assert item["media_id"] == "550"
+    assert item["detail_link"] == "https://www.themoviedb.org/movie/550"
+    assert item["unique"] == "actorsubscribe: 搏击俱乐部 (tmdb:550)"
+    assert {"tmdbid", "doubanid"}.isdisjoint(item)
+    assert saved == [("history", history)]
+
+    plugin._ActorSubscribe__migrate_history_identity()
+    assert history != original
+    assert len(saved) == 1
+
+
+def test_invalid_history_identity_is_preserved() -> None:
+    """无法回填合法身份的记录不得被清理或改写。"""
+    history = [
+        {
+            "title": "未知媒体",
+            "media_source": "invalid source",
+            "media_id": "0",
+            "tmdbid": "0",
+            "doubanid": "",
+        }
+    ]
+    original = deepcopy(history)
+    saved = []
+    plugin = ActorSubscribe()
+    plugin.get_data = lambda _key: history
+    plugin.save_data = lambda key, value: saved.append((key, value))
+
+    plugin._ActorSubscribe__migrate_history_identity()
+
+    assert history == original
+    assert saved == []
+
+
+def test_actor_subscription_passes_media_identity_and_records_success() -> None:
+    """演员命中后应把同一媒体 pair 传给检查、写入和历史。"""
+    plugin = ActorSubscribe()
+    mediainfo = _media_info()
+    data = {"history": [], "already_handle": []}
+    _prepare_actor_run(plugin, data, mediainfo)
+    plugin.subscribechain.add.return_value = (7, "")
+
+    plugin._ActorSubscribe__actor_subscribe()
+
+    discover_kwargs = plugin.tmdbchain.tmdb_discover.call_args.kwargs
+    assert discover_kwargs == {
+        "mtype": MediaType.MOVIE,
+        "sort_by": "popularity.desc",
+        "with_genres": "",
+        "with_original_language": "",
+        "with_keywords": "",
+        "with_watch_providers": "",
+        "vote_average": 0,
+        "vote_count": 0,
+        "release_date": "",
+        "page": 1,
+    }
+    plugin.downloadchain.get_no_exists_info.assert_called_once()
+    plugin.subscribechain.exists.assert_called_once_with(mediainfo=mediainfo)
+    plugin.subscribechain.add.assert_called_once_with(
+        title="搏击俱乐部",
+        year="1999",
+        mtype=MediaType.MOVIE,
+        media_source=MediaSource.TMDB,
+        media_id="550",
+        exist_ok=True,
+        quality="Remux",
+        resolution="1080[pi]|x1080",
+        effect="",
+        username="演员订阅",
+    )
+
+    saved = _saved_values(plugin)
+    assert saved["already_handle"] == ["tmdb:550"]
+    assert saved["history"][0]["media_source"] == MediaSource.TMDB.value
+    assert saved["history"][0]["media_id"] == "550"
+    assert {"tmdbid", "doubanid"}.isdisjoint(saved["history"][0])
+
+
+def test_failed_subscription_is_not_marked_as_handled() -> None:
+    """订阅写入失败时不得伪装成已处理，后续任务仍可重试。"""
+    plugin = ActorSubscribe()
+    mediainfo = _media_info()
+    data = {"history": [], "already_handle": []}
+    _prepare_actor_run(plugin, data, mediainfo)
+    plugin.subscribechain.add.return_value = (None, "写入失败")
+
+    plugin._ActorSubscribe__actor_subscribe()
+
+    saved = _saved_values(plugin)
+    assert saved["history"] == []
+    assert saved["already_handle"] == []
+
+
+def test_legacy_handled_title_is_normalized_to_media_key() -> None:
+    """旧标题年份键首次命中时应转为来源和原生 ID，避免跨来源误判长期存在。"""
+    plugin = ActorSubscribe()
+    mediainfo = _media_info()
+    data = {"history": [], "already_handle": ["搏击俱乐部 (1999)"]}
+    _prepare_actor_run(plugin, data, mediainfo)
+
+    plugin._ActorSubscribe__actor_subscribe()
+
+    plugin.subscribechain.add.assert_not_called()
+    saved = _saved_values(plugin)
+    assert saved["history"] == []
+    assert saved["already_handle"] == ["tmdb:550"]
+
+
+def test_douban_actor_fallback_keeps_douban_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    """豆瓣详情补充演员时仍应按候选的 Douban pair 创建订阅。"""
+    plugin = ActorSubscribe()
+    mediainfo = _media_info(
+        media_source=MediaSource.Douban,
+        media_id="129",
+        title="示例电影",
+        title_year="示例电影 (2026)",
+        year="2026",
+        actors=[],
+        directors=[],
+        detail_link="https://movie.douban.com/subject/129",
+    )
+    data = {"history": [], "already_handle": []}
+    _prepare_actor_run(plugin, data, mediainfo, source="douban_showing")
+    plugin.doubanchain.douban_info.return_value = {"actors": [{"name": "演员"}], "directors": []}
+    plugin.subscribechain.add.return_value = (7, "")
+    monkeypatch.setattr(actorsubscribe_module.time, "sleep", Mock())
+
+    plugin._ActorSubscribe__actor_subscribe()
+
+    plugin.doubanchain.douban_info.assert_called_once_with("129", mtype=MediaType.MOVIE)
+    plugin.subscribechain.add.assert_called_once_with(
+        title="示例电影",
+        year="2026",
+        mtype=MediaType.MOVIE,
+        media_source=MediaSource.Douban,
+        media_id="129",
+        exist_ok=True,
+        quality="Remux",
+        resolution="1080[pi]|x1080",
+        effect="",
+        username="演员订阅",
+    )
+
+
+def test_history_page_and_api_use_bearer_auth_without_legacy_token() -> None:
+    """历史删除接口应使用宿主认证，不再把旧 API token 拼入页面。"""
+    plugin = ActorSubscribe()
+    plugin.get_data = Mock(
+        return_value=[
+            {
+                "title": "搏击俱乐部",
+                "type": "电影",
+                "time": "2026-08-28 10:00:00",
+                "poster": "poster",
+                "media_source": MediaSource.TMDB.value,
+                "media_id": "550",
+                "unique": "actorsubscribe: 搏击俱乐部 (tmdb:550)",
+            }
+        ]
+    )
+    page = plugin.get_page()
+    page_text = repr(page)
+
+    assert "apikey" not in page_text
+    assert "https://www.themoviedb.org/movie/550" in page_text
+    click_params = page[0]["content"][0]["content"][0]["events"]["click"]["params"]
+    assert click_params == {"key": "actorsubscribe: 搏击俱乐部 (tmdb:550)"}
+    assert plugin.get_api()[0]["response_model"] is schemas.Response[None]

--- a/tests/v3/actorsubscribeplus/test_actorsubscribeplus.py
+++ b/tests/v3/actorsubscribeplus/test_actorsubscribeplus.py
@@ -1,0 +1,389 @@
+from __future__ import annotations
+
+import ast
+import json
+import os
+import sys
+from copy import deepcopy
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+BACKEND_ROOT = Path(os.environ["MOVIEPILOT_BACKEND_PATH"])
+sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.testing.bootstrap import prepare_v3_backend
+
+prepare_v3_backend(REPOSITORY_ROOT)
+
+from app import schemas
+from app.application.chain.context import (
+    ChainRuntimeContext,
+    configure_chain_runtime_context_provider,
+)
+from app.application.chain.data import configure_chain_data_ports, get_chain_data_ports
+from app.plugins import actorsubscribeplus as actorsubscribeplus_module
+from app.plugins.actorsubscribeplus import ActorSubscribePlus
+from app.schemas.types import MediaSource, MediaType
+
+PLUGIN_PATH = REPOSITORY_ROOT / "plugins.v3" / "actorsubscribeplus" / "__init__.py"
+
+configure_chain_data_ports(
+    **{
+        name: lambda: Mock()
+        for name in (
+            "site",
+            "subscribe",
+            "workflow",
+            "download_history",
+            "transfer_history",
+            "transfer_execution",
+            "transfer_pending",
+            "media_server",
+            "download_failure",
+            "user",
+        )
+    }
+)
+
+
+@pytest.fixture(autouse=True)
+def _chain_runtime_context():
+    """为插件基类提供隔离 Chain 上下文。"""
+    configure_chain_runtime_context_provider(
+        lambda: ChainRuntimeContext(
+            module_manager=Mock(),
+            plugin_manager=Mock(),
+            event_manager=Mock(),
+            message_oper=Mock(),
+            message_helper=Mock(),
+            file_cache=Mock(),
+            async_file_cache=Mock(),
+            message_queue_factory=lambda _callback: Mock(),
+            module_dispatcher_factory=lambda **_kwargs: Mock(),
+            data_ports=get_chain_data_ports(),
+        )
+    )
+    yield
+    configure_chain_runtime_context_provider(None)
+
+
+@pytest.fixture(autouse=True)
+def _meta_info(monkeypatch: pytest.MonkeyPatch) -> None:
+    """隔离需要宿主识别配置的元数据解析器。"""
+    monkeypatch.setattr(
+        actorsubscribeplus_module,
+        "MetaInfo",
+        lambda title: SimpleNamespace(title=title),
+    )
+
+
+def _imports() -> set[str]:
+    """返回插件源码中的 from-import 模块集合。"""
+    tree = ast.parse(PLUGIN_PATH.read_text(encoding="utf-8"))
+    return {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module
+    }
+
+
+def _media_info(**overrides):
+    """构造包含完整 V3 媒体身份的影视信息。"""
+    values = {
+        "media_source": MediaSource.TMDB,
+        "media_id": "550",
+        "type": MediaType.MOVIE,
+        "title": "搏击俱乐部",
+        "title_year": "搏击俱乐部 (1999)",
+        "year": "1999",
+        "first_air_date": None,
+        "release_date": "1999-10-15",
+        "vote_average": 8.8,
+        "overview": "简介",
+        "detail_link": "https://www.themoviedb.org/movie/550",
+        "get_poster_image": Mock(return_value="poster"),
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _saved_values(plugin: ActorSubscribePlus) -> dict[str, object]:
+    """读取插件本轮保存的数据快照。"""
+    return {
+        call.args[0]: call.args[1]
+        for call in plugin.save_data.call_args_list
+        if len(call.args) >= 2
+    }
+
+
+def _prepare_actor_run(plugin: ActorSubscribePlus, data: dict[str, object], mediainfo):
+    """注入演员订阅任务的链和隔离存储。"""
+    plugin._actors = "演员"
+    plugin._mtype = [MediaType.MOVIE.value, MediaType.TV.value]
+    plugin._year = 1990
+    plugin._last = 30
+    plugin._vate = 0
+    plugin.mediachain = Mock()
+    plugin.tmdbchain = Mock()
+    plugin.downloadchain = Mock()
+    plugin.subscribechain = Mock()
+    plugin.mediachain.search_persons.return_value = [
+        SimpleNamespace(source=MediaSource.TMDB.value, id=123)
+    ]
+    plugin.tmdbchain.person_credits.side_effect = [[mediainfo], []]
+    plugin.downloadchain.get_no_exists_info.return_value = (False, {})
+    plugin.subscribechain.exists.return_value = False
+    plugin.get_data = lambda key: data.get(key)
+    plugin.save_data = Mock()
+
+
+def test_v3_manifest_and_sdk_contract() -> None:
+    """V3 索引、旧代回退开关、版本和稳定 SDK 导入应保持一致。"""
+    manifest = json.loads(
+        (REPOSITORY_ROOT / "package.v3.json").read_text(encoding="utf-8")
+    )["ActorSubscribePlus"]
+    legacy_manifest = json.loads(
+        (REPOSITORY_ROOT / "package.json").read_text(encoding="utf-8")
+    )["ActorSubscribePlus"]
+
+    assert manifest["version"] == ActorSubscribePlus.plugin_version == "2.0.0"
+    assert manifest["release"] is True
+    assert manifest["system_version"] == ">=3.0.0"
+    assert list(manifest["history"]) == ["v2.0.0"]
+    assert legacy_manifest["v3"] is False
+
+    imports = _imports()
+    assert {"app.sdk.config", "app.sdk.logging", "app.sdk.media"}.issubset(imports)
+    forbidden_prefixes = (
+        "app.adapters",
+        "app.core",
+        "app.db.models",
+        "app.domain",
+        "app.foundation",
+        "app.helper",
+        "app.runtime",
+        "app.sdk._legacy",
+        "app.utils",
+    )
+    assert not any(module.startswith(forbidden_prefixes) for module in imports)
+    source = PLUGIN_PATH.read_text(encoding="utf-8")
+    assert "tmdb_id" not in source
+    assert "douban_id" not in source
+    assert "tmdbid=" not in source
+    assert "doubanid=" not in source
+    assert "logger.warn(" not in source
+    assert "apikey" not in source
+
+
+def test_plugin_initializes_v3_chains_and_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    """插件初始化应构造 V3 媒体、TMDB、下载和订阅链。"""
+    media_chain = Mock()
+    tmdb_chain = Mock()
+    download_chain = Mock()
+    subscribe_chain = Mock()
+    monkeypatch.setattr(actorsubscribeplus_module, "MediaChain", lambda: media_chain)
+    monkeypatch.setattr(actorsubscribeplus_module, "TmdbChain", lambda: tmdb_chain)
+    monkeypatch.setattr(actorsubscribeplus_module, "DownloadChain", lambda: download_chain)
+    monkeypatch.setattr(actorsubscribeplus_module, "SubscribeChain", lambda: subscribe_chain)
+
+    plugin = ActorSubscribePlus()
+    plugin.get_data = Mock(return_value=[])
+    plugin.init_plugin({})
+
+    assert plugin.mediachain is media_chain
+    assert plugin.tmdbchain is tmdb_chain
+    assert plugin.downloadchain is download_chain
+    assert plugin.subscribechain is subscribe_chain
+    assert plugin.get_state() is False
+    assert plugin.get_command() == []
+    assert plugin.get_api()[0]["auth"] == "bear"
+    assert plugin.get_api()[0]["response_model"] is schemas.Response[None]
+    plugin.stop_service()
+
+
+def test_history_identity_migration_is_idempotent() -> None:
+    """存量 TMDB/豆瓣字段应迁移为统一 pair，并保留详情链接。"""
+    history = [
+        {
+            "title": "搏击俱乐部",
+            "type": "电影",
+            "tmdbid": 550,
+            "doubanid": "0",
+            "time": "2026-08-28 10:00:00",
+        }
+    ]
+    original = deepcopy(history)
+    saved = []
+    plugin = object.__new__(ActorSubscribePlus)
+    plugin.get_data = lambda _key: history
+    plugin.save_data = lambda key, value: saved.append((key, deepcopy(value)))
+
+    plugin._ActorSubscribePlus__migrate_history_identity()
+
+    item = history[0]
+    assert item["media_source"] == MediaSource.TMDB.value
+    assert item["media_id"] == "550"
+    assert item["detail_link"] == "https://www.themoviedb.org/movie/550"
+    assert item["unique"] == "actorsubscribeplus: 搏击俱乐部 (tmdb:550)"
+    assert {"tmdbid", "doubanid"}.isdisjoint(item)
+    assert saved == [("history", history)]
+
+    plugin._ActorSubscribePlus__migrate_history_identity()
+    assert history != original
+    assert len(saved) == 1
+
+
+def test_invalid_history_identity_is_preserved() -> None:
+    """无法回填合法身份的记录不得被清理或改写。"""
+    history = [
+        {
+            "title": "未知媒体",
+            "media_source": "invalid source",
+            "media_id": "0",
+            "tmdbid": "0",
+            "doubanid": "",
+        }
+    ]
+    original = deepcopy(history)
+    saved = []
+    plugin = object.__new__(ActorSubscribePlus)
+    plugin.get_data = lambda _key: history
+    plugin.save_data = lambda key, value: saved.append((key, value))
+
+    plugin._ActorSubscribePlus__migrate_history_identity()
+
+    assert history == original
+    assert saved == []
+
+
+def test_actor_subscription_passes_media_identity_and_records_success() -> None:
+    """演员作品订阅应把同一媒体 pair 传给检查、写入和历史。"""
+    plugin = ActorSubscribePlus()
+    mediainfo = _media_info()
+    data = {"history": [], "already_handle": []}
+    _prepare_actor_run(plugin, data, mediainfo)
+    plugin.subscribechain.add.return_value = (7, "")
+
+    plugin._ActorSubscribePlus__actor_subscribe()
+
+    plugin.mediachain.search_persons.assert_called_once_with(
+        name="演员",
+        media_source=MediaSource.TMDB,
+    )
+    assert plugin.tmdbchain.person_credits.call_args_list[0].kwargs == {
+        "person_id": 123,
+        "page": 1,
+    }
+    plugin.downloadchain.get_no_exists_info.assert_called_once()
+    plugin.subscribechain.exists.assert_called_once_with(mediainfo=mediainfo)
+    plugin.subscribechain.add.assert_called_once_with(
+        title="搏击俱乐部",
+        year="1999",
+        mtype=MediaType.MOVIE,
+        media_source=MediaSource.TMDB,
+        media_id="550",
+        exist_ok=True,
+        username="演员作品订阅",
+    )
+
+    saved = _saved_values(plugin)
+    assert saved["already_handle"] == ["tmdb:550"]
+    assert saved["history"][0]["media_source"] == MediaSource.TMDB.value
+    assert saved["history"][0]["media_id"] == "550"
+    assert {"tmdbid", "doubanid"}.isdisjoint(saved["history"][0])
+
+
+def test_failed_subscription_is_not_marked_as_handled() -> None:
+    """订阅写入失败时不得伪装成已处理，后续任务仍可重试。"""
+    plugin = ActorSubscribePlus()
+    mediainfo = _media_info()
+    data = {"history": [], "already_handle": []}
+    _prepare_actor_run(plugin, data, mediainfo)
+    plugin.subscribechain.add.return_value = (None, "写入失败")
+
+    plugin._ActorSubscribePlus__actor_subscribe()
+
+    saved = _saved_values(plugin)
+    assert saved["history"] == []
+    assert saved["already_handle"] == []
+
+
+def test_completed_subscription_is_saved_before_later_actor_failure() -> None:
+    """后续演员查询失败时，前序成功订阅的历史和去重状态仍应保留。"""
+    plugin = ActorSubscribePlus()
+    mediainfo = _media_info()
+    data = {"history": [], "already_handle": []}
+    _prepare_actor_run(plugin, data, mediainfo)
+    plugin._actors = "演员一,演员二"
+    person = SimpleNamespace(source=MediaSource.TMDB.value, id=123)
+    plugin.mediachain.search_persons.side_effect = [
+        [person],
+        RuntimeError("演员服务不可用"),
+    ]
+    plugin.subscribechain.add.return_value = (7, "")
+
+    with pytest.raises(RuntimeError, match="演员服务不可用"):
+        plugin._ActorSubscribePlus__actor_subscribe()
+
+    saved = _saved_values(plugin)
+    assert saved["already_handle"] == ["tmdb:550"]
+    assert saved["history"][0]["media_source"] == MediaSource.TMDB.value
+    assert saved["history"][0]["media_id"] == "550"
+
+
+@pytest.mark.parametrize("handled", [["tmdb:550"], ["搏击俱乐部 (1999)"]])
+def test_existing_handled_identity_skips_subscription(handled: list[str]) -> None:
+    """新旧已处理键都应阻止同一作品重复提交。"""
+    plugin = ActorSubscribePlus()
+    mediainfo = _media_info()
+    data = {"history": [], "already_handle": handled}
+    _prepare_actor_run(plugin, data, mediainfo)
+
+    plugin._ActorSubscribePlus__actor_subscribe()
+
+    plugin.subscribechain.add.assert_not_called()
+    assert _saved_values(plugin)["already_handle"] == handled
+
+
+def test_missing_release_date_is_skipped_without_crashing() -> None:
+    """来源没有有效上映时间时应跳过该作品，而不是中断整轮任务。"""
+    plugin = ActorSubscribePlus()
+    mediainfo = _media_info(release_date=None, first_air_date=None)
+    data = {"history": [], "already_handle": []}
+    _prepare_actor_run(plugin, data, mediainfo)
+    plugin.subscribechain.add.return_value = (7, "")
+
+    plugin._ActorSubscribePlus__actor_subscribe()
+
+    plugin.subscribechain.add.assert_not_called()
+    assert _saved_values(plugin)["history"] == []
+
+
+def test_history_page_and_api_use_bearer_auth_without_legacy_token() -> None:
+    """历史删除接口应使用宿主认证，不再把旧 API token 拼入页面。"""
+    plugin = ActorSubscribePlus()
+    plugin.get_data = Mock(
+        return_value=[
+            {
+                "title": "搏击俱乐部",
+                "type": "电影",
+                "time": "2026-08-28 10:00:00",
+                "poster": "poster",
+                "media_source": MediaSource.TMDB.value,
+                "media_id": "550",
+                "unique": "actorsubscribeplus: 搏击俱乐部 (tmdb:550)",
+            }
+        ]
+    )
+    page = plugin.get_page()
+    page_text = repr(page)
+
+    assert "apikey" not in page_text
+    assert "https://www.themoviedb.org/movie/550" in page_text
+    click_params = page[0]["content"][0]["content"][0]["events"]["click"]["params"]
+    assert click_params == {"key": "actorsubscribeplus: 搏击俱乐部 (tmdb:550)"}
+    assert plugin.get_api()[0]["response_model"] is schemas.Response[None]

--- a/tests/v3/cloudsyncdel/test_cloudsyncdel.py
+++ b/tests/v3/cloudsyncdel/test_cloudsyncdel.py
@@ -1,0 +1,481 @@
+from __future__ import annotations
+
+import ast
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+BACKEND_ROOT = Path(os.environ["MOVIEPILOT_BACKEND_PATH"])
+sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.testing.bootstrap import prepare_v3_backend
+
+prepare_v3_backend(REPOSITORY_ROOT)
+
+from app import schemas
+from app.application.chain.context import (
+    ChainRuntimeContext,
+    configure_chain_runtime_context_provider,
+)
+from app.application.chain.data import configure_chain_data_ports, get_chain_data_ports
+from app.plugins import cloudsyncdel as cloudsyncdel_module
+from app.plugins.cloudsyncdel import CloudSyncDel
+from app.schemas.types import EventType, MediaSource
+from app.sdk.events import Event
+
+
+configure_chain_data_ports(
+    **{
+        name: lambda: Mock()
+        for name in (
+            "site",
+            "subscribe",
+            "workflow",
+            "download_history",
+            "transfer_history",
+            "transfer_pending",
+            "transfer_execution",
+            "media_server",
+            "download_failure",
+            "user",
+        )
+    }
+)
+
+PLUGIN_PATH = REPOSITORY_ROOT / "plugins.v3" / "cloudsyncdel" / "__init__.py"
+
+
+@pytest.fixture(autouse=True)
+def _chain_runtime_context():
+    """为插件基类提供隔离 Chain 上下文。"""
+    configure_chain_runtime_context_provider(
+        lambda: ChainRuntimeContext(
+            module_manager=Mock(),
+            plugin_manager=Mock(),
+            event_manager=Mock(),
+            message_oper=Mock(),
+            message_helper=Mock(),
+            file_cache=Mock(),
+            async_file_cache=Mock(),
+            message_queue_factory=lambda _callback: Mock(),
+            module_dispatcher_factory=lambda **_kwargs: Mock(),
+            data_ports=get_chain_data_ports(),
+        )
+    )
+    yield
+    configure_chain_runtime_context_provider(None)
+
+
+def _imports() -> set[str]:
+    tree = ast.parse(PLUGIN_PATH.read_text(encoding="utf-8"))
+    return {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module
+    }
+
+
+def _event(path: Path, **extra) -> Event:
+    data = {
+        "action": "networkdisk_del",
+        "media_path": str(path),
+        "media_name": "示例电影",
+        "media_type": "Movie",
+        "media_source": MediaSource.Douban.value,
+        "media_id": "1295644",
+        "season_num": None,
+        "episode_num": None,
+    }
+    data.update(extra)
+    return Event(EventType.PluginAction, data)
+
+
+def test_v3_manifest_and_import_contract() -> None:
+    """V3 索引、旧代回退和 SDK 导入边界应保持一致。"""
+    manifest = json.loads(
+        (REPOSITORY_ROOT / "package.v3.json").read_text(encoding="utf-8")
+    )["CloudSyncDel"]
+    legacy_manifest = json.loads(
+        (REPOSITORY_ROOT / "package.json").read_text(encoding="utf-8")
+    )["CloudSyncDel"]
+
+    assert manifest["version"] == CloudSyncDel.plugin_version == "2.0.0"
+    assert manifest["release"] is True
+    assert manifest["system_version"] == ">=3.0.0"
+    assert list(manifest["history"]) == ["v2.0.0"]
+    assert legacy_manifest["v3"] is False
+
+    imports = _imports()
+    assert {
+        "app.sdk.config",
+        "app.sdk.events",
+        "app.sdk.logging",
+        "app.sdk.media",
+        "app.sdk.network",
+    }.issubset(imports)
+    forbidden_prefixes = (
+        "app.adapters",
+        "app.application",
+        "app.core",
+        "app.db.models",
+        "app.domain",
+        "app.foundation",
+        "app.helper",
+        "app.log",
+        "app.runtime",
+        "app.sdk._legacy",
+        "app.utils",
+    )
+    assert not any(module.startswith(forbidden_prefixes) for module in imports)
+    source = PLUGIN_PATH.read_text(encoding="utf-8")
+    assert "tmdb_id" not in source
+    assert "apikey" not in source
+    assert "logger.warn(" not in source
+
+
+def test_plugin_imports_and_reinitializes_state() -> None:
+    """插件应完成 V3 生命周期，并在热重载时清理旧映射。"""
+    plugin = CloudSyncDel()
+    plugin.init_plugin({})
+    assert plugin.get_state() is False
+    assert plugin.get_api()[0]["auth"] == "bear"
+    assert plugin.get_api()[0]["response_model"] is schemas.Response[None]
+
+    plugin.init_plugin({
+        "enabled": True,
+        "path": "/source:/cloud",
+        "local_path": "/source:/local",
+    })
+    assert plugin.get_state() is True
+    assert plugin._cloud_paths == {"/source": "/cloud"}
+    assert plugin._local_paths == {"/source": "/local"}
+
+    plugin.init_plugin({})
+    assert plugin._cloud_paths == {}
+    assert plugin._local_paths == {}
+    assert plugin.stop_service() is None
+
+
+def test_history_identity_migration_is_idempotent() -> None:
+    """可恢复的旧历史应补齐 TMDB 身份，重复初始化不得重复写入。"""
+    history = [{
+        "title": "示例电影",
+        "unique": "示例电影 550",
+        "path": "/source/movie.mkv",
+    }]
+    plugin = CloudSyncDel()
+    plugin.get_data = Mock(return_value=history)
+    plugin.save_data = Mock()
+
+    plugin.init_plugin({})
+
+    assert history[0]["media_source"] == MediaSource.TMDB.value
+    assert history[0]["media_id"] == "550"
+    plugin.save_data.assert_called_once_with("history", history)
+
+    plugin.save_data.reset_mock()
+    plugin.init_plugin({})
+    plugin.save_data.assert_not_called()
+
+
+def test_invalid_history_identity_is_preserved() -> None:
+    """无法可靠判断来源和 ID 的旧历史应原样保留。"""
+    history = [{"title": "示例电影", "unique": "legacy-record"}]
+    plugin = CloudSyncDel()
+    plugin.get_data = Mock(return_value=history)
+    plugin.save_data = Mock()
+
+    plugin.init_plugin({})
+
+    assert history == [{"title": "示例电影", "unique": "legacy-record"}]
+    plugin.save_data.assert_not_called()
+
+
+def test_mapping_mismatch_does_not_fallback_to_original_path(tmp_path: Path) -> None:
+    """事件路径未匹配映射时，原路径绝不能被当作删除目标。"""
+    source_root = tmp_path / "source"
+    cloud_root = tmp_path / "cloud"
+    source_root.mkdir()
+    cloud_root.mkdir()
+    original = tmp_path / "source-other" / "movie.mkv"
+    original.parent.mkdir()
+    original.write_text("keep", encoding="utf-8")
+
+    plugin = CloudSyncDel()
+    plugin.init_plugin({
+        "enabled": True,
+        "path": f"{source_root}:{cloud_root}",
+    })
+    plugin.eventmanager = Mock()
+    plugin.clouddisk_del(_event(original))
+
+    assert original.exists()
+    plugin.eventmanager.send_event.assert_not_called()
+
+
+def test_empty_directory_cleanup_stays_inside_mapping_root(tmp_path: Path) -> None:
+    """删除媒体后的空目录清理只能到达映射目标根，不能删除其父目录。"""
+    source_root = tmp_path / "source"
+    target_parent = tmp_path / "targets"
+    target_root = target_parent / "cloud"
+    media_dir = target_root / "movies"
+    source_root.mkdir()
+    media_dir.mkdir(parents=True)
+    target_parent.mkdir(exist_ok=True)
+    media_file = media_dir / "movie.mkv"
+    media_file.write_text("remove", encoding="utf-8")
+
+    plugin = CloudSyncDel()
+    plugin.init_plugin({
+        "enabled": True,
+        "path": f"{source_root}:{target_root}",
+    })
+    plugin._save_history = Mock()
+    plugin.clouddisk_del(_event(source_root / "movies" / "movie.mkv"))
+
+    assert not media_file.exists()
+    assert not media_dir.exists()
+    assert target_root.exists()
+    assert target_parent.exists()
+
+
+def test_symlink_escape_is_rejected(tmp_path: Path) -> None:
+    """映射目标中的符号链接指向根外时必须停止删除。"""
+    source_root = tmp_path / "source"
+    target_root = tmp_path / "cloud"
+    outside = tmp_path / "outside"
+    source_root.mkdir()
+    target_root.mkdir()
+    outside.mkdir()
+    escaped_file = outside / "movie.mkv"
+    escaped_file.write_text("keep", encoding="utf-8")
+    (target_root / "escape").symlink_to(outside, target_is_directory=True)
+
+    plugin = CloudSyncDel()
+    plugin.init_plugin({
+        "enabled": True,
+        "path": f"{source_root}:{target_root}",
+    })
+    plugin.clouddisk_del(_event(source_root / "escape" / "movie.mkv"))
+
+    assert escaped_file.exists()
+
+
+@pytest.mark.parametrize("leaf_symlink", [True, False])
+def test_unsafe_local_mapping_never_falls_back_to_cloud_delete(
+    tmp_path: Path,
+    leaf_symlink: bool,
+) -> None:
+    """本地映射命中后发现符号链接越界时，整个删除链必须立即终止。"""
+    source_root = tmp_path / "source"
+    local_root = tmp_path / "local"
+    cloud_root = tmp_path / "cloud"
+    outside = tmp_path / "outside"
+    source_root.mkdir()
+    local_root.mkdir()
+    cloud_root.mkdir()
+    outside.mkdir()
+
+    local_link = None
+    if leaf_symlink:
+        outside_file = outside / "movie.mkv"
+        outside_file.write_text("keep", encoding="utf-8")
+        local_link = local_root / "movie.mkv"
+        local_link.symlink_to(outside_file)
+        source_path = source_root / "movie.mkv"
+        cloud_file = cloud_root / "movie.mkv"
+    else:
+        escaped_directory = outside / "escape"
+        escaped_directory.mkdir()
+        outside_file = escaped_directory / "movie.mkv"
+        outside_file.write_text("keep", encoding="utf-8")
+        (local_root / "escape").symlink_to(escaped_directory, target_is_directory=True)
+        source_path = source_root / "escape" / "movie.mkv"
+        cloud_file = cloud_root / "escape" / "movie.mkv"
+
+    cloud_file.parent.mkdir(parents=True, exist_ok=True)
+    cloud_file.write_text("keep", encoding="utf-8")
+
+    plugin = CloudSyncDel()
+    plugin.init_plugin({
+        "enabled": True,
+        "local_path": f"{source_root}:{local_root}",
+        "path": f"{source_root}:{cloud_root}",
+    })
+    plugin.eventmanager = Mock()
+    plugin.clouddisk_del(_event(source_path))
+
+    assert outside_file.exists()
+    assert cloud_file.exists()
+    if leaf_symlink:
+        assert local_link and not local_link.is_symlink()
+        plugin.eventmanager.send_event.assert_called_once()
+    else:
+        assert (local_root / "escape").is_symlink()
+        plugin.eventmanager.send_event.assert_not_called()
+
+
+def test_local_delete_forwards_complete_media_identity(tmp_path: Path) -> None:
+    """本地删除回调必须继续携带来源和来源原生 ID。"""
+    source_root = tmp_path / "source"
+    local_root = tmp_path / "local"
+    local_media = local_root / "movie.mkv"
+    source_root.mkdir()
+    local_media.parent.mkdir()
+    local_media.write_text("remove", encoding="utf-8")
+
+    plugin = CloudSyncDel()
+    plugin.init_plugin({
+        "enabled": True,
+        "local_path": f"{source_root}:{local_root}",
+    })
+    plugin.eventmanager = Mock()
+    plugin.clouddisk_del(_event(source_root / "movie.mkv"))
+
+    assert not local_media.exists()
+    plugin.eventmanager.send_event.assert_called_once()
+    event_type, payload = plugin.eventmanager.send_event.call_args.args
+    assert event_type is EventType.PluginAction
+    assert payload["action"] == "media_sync_del"
+    assert payload["media_source"] == MediaSource.Douban.value
+    assert payload["media_id"] == "1295644"
+    assert "tmdb_id" not in payload
+
+
+def test_local_directory_delete_forwards_complete_media_identity(tmp_path: Path) -> None:
+    """本地目录删除也必须通知下游，并携带完整媒体身份。"""
+    source_root = tmp_path / "source"
+    local_root = tmp_path / "local"
+    local_directory = local_root / "Season 01"
+    source_root.mkdir()
+    local_directory.mkdir(parents=True)
+    (local_directory / "episode.mkv").write_text("remove", encoding="utf-8")
+
+    plugin = CloudSyncDel()
+    plugin.init_plugin({
+        "enabled": True,
+        "local_path": f"{source_root}:{local_root}",
+    })
+    plugin.eventmanager = Mock()
+    plugin.clouddisk_del(_event(source_root / "Season 01"))
+
+    assert not local_directory.exists()
+    plugin.eventmanager.send_event.assert_called_once()
+    _, payload = plugin.eventmanager.send_event.call_args.args
+    assert payload["action"] == "media_sync_del"
+    assert payload["media_source"] == MediaSource.Douban.value
+    assert payload["media_id"] == "1295644"
+
+
+def test_local_directory_symlink_forwards_complete_media_identity(tmp_path: Path) -> None:
+    """映射根内目录符号链接只解除链接，并继续向下游转发完整媒体身份。"""
+    source_root = tmp_path / "source"
+    local_root = tmp_path / "local"
+    local_directory = local_root / "target"
+    local_link = local_root / "Season 01"
+    source_root.mkdir()
+    local_directory.mkdir(parents=True)
+    (local_directory / "episode.mkv").write_text("keep", encoding="utf-8")
+    local_link.symlink_to(local_directory, target_is_directory=True)
+
+    plugin = CloudSyncDel()
+    plugin.init_plugin({
+        "enabled": True,
+        "local_path": f"{source_root}:{local_root}",
+    })
+    plugin.eventmanager = Mock()
+    plugin.clouddisk_del(_event(source_root / "Season 01"))
+
+    assert not local_link.exists()
+    assert local_directory.exists()
+    plugin.eventmanager.send_event.assert_called_once()
+    _, payload = plugin.eventmanager.send_event.call_args.args
+    assert payload["action"] == "media_sync_del"
+    assert payload["media_source"] == MediaSource.Douban.value
+    assert payload["media_id"] == "1295644"
+
+
+def test_missing_media_identity_fails_closed(tmp_path: Path) -> None:
+    """缺少完整媒体身份时不得删除已映射文件。"""
+    source_root = tmp_path / "source"
+    cloud_root = tmp_path / "cloud"
+    source_root.mkdir()
+    cloud_file = cloud_root / "movie.mkv"
+    cloud_file.parent.mkdir(parents=True)
+    cloud_file.write_text("keep", encoding="utf-8")
+
+    plugin = CloudSyncDel()
+    plugin.init_plugin({"enabled": True, "path": f"{source_root}:{cloud_root}"})
+    plugin.clouddisk_del(_event(source_root / "movie.mkv", media_source=None, media_id=None))
+
+    assert cloud_file.exists()
+
+
+def test_cloud_callback_failure_does_not_recreate_or_escape_delete(tmp_path: Path, monkeypatch) -> None:
+    """外部回调失败只记录错误，不改变已完成的根内删除结果。"""
+    source_root = tmp_path / "source"
+    cloud_root = tmp_path / "cloud"
+    source_root.mkdir()
+    cloud_root.mkdir()
+    cloud_file = cloud_root / "movie.mkv"
+    cloud_file.write_text("remove", encoding="utf-8")
+
+    request = Mock()
+    request.post.side_effect = RuntimeError("network unavailable")
+    monkeypatch.setattr(cloudsyncdel_module, "RequestUtils", Mock(return_value=request))
+
+    plugin = CloudSyncDel()
+    plugin.init_plugin({
+        "enabled": True,
+        "path": f"{source_root}:{cloud_root}",
+        "url": "https://example.invalid/callback",
+    })
+    plugin._save_history = Mock()
+    plugin.clouddisk_del(_event(source_root / "movie.mkv"))
+
+    assert not cloud_file.exists()
+    request.post.assert_called_once()
+    assert plugin._save_history.call_count == 1
+
+
+def test_api_uses_bear_auth_and_never_exposes_token() -> None:
+    """历史 API 使用宿主 Bearer 鉴权，页面参数不能携带 API token。"""
+    plugin = CloudSyncDel()
+    plugin.init_plugin({})
+    api = plugin.get_api()[0]
+    assert api["auth"] == "bear"
+    assert api["response_model"] is schemas.Response[None]
+
+    plugin.get_data = Mock(return_value=[{"unique": "one", "title": "示例"}])
+    plugin.save_data = Mock()
+    assert plugin.delete_history("one").success is True
+    plugin.save_data.assert_called_once_with("history", [])
+
+    plugin.get_data = Mock(return_value=[{
+        "unique": "one",
+        "title": "示例",
+        "type": "电视剧",
+        "media_source": MediaSource.TMDB.value,
+        "media_id": "550",
+        "season": 1,
+        "episode": 2,
+        "image": "https://example.invalid/poster.jpg",
+        "del_time": "2026-08-28 00:00:00",
+    }])
+    page = plugin.get_page()
+    close_button = page[0]["content"][0]["content"][0]
+    assert "apikey" not in close_button["events"]["click"]["params"]
+    card_body = page[0]["content"][0]["content"][1]
+    assert card_body["content"][0]["component"] == "VImg"
+    assert card_body["content"][0]["props"]["src"] == "https://example.invalid/poster.jpg"
+    detail_text = {
+        component.get("text")
+        for component in card_body["content"][1]["content"]
+    }
+    assert "季：1" in detail_text
+    assert "集：2" in detail_text

--- a/tests/v3/lucky/test_lucky.py
+++ b/tests/v3/lucky/test_lucky.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import ast
+import json
+import os
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+BACKEND_ROOT = Path(os.environ["MOVIEPILOT_BACKEND_PATH"])
+sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.testing.bootstrap import prepare_v3_backend
+
+prepare_v3_backend(REPOSITORY_ROOT)
+
+from app.plugins.lucky import Lucky, LuckyStatusData
+from app.application.chain.context import (
+    ChainRuntimeContext,
+    configure_chain_runtime_context_provider,
+)
+from app.application.chain.data import (
+    configure_chain_data_ports,
+    get_chain_data_ports,
+)
+
+
+PLUGIN_PATH = REPOSITORY_ROOT / "plugins.v3" / "lucky" / "__init__.py"
+
+configure_chain_data_ports(
+    **{
+        name: lambda: Mock()
+        for name in (
+            "site",
+            "subscribe",
+            "workflow",
+            "download_history",
+            "transfer_history",
+            "transfer_pending",
+            "transfer_execution",
+            "media_server",
+            "download_failure",
+            "user",
+        )
+    }
+)
+
+
+@pytest.fixture(autouse=True)
+def _chain_runtime_context():
+    """为插件基类提供隔离的链运行时上下文。"""
+    configure_chain_runtime_context_provider(
+        lambda: ChainRuntimeContext(
+            module_manager=Mock(),
+            plugin_manager=Mock(),
+            event_manager=Mock(),
+            message_oper=Mock(),
+            message_helper=Mock(),
+            file_cache=Mock(),
+            async_file_cache=Mock(),
+            message_queue_factory=lambda _callback: Mock(),
+            module_dispatcher_factory=lambda **_kwargs: Mock(),
+            data_ports=get_chain_data_ports(),
+        )
+    )
+    yield
+    configure_chain_runtime_context_provider(None)
+
+
+def _imports() -> set[str]:
+    """返回插件源码使用的 from-import 模块集合。"""
+    tree = ast.parse(PLUGIN_PATH.read_text(encoding="utf-8"))
+    return {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module
+    }
+
+
+def test_v3_manifest_and_sdk_contract() -> None:
+    """V3 元数据、旧代路由和公开 SDK 导入必须保持一致。"""
+    manifest = json.loads(
+        (REPOSITORY_ROOT / "package.v3.json").read_text(encoding="utf-8")
+    )["Lucky"]
+    legacy_manifest = json.loads(
+        (REPOSITORY_ROOT / "package.json").read_text(encoding="utf-8")
+    )["Lucky"]
+
+    assert manifest["version"] == Lucky.plugin_version == "2.0.0"
+    assert manifest["release"] is True
+    assert manifest["system_version"] == ">=3.0.0"
+    assert list(manifest["history"]) == ["v2.0.0"]
+    assert legacy_manifest["v2"] is True
+    assert legacy_manifest["v3"] is False
+
+    imports = _imports()
+    assert {
+        "app.sdk.logging",
+        "app.sdk.network",
+        "app.sdk.utilities",
+    }.issubset(imports)
+    forbidden_prefixes = (
+        "app.adapters",
+        "app.core",
+        "app.domain",
+        "app.foundation",
+        "app.helper",
+        "app.runtime",
+        "app.sdk._legacy",
+        "app.utils",
+    )
+    assert not any(module.startswith(forbidden_prefixes) for module in imports)
+
+
+def test_init_resets_hot_reload_state_and_declares_api_model() -> None:
+    """重复初始化不得保留旧地址或凭据，API 必须声明真实响应模型。"""
+    plugin = Lucky()
+    plugin.init_plugin(
+        {"enabled": True, "baseUrl": "https://lucky.example/", "openToken": "secret"}
+    )
+
+    assert plugin.get_state() is True
+    assert plugin._base_url == "https://lucky.example"
+    assert plugin._open_token == "secret"
+    assert plugin._request is not None
+    assert plugin.get_command() == []
+    api = plugin.get_api()[0]
+    assert api["auth"] == "apikey"
+    assert api["response_model"] is LuckyStatusData
+
+    plugin.init_plugin({})
+
+    assert plugin.get_state() is False
+    assert plugin._base_url is None
+    assert plugin._open_token is None
+    assert plugin._request is None
+    _, defaults = plugin.get_form()
+    assert defaults == {"enabled": False, "baseUrl": "", "openToken": ""}
+
+
+def test_request_keeps_token_out_of_url_and_validates_payload() -> None:
+    """OpenToken 只能作为请求参数传递，非对象或失败响应应被拒绝。"""
+
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self):
+            return {"ret": 0, "data": []}
+
+    class FakeRequest:
+        def __init__(self) -> None:
+            self.call = None
+
+        @contextmanager
+        def response_manager(self, method, url, **kwargs):
+            self.call = (method, url, kwargs)
+            yield FakeResponse()
+
+    request = FakeRequest()
+    plugin = Lucky()
+    plugin._base_url = "https://lucky.example"
+    plugin._open_token = "secret"
+    plugin._request = request
+
+    assert plugin._request_json("/api/ddnstasklist") == {"ret": 0, "data": []}
+    method, url, kwargs = request.call
+    assert method == "GET"
+    assert url == "https://lucky.example/api/ddnstasklist"
+    assert "secret" not in url
+    assert kwargs["params"]["openToken"] == "secret"
+    assert kwargs["raise_exception"] is True
+
+    response = Mock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = ["unexpected"]
+
+    @contextmanager
+    def invalid_response(*_args, **_kwargs):
+        yield response
+
+    plugin._request.response_manager = invalid_response
+    assert plugin._request_json("/api/ddnstasklist") is None
+
+
+def test_lucky_aggregates_external_payload_into_declared_model(monkeypatch) -> None:
+    """规则、流量、DDNS 与证书响应应稳定映射为声明的数据模型。"""
+    payloads = {
+        "/api/webservice/rules": {
+            "ret": 0,
+            "ruleList": [
+                {"ProxyList": [{"Enable": True}, {"Enable": False}]},
+                {"ProxyList": None},
+            ],
+            "statistics": {
+                "one": {"Connections": 2, "TrafficIn": 1024, "TrafficOut": 2048},
+                "two": {"Connections": "3", "TrafficIn": None, "TrafficOut": "1024"},
+            },
+        },
+        "/api/ddnstasklist": {"ret": 0, "data": [{"Ipv4Addr": "192.0.2.1"}]},
+        "/api/ssl": {
+            "ret": 0,
+            "list": [{"CertsInfo": [{"NotAfterTime": "2030-04-05 00:00:00"}]}],
+        },
+    }
+    plugin = Lucky()
+    monkeypatch.setattr(plugin, "_request_json", lambda path: payloads[path])
+
+    result = plugin.lucky()
+    model = LuckyStatusData.model_validate(result)
+
+    assert model.total_cnt == 2
+    assert model.enabled_cnt == 1
+    assert model.closed_cnt == 1
+    assert model.connections == 5
+    assert model.ipaddr == "192.0.2.1"
+    assert model.expire_time == "20300405"
+    assert model.traffic_in
+    assert model.traffic_out
+    assert {"trafficIn", "trafficOut"}.issubset(model.model_dump(by_alias=True))
+
+
+def test_external_shape_failures_return_empty_status(monkeypatch) -> None:
+    """Lucky 响应缺字段时应返回稳定空状态，而不是抛出索引或类型异常。"""
+    plugin = Lucky()
+    monkeypatch.setattr(plugin, "_request_json", lambda _path: None)
+
+    result = LuckyStatusData.model_validate(plugin.lucky())
+
+    assert result.total_cnt == 0
+    assert result.connections == 0
+    assert result.ipaddr is None
+    assert result.expire_time is None

--- a/tests/v3/popularsubscribe/test_popularsubscribe.py
+++ b/tests/v3/popularsubscribe/test_popularsubscribe.py
@@ -1,0 +1,380 @@
+from __future__ import annotations
+
+import ast
+import json
+import os
+import sys
+from copy import deepcopy
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+BACKEND_ROOT = Path(os.environ["MOVIEPILOT_BACKEND_PATH"])
+sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.testing.bootstrap import prepare_v3_backend
+
+prepare_v3_backend(REPOSITORY_ROOT)
+
+from app import schemas
+from app.application.chain.context import (
+    ChainRuntimeContext,
+    configure_chain_runtime_context_provider,
+)
+from app.application.chain.data import configure_chain_data_ports, get_chain_data_ports
+from app.plugins import popularsubscribe as popularsubscribe_module
+from app.plugins.popularsubscribe import PopularSubscribe
+from app.schemas.types import MediaSource, MediaType
+from app.sdk.media import MediaInfo
+
+PLUGIN_PATH = REPOSITORY_ROOT / "plugins.v3" / "popularsubscribe" / "__init__.py"
+
+configure_chain_data_ports(
+    **{
+        name: lambda: Mock()
+        for name in (
+            "site",
+            "subscribe",
+            "workflow",
+            "download_history",
+            "transfer_history",
+            "transfer_execution",
+            "transfer_pending",
+            "media_server",
+            "download_failure",
+            "user",
+        )
+    }
+)
+
+
+@pytest.fixture(autouse=True)
+def _chain_runtime_context():
+    """为插件基类提供隔离 Chain 上下文。"""
+    configure_chain_runtime_context_provider(
+        lambda: ChainRuntimeContext(
+            module_manager=Mock(),
+            plugin_manager=Mock(),
+            event_manager=Mock(),
+            message_oper=Mock(),
+            message_helper=Mock(),
+            file_cache=Mock(),
+            async_file_cache=Mock(),
+            message_queue_factory=lambda _callback: Mock(),
+            module_dispatcher_factory=lambda **_kwargs: Mock(),
+            data_ports=get_chain_data_ports(),
+        )
+    )
+    yield
+    configure_chain_runtime_context_provider(None)
+
+
+@pytest.fixture(autouse=True)
+def _meta_info(monkeypatch: pytest.MonkeyPatch) -> None:
+    """隔离需要宿主识别配置的元数据解析器。"""
+    monkeypatch.setattr(
+        popularsubscribe_module,
+        "MetaInfo",
+        lambda title: SimpleNamespace(title=title, type=None, begin_season=None),
+    )
+
+
+def _imports() -> set[str]:
+    """返回插件源码中的 from-import 模块集合。"""
+    tree = ast.parse(PLUGIN_PATH.read_text(encoding="utf-8"))
+    return {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module
+    }
+
+
+def _statistic_item(**overrides) -> dict:
+    """构造包含完整 V3 媒体身份的热门订阅条目。"""
+    item = {
+        "name": "搏击俱乐部",
+        "year": "1999",
+        "type": "电影",
+        "media_source": MediaSource.TMDB.value,
+        "media_id": "550",
+        "count": 20,
+        "poster": "/poster.jpg",
+        "description": "简介",
+        "vote": 8.8,
+        "genre_ids": [18],
+    }
+    item.update(overrides)
+    return item
+
+
+def _saved_values(plugin: PopularSubscribe) -> dict[str, object]:
+    """读取插件本轮保存的数据快照。"""
+    return {
+        call.args[0]: deepcopy(call.args[1])
+        for call in plugin.save_data.call_args_list
+        if len(call.args) >= 2
+    }
+
+
+def _prepare_run(plugin: PopularSubscribe, items: list[dict], data: dict[str, object]):
+    """注入热门订阅任务的链、统计响应和隔离存储。"""
+    plugin.downloadchain = Mock()
+    plugin.subscribechain = Mock()
+    plugin.mediachain = Mock()
+    plugin._username = "热门订阅"
+    plugin.downloadchain.get_no_exists_info.return_value = (False, {})
+    plugin.subscribechain.exists.return_value = False
+    plugin.subscribechain.add.return_value = (7, "")
+    plugin.get_data = lambda key: data.get(key)
+    plugin.save_data = Mock()
+    plugin._PopularSubscribe__get_subscribe_statistic = Mock(return_value=items)
+
+
+def test_v3_manifest_and_sdk_contract() -> None:
+    """V3 索引、旧代路由、版本和稳定 SDK 导入应保持一致。"""
+    manifest = json.loads(
+        (REPOSITORY_ROOT / "package.v3.json").read_text(encoding="utf-8")
+    )["PopularSubscribe"]
+    legacy_manifest = json.loads(
+        (REPOSITORY_ROOT / "package.json").read_text(encoding="utf-8")
+    )["PopularSubscribe"]
+
+    assert manifest["version"] == PopularSubscribe.plugin_version == "3.0.0"
+    assert manifest["release"] is True
+    assert manifest["system_version"] == ">=3.0.0"
+    assert list(manifest["history"]) == ["v3.0.0"]
+    assert legacy_manifest["v3"] is False
+
+    imports = _imports()
+    assert {
+        "app.sdk.config",
+        "app.sdk.logging",
+        "app.sdk.media",
+        "app.sdk.network",
+    }.issubset(imports)
+    forbidden_prefixes = (
+        "app.adapters",
+        "app.core",
+        "app.db.models",
+        "app.domain",
+        "app.foundation",
+        "app.helper",
+        "app.runtime",
+        "app.sdk._legacy",
+        "app.utils",
+    )
+    assert not any(module.startswith(forbidden_prefixes) for module in imports)
+    source = PLUGIN_PATH.read_text(encoding="utf-8")
+    assert "logger.warn(" not in source
+    assert "apikey" not in source
+
+    tree = ast.parse(source)
+    subscribe_add_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "add"
+        and isinstance(node.func.value, ast.Attribute)
+        and node.func.value.attr == "subscribechain"
+    ]
+    assert subscribe_add_calls
+    assert not {
+        keyword.arg
+        for call in subscribe_add_calls
+        for keyword in call.keywords
+    }.intersection({"tmdbid", "doubanid"})
+
+
+def test_init_without_config_resets_runtime_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """空配置热重载不得保留上一次启用状态或任务参数。"""
+    monkeypatch.setattr(popularsubscribe_module, "DownloadChain", Mock)
+    monkeypatch.setattr(popularsubscribe_module, "SubscribeChain", Mock)
+    monkeypatch.setattr(popularsubscribe_module, "MediaChain", Mock)
+    plugin = PopularSubscribe()
+    plugin._movie_enabled = True
+    plugin._tv_enabled = True
+    plugin._anime_enabled = True
+    plugin.get_data = Mock(return_value=[])
+
+    plugin.init_plugin(None)
+
+    assert plugin.get_state() is False
+    assert plugin._movie_cron == ""
+    assert plugin._username == "热门订阅"
+    plugin.stop_service()
+
+
+def test_api_and_service_contract() -> None:
+    """插件 API 应使用宿主认证，周期任务应由宿主服务投影注册。"""
+    plugin = PopularSubscribe()
+    plugin._movie_enabled = True
+    plugin._movie_cron = "5 1 * * *"
+    plugin._movie_page_cnt = 12
+    plugin._movie_popular_cnt = 8
+
+    api = plugin.get_api()[0]
+    services = plugin.get_service()
+
+    assert api["auth"] == "bear"
+    assert api["response_model"] is schemas.Response[None]
+    assert len(services) == 1
+    assert services[0]["id"] == "PopularSubscribeMovie"
+    assert services[0]["func_kwargs"] == {
+        "stype": "电影",
+        "page_cnt": 12,
+        "popular_cnt": 8,
+    }
+
+
+def test_history_identity_migration_is_idempotent() -> None:
+    """旧专用 ID 历史应迁移为统一媒体身份且重复执行不再写入。"""
+    history = [{
+        "title": "搏击俱乐部",
+        "type": "电影",
+        "year": "1999",
+        "tmdbid": 550,
+        "doubanid": "0",
+        "time": "2026-08-28 10:00:00",
+    }]
+    plugin = object.__new__(PopularSubscribe)
+    plugin.get_data = lambda _key: history
+    plugin.save_data = Mock()
+
+    plugin._PopularSubscribe__migrate_history_identity()
+
+    assert history[0]["media_source"] == MediaSource.TMDB.value
+    assert history[0]["media_id"] == "550"
+    assert {"tmdbid", "doubanid"}.isdisjoint(history[0])
+    assert "tmdb:550" in history[0]["unique"]
+    assert plugin.save_data.call_count == 1
+
+    plugin._PopularSubscribe__migrate_history_identity()
+    assert plugin.save_data.call_count == 1
+
+
+def test_build_media_requires_complete_identity() -> None:
+    """中心统计缺少统一身份 pair 时不得退回旧专用 ID。"""
+    valid = PopularSubscribe._PopularSubscribe__build_media(_statistic_item())
+    invalid = PopularSubscribe._PopularSubscribe__build_media(
+        _statistic_item(media_source=None, media_id=None, tmdbid=550)
+    )
+
+    assert valid.media_source == MediaSource.TMDB
+    assert valid.media_id == "550"
+    assert valid.type == MediaType.MOVIE
+    assert invalid is None
+
+
+def test_successful_subscription_uses_identity_and_checkpoints() -> None:
+    """成功订阅应传递统一身份并及时保存历史和媒体键。"""
+    plugin = PopularSubscribe()
+    _prepare_run(plugin, [_statistic_item()], {"history": [], "already_handle": []})
+
+    plugin._PopularSubscribe__popular_subscribe("电影", 30, 0)
+
+    plugin.subscribechain.add.assert_called_once_with(
+        title="搏击俱乐部",
+        year="1999",
+        mtype=MediaType.MOVIE,
+        media_source=MediaSource.TMDB,
+        media_id="550",
+        season=None,
+        exist_ok=True,
+        username="热门订阅",
+    )
+    saved = _saved_values(plugin)
+    assert saved["already_handle"] == ["tmdb:550"]
+    assert saved["history"][0]["media_source"] == MediaSource.TMDB.value
+    assert saved["history"][0]["media_id"] == "550"
+
+
+@pytest.mark.parametrize("handled", [["tmdb:550"], ["搏击俱乐部 (1999)"]])
+def test_new_and_legacy_handled_keys_skip_subscription(handled: list[str]) -> None:
+    """统一媒体键和存量标题键都应阻止重复订阅。"""
+    plugin = PopularSubscribe()
+    _prepare_run(plugin, [_statistic_item()], {"history": [], "already_handle": handled})
+
+    plugin._PopularSubscribe__popular_subscribe("电影", 30, 0)
+
+    plugin.subscribechain.add.assert_not_called()
+    assert _saved_values(plugin)["already_handle"] == handled
+
+
+def test_inventory_failure_is_fail_closed() -> None:
+    """媒体库查询失败时不得继续创建订阅或写入已处理状态。"""
+    plugin = PopularSubscribe()
+    _prepare_run(plugin, [_statistic_item()], {"history": [], "already_handle": []})
+    plugin.downloadchain.get_no_exists_info.side_effect = RuntimeError("媒体库不可用")
+
+    plugin._PopularSubscribe__popular_subscribe("电影", 30, 0)
+
+    plugin.subscribechain.exists.assert_not_called()
+    plugin.subscribechain.add.assert_not_called()
+    saved = _saved_values(plugin)
+    assert saved["history"] == []
+    assert saved["already_handle"] == []
+
+
+def test_failed_subscription_is_not_marked_as_handled() -> None:
+    """订阅写入失败时不得产生历史或已处理状态。"""
+    plugin = PopularSubscribe()
+    _prepare_run(plugin, [_statistic_item()], {"history": [], "already_handle": []})
+    plugin.subscribechain.add.return_value = (None, "写入失败")
+
+    plugin._PopularSubscribe__popular_subscribe("电影", 30, 0)
+
+    saved = _saved_values(plugin)
+    assert saved["history"] == []
+    assert saved["already_handle"] == []
+
+
+def test_completed_item_is_saved_before_later_candidate_failure() -> None:
+    """后续候选构建失败时，前序成功订阅的状态仍应保留。"""
+    plugin = PopularSubscribe()
+    _prepare_run(
+        plugin,
+        [_statistic_item(), _statistic_item(name="第二部", media_id="551")],
+        {"history": [], "already_handle": []},
+    )
+    first = PopularSubscribe._PopularSubscribe__build_media(_statistic_item())
+    second = PopularSubscribe._PopularSubscribe__build_media(
+        _statistic_item(name="第二部", media_id="551")
+    )
+    second.get_poster_image = Mock(side_effect=RuntimeError("海报构建失败"))
+    plugin._PopularSubscribe__build_media = Mock(side_effect=[first, second])
+
+    with pytest.raises(RuntimeError, match="海报构建失败"):
+        plugin._PopularSubscribe__popular_subscribe("电影", 30, 0)
+
+    saved = _saved_values(plugin)
+    assert saved["already_handle"] == ["tmdb:550"]
+    assert saved["history"][0]["media_id"] == "550"
+
+
+def test_history_page_uses_bearer_route_without_legacy_token() -> None:
+    """详情页删除动作不得暴露 API token，并应保留来源详情链接。"""
+    plugin = PopularSubscribe()
+    plugin.get_data = Mock(return_value=[{
+        "title": "搏击俱乐部",
+        "type": "电影",
+        "year": "1999",
+        "poster": "poster",
+        "media_source": MediaSource.TMDB.value,
+        "media_id": "550",
+        "time": "2026-08-28 10:00:00",
+        "unique": "popularsubscribe:搏击俱乐部:tmdb:550:2026-08-28 10:00:00",
+    }])
+
+    page = plugin.get_page()
+    page_text = repr(page)
+
+    assert "apikey" not in page_text
+    assert "https://www.themoviedb.org/movie/550" in page_text
+    params = page[0]["content"][0]["content"][0]["events"]["click"]["params"]
+    assert params == {
+        "key": "popularsubscribe:搏击俱乐部:tmdb:550:2026-08-28 10:00:00"
+    }

--- a/tests/v3/synologynotify/test_synologynotify.py
+++ b/tests/v3/synologynotify/test_synologynotify.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import ast
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+BACKEND_ROOT = Path(os.environ["MOVIEPILOT_BACKEND_PATH"])
+sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.testing.bootstrap import prepare_v3_backend
+
+prepare_v3_backend(REPOSITORY_ROOT)
+
+from app import schemas
+from app.application.chain.context import (
+    ChainRuntimeContext,
+    configure_chain_runtime_context_provider,
+)
+from app.application.chain.data import configure_chain_data_ports, get_chain_data_ports
+from app.plugins.synologynotify import SynologyNotify
+from app.schemas.types import MessageType
+
+
+PLUGIN_PATH = REPOSITORY_ROOT / "plugins.v3" / "synologynotify" / "__init__.py"
+
+configure_chain_data_ports(
+    **{
+        name: lambda: Mock()
+        for name in (
+            "site",
+            "subscribe",
+            "workflow",
+            "download_history",
+            "transfer_history",
+            "transfer_pending",
+            "transfer_execution",
+            "media_server",
+            "download_failure",
+            "user",
+        )
+    }
+)
+
+
+@pytest.fixture(autouse=True)
+def _chain_runtime_context():
+    """为插件基类提供隔离的消息链上下文。"""
+    configure_chain_runtime_context_provider(
+        lambda: ChainRuntimeContext(
+            module_manager=Mock(),
+            plugin_manager=Mock(),
+            event_manager=Mock(),
+            message_oper=Mock(),
+            message_helper=Mock(),
+            file_cache=Mock(),
+            async_file_cache=Mock(),
+            message_queue_factory=lambda _callback: Mock(),
+            module_dispatcher_factory=lambda **_kwargs: Mock(),
+            data_ports=get_chain_data_ports(),
+        )
+    )
+    yield
+    configure_chain_runtime_context_provider(None)
+
+
+def _imports() -> set[str]:
+    """返回插件源码中的 from-import 模块集合。"""
+    tree = ast.parse(PLUGIN_PATH.read_text(encoding="utf-8"))
+    return {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module
+    }
+
+
+def test_v3_manifest_and_import_contract() -> None:
+    """V3 索引、旧代回退开关和稳定 SDK 导入应保持一致。"""
+    manifest = json.loads(
+        (REPOSITORY_ROOT / "package.v3.json").read_text(encoding="utf-8")
+    )["SynologyNotify"]
+    legacy_manifest = json.loads(
+        (REPOSITORY_ROOT / "package.json").read_text(encoding="utf-8")
+    )["SynologyNotify"]
+    source = PLUGIN_PATH.read_text(encoding="utf-8")
+
+    assert manifest["version"] == SynologyNotify.plugin_version == "2.0.0"
+    assert manifest["release"] is True
+    assert manifest["system_version"] == ">=3.0.0"
+    assert list(manifest["history"]) == ["v2.0.0"]
+    assert legacy_manifest["v3"] is False
+
+    imports = _imports()
+    assert {"app.plugins", "app.schemas.types", "app.sdk.logging"}.issubset(
+        imports
+    )
+    forbidden_prefixes = (
+        "app.adapters",
+        "app.application",
+        "app.core",
+        "app.db.models",
+        "app.domain",
+        "app.foundation",
+        "app.helper",
+        "app.log",
+        "app.runtime",
+        "app.sdk._legacy",
+        "app.utils",
+    )
+    assert not any(module.startswith(forbidden_prefixes) for module in imports)
+    assert "NotificationType" not in source
+
+
+def test_plugin_lifecycle_and_api_contract() -> None:
+    """插件应重置生命周期状态，并声明带统一响应模型的 Webhook API。"""
+    plugin = SynologyNotify()
+
+    assert plugin.get_state() is False
+    plugin.init_plugin({"enabled": True, "notify": True, "msgtype": "Plugin"})
+    assert plugin.get_state() is True
+    assert plugin.get_api() == [
+        {
+            "path": "/webhook",
+            "endpoint": plugin.send_notify,
+            "methods": ["GET"],
+            "auth": "apikey",
+            "summary": "群辉webhook",
+            "description": "接受群辉webhook通知并推送",
+            "response_model": schemas.Response[None],
+        }
+    ]
+    assert plugin.get_command() == []
+    assert plugin.get_page() == []
+    plugin.init_plugin({})
+    assert plugin.get_state() is False
+    assert plugin.stop_service() is None
+
+
+def test_get_form_uses_v3_message_types() -> None:
+    """配置表单的消息类型选项应来自 V3 MessageType。"""
+    form, defaults = SynologyNotify().get_form()
+
+    select = form[0]["content"][1]["content"][0]["content"][0]
+    options = select["props"]["items"]
+    assert options == [
+        {"title": item.value, "value": item.name} for item in MessageType
+    ]
+    assert defaults == {"enabled": False, "notify": False, "msgtype": ""}
+
+
+def test_send_notify_forwards_text_and_selected_message_type() -> None:
+    """Webhook text 应按配置转发，并保留统一通知标题。"""
+    plugin = SynologyNotify()
+    plugin.init_plugin({"enabled": True, "notify": True, "msgtype": "Plugin"})
+    plugin.post_message = Mock()
+
+    response = plugin.send_notify(
+        text="下载完成",
+        title="忽略的标题",
+        content="正文",
+        url="https://example.test/detail",
+    )
+
+    assert response == schemas.Response(success=True, message="发送成功")
+    plugin.post_message.assert_called_once_with(
+        title="群辉通知",
+        mtype=MessageType.Plugin,
+        text="下载完成",
+    )
+
+
+def test_send_notify_uses_detail_fields_and_falls_back_to_manual_type() -> None:
+    """没有 text 时应拼接详情链接，非法消息类型应回退为手动处理。"""
+    plugin = SynologyNotify()
+    plugin.init_plugin({"enabled": True, "notify": True, "msgtype": "unknown"})
+    plugin.post_message = Mock()
+
+    plugin.send_notify(
+        title="详情标题",
+        content="详情正文",
+        url="https://example.test/detail",
+    )
+
+    plugin.post_message.assert_called_once_with(
+        title="详情标题",
+        mtype=MessageType.Manual,
+        text="详情正文\n[查看详情](https://example.test/detail)",
+    )
+
+
+def test_send_notify_respects_notification_switch() -> None:
+    """插件或通知开关关闭时不得投递消息，但 Webhook 仍返回成功。"""
+    plugin = SynologyNotify()
+    plugin.init_plugin({"enabled": True, "notify": False})
+    plugin.post_message = Mock()
+
+    response = plugin.send_notify(text="不会发送")
+
+    assert response.success is True
+    plugin.post_message.assert_not_called()
+
+
+def test_send_notify_rejects_empty_payload() -> None:
+    """空 Webhook 不得生成包含 None 的伪通知。"""
+    plugin = SynologyNotify()
+    plugin.init_plugin({"enabled": True, "notify": True})
+    plugin.post_message = Mock()
+
+    response = plugin.send_notify()
+
+    assert response == schemas.Response(success=False, message="消息内容不能为空")
+    plugin.post_message.assert_not_called()
+
+
+def test_send_notify_omits_missing_detail_url() -> None:
+    """详情 URL 缺失时通知正文不得包含无效 Markdown 链接。"""
+    plugin = SynologyNotify()
+    plugin.init_plugin({"enabled": True, "notify": True})
+    plugin.post_message = Mock()
+
+    plugin.send_notify(title="存储告警", content="空间不足")
+
+    plugin.post_message.assert_called_once_with(
+        title="存储告警",
+        mtype=MessageType.Manual,
+        text="空间不足",
+    )


### PR DESCRIPTION
## 目标

完成第四批 MoviePilot V3 严格迁移，将六个个人仓插件切换到独立 V3 实现。

## 主要变化

- 新增 `ActorSubscribe`、`ActorSubscribePlus`、`PopularSubscribe`、`Lucky`、`SynologyNotify` 和 `CloudSyncDel` 的独立 V3 实现。
- 演员与热门订阅链路统一使用 `media_source + media_id` 媒体身份，并迁移订阅历史、统计读取和职责链调用合同。
- `Lucky` 与 `SynologyNotify` 迁移到公开 SDK 的网络、日志与消息类型合同，收敛外部 API 错误边界和响应模型。
- `CloudSyncDel` 统一媒体身份与事件合同，并对路径映射和删除目标执行失败关闭。
- 同步插件版本、发布历史、代际路由和聚焦测试；旧代条目显式设置 `v3:false`。

## 关键边界

- V3 生产实现不使用 `app.sdk._legacy`，不直接访问宿主 Model、Session 或非公开应用层入口。
- 云盘删除仅在媒体身份与路径边界可确认时执行，无法确认时不推断删除目标。
- 外部网络和消息发送在测试中均使用替身，不产生真实出站请求。

## 验证

- Batch 04 聚焦测试及 CI 合同测试：`64 passed`
- 插件版本门禁通过
- `package.json`、`package.v2.json`、`package.v3.json` JSON 解析通过
- 6 个新增 V3 插件目录编译通过
- replay 叶子树一致性、非公开宿主导入扫描、代际路由断言和 `git diff --check` 通过
