### PR TITLE
chore(ci): 更新 Release checkout Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## 背景

Release workflow 仍使用旧版 checkout Action。

## 调整

- `actions/checkout` 从 `v6` 更新到当前稳定 `v7`。
- 不修改插件源码、版本或发布契约。

## 验证

- actionlint：通过
- `git diff --check`：通过
