### PR TITLE
feat: 完成第五批 MoviePilot V3 插件迁移

### DIFF
--- a/package.json
+++ b/package.json
@@ -768,6 +768,7 @@
     "description": "通知Emby Danmu插件下载弹幕。",
     "labels": "Emby,媒体库",
     "version": "1.2",
+    "v3": false,
     "icon": "https://raw.githubusercontent.com/thsrite/MoviePilot-Plugins/main/icons/danmu.png",
     "author": "thsrite",
     "level": 1,

--- a/package.json
+++ b/package.json
@@ -789,6 +789,7 @@
     "icon": "https://raw.githubusercontent.com/thsrite/MoviePilot-Plugins/main/icons/embyactorsync.png",
     "author": "thsrite",
     "level": 1,
+    "v3": false,
     "history": {
       "v1.3": "剧集优先使用季演员。",
       "v1.2": "交互命令返回处理完成信息。",

--- a/package.json
+++ b/package.json
@@ -759,6 +759,7 @@
     "icon": "https://raw.githubusercontent.com/thsrite/MoviePilot-Plugins/main/icons/audiobook.png",
     "author": "thsrite",
     "level": 1,
+    "v3": false,
     "history": {
       "v1.1": "整理完锁定，防止数据被刷新",
       "v1.0": "还在为Emby有声书整理烦恼吗？入库存在很多单集。"

--- a/package.json
+++ b/package.json
@@ -236,6 +236,7 @@
     "icon": "Pydiocells_A.png",
     "author": "thsrite",
     "level": 1,
+    "v3": false,
     "history": {
       "v1.9.3": "修复观影记录日期获取",
       "v1.9.2": "媒体库黑名单改为媒体库名称",

--- a/package.json
+++ b/package.json
@@ -720,6 +720,7 @@
     "icon": "Element_A.png",
     "author": "thsrite",
     "level": 1,
+    "v3": false,
     "history": {
       "v1.1": "优化处理逻辑",
       "v1.0": "保留按照加入时间倒序的前提下，把合集中的媒体放一块，不用到处找。"

--- a/package.json
+++ b/package.json
@@ -746,6 +746,7 @@
     "icon": "https://raw.githubusercontent.com/thsrite/MoviePilot-Plugins/main/icons/extendtype.png",
     "author": "thsrite",
     "level": 1,
+    "v3": false,
     "history": {
       "v1.0": "定期检查Emby媒体库中是否包含指定的视频类型，发送通知。"
     }

--- a/package.v2.json
+++ b/package.v2.json
@@ -91,6 +91,7 @@
     "icon": "Pydiocells_A.png",
     "author": "thsrite",
     "level": 1,
+    "v3": false,
     "history": {
       "v2.1.5": "修复依赖问题",
       "v2.1.4": "修复观影记录日期获取",

--- a/package.v2.json
+++ b/package.v2.json
@@ -224,6 +224,7 @@
     "icon": "https://raw.githubusercontent.com/thsrite/MoviePilot-Plugins/main/icons/embyactorsync.png",
     "author": "thsrite",
     "level": 1,
+    "v3": false,
     "history": {
       "v1.5": "修复自定义参数",
       "v1.4": "适配v2多媒体服务器",

--- a/package.v2.json
+++ b/package.v2.json
@@ -207,6 +207,7 @@
     "icon": "Element_A.png",
     "author": "thsrite",
     "level": 1,
+    "v3": false,
     "history": {
       "v1.4": "优化执行周期输入，需要MoviePilot v2.2.1+",
       "v1.3": "可设置合集排序黑名单",

--- a/package.v2.json
+++ b/package.v2.json
@@ -172,6 +172,7 @@
     "icon": "https://raw.githubusercontent.com/thsrite/MoviePilot-Plugins/main/icons/extendtype.png",
     "author": "thsrite",
     "level": 1,
+    "v3": false,
     "history": {
       "v1.2": "优化执行周期输入，需要MoviePilot v2.2.1+",
       "v1.1": "适配v2多媒体服务器",

--- a/package.v2.json
+++ b/package.v2.json
@@ -146,6 +146,7 @@
     "description": "通知Emby Danmu插件下载弹幕。",
     "labels": "Emby,媒体库",
     "version": "2.0",
+    "v3": false,
     "icon": "https://raw.githubusercontent.com/thsrite/MoviePilot-Plugins/main/icons/danmu.png",
     "author": "thsrite",
     "level": 1,

--- a/package.v2.json
+++ b/package.v2.json
@@ -187,6 +187,7 @@
     "icon": "https://raw.githubusercontent.com/thsrite/MoviePilot-Plugins/main/icons/audiobook.png",
     "author": "thsrite",
     "level": 1,
+    "v3": false,
     "history": {
       "v1.4.3": "优化执行周期输入，需要MoviePilot v2.2.1+",
       "v1.4.2": "支持交互命令修改有声书演播作者",

--- a/package.v3.json
+++ b/package.v3.json
@@ -320,5 +320,19 @@
     "history": {
       "v3.0.0": "适配 V3 SDK，并将报告任务迁移到宿主调度器。"
     }
+  },
+  "EmbyDanmu": {
+    "name": "Emby弹幕下载",
+    "description": "通知Emby Danmu插件下载弹幕。",
+    "labels": "Emby,媒体库",
+    "version": "3.0.0",
+    "icon": "https://raw.githubusercontent.com/thsrite/MoviePilot-Plugins/main/icons/danmu.png",
+    "author": "thsrite",
+    "level": 1,
+    "release": true,
+    "system_version": ">=3.0.0",
+    "history": {
+      "v3.0.0": "适配 V3 SDK、收口 Emby 请求和弹幕任务处理。"
+    }
   }
 }

--- a/package.v3.json
+++ b/package.v3.json
@@ -334,5 +334,19 @@
     "history": {
       "v3.0.0": "适配 V3 SDK、收口 Emby 请求和弹幕任务处理。"
     }
+  },
+  "EmbyExtendType": {
+    "name": "Emby视频类型检查",
+    "description": "定期检查Emby媒体库中是否包含指定的视频类型，发送通知。",
+    "labels": "Emby,媒体库",
+    "version": "2.0.0",
+    "icon": "https://raw.githubusercontent.com/thsrite/MoviePilot-Plugins/main/icons/extendtype.png",
+    "author": "thsrite",
+    "level": 1,
+    "release": true,
+    "system_version": ">=3.0.0",
+    "history": {
+      "v2.0.0": "适配 V3 SDK，迁移 Emby 视频类型检查与通知链路。"
+    }
   }
 }

--- a/package.v3.json
+++ b/package.v3.json
@@ -376,5 +376,19 @@
     "history": {
       "v2.0.0": "适配 V3 SDK、迁移 Emby 合集排序和多媒体服务器处理链路。"
     }
+  },
+  "EmbyActorSync": {
+    "name": "Emby剧集演员同步",
+    "description": "同步剧演员信息到集演员信息。",
+    "labels": "Emby,媒体库",
+    "version": "2.0.0",
+    "icon": "https://raw.githubusercontent.com/thsrite/MoviePilot-Plugins/main/icons/embyactorsync.png",
+    "author": "thsrite",
+    "level": 1,
+    "release": true,
+    "system_version": ">=3.0.0",
+    "history": {
+      "v2.0.0": "适配 V3 SDK、收紧 Emby 演员同步生命周期与网络资源释放。"
+    }
   }
 }

--- a/package.v3.json
+++ b/package.v3.json
@@ -362,5 +362,19 @@
     "history": {
       "v2.0.0": "适配 V3 SDK，迁移 Emby 有声书整理与演播作者修正链路。"
     }
+  },
+  "EmbyCollectionSort": {
+    "name": "Emby合集媒体排序",
+    "description": "Emby保留按照加入时间倒序的前提下，把合集中的媒体按照发布日期排序，修改加入时间已到达顺序排列的目的。",
+    "labels": "媒体库",
+    "version": "2.0.0",
+    "icon": "Element_A.png",
+    "author": "thsrite",
+    "level": 1,
+    "release": true,
+    "system_version": ">=3.0.0",
+    "history": {
+      "v2.0.0": "适配 V3 SDK、迁移 Emby 合集排序和多媒体服务器处理链路。"
+    }
   }
 }

--- a/package.v3.json
+++ b/package.v3.json
@@ -348,5 +348,19 @@
     "history": {
       "v2.0.0": "适配 V3 SDK，迁移 Emby 视频类型检查与通知链路。"
     }
+  },
+  "EmbyAudioBook": {
+    "name": "Emby有声书整理",
+    "description": "还在为Emby有声书整理烦恼吗？入库存在很多单集？",
+    "labels": "Emby,媒体库",
+    "version": "2.0.0",
+    "icon": "https://raw.githubusercontent.com/thsrite/MoviePilot-Plugins/main/icons/audiobook.png",
+    "author": "thsrite",
+    "level": 1,
+    "release": true,
+    "system_version": ">=3.0.0",
+    "history": {
+      "v2.0.0": "适配 V3 SDK，迁移 Emby 有声书整理与演播作者修正链路。"
+    }
   }
 }

--- a/package.v3.json
+++ b/package.v3.json
@@ -306,5 +306,19 @@
     "history": {
       "v2.0.0": "适配 V3 SDK，迁移订阅数据访问合同。"
     }
+  },
+  "EmbyReporter": {
+    "name": "Emby观影报告",
+    "description": "推送Emby观影报告，需Emby安装Playback Report插件。",
+    "labels": "Emby",
+    "version": "3.0.0",
+    "icon": "Pydiocells_A.png",
+    "author": "thsrite",
+    "level": 1,
+    "release": true,
+    "system_version": ">=3.0.0",
+    "history": {
+      "v3.0.0": "适配 V3 SDK，并将报告任务迁移到宿主调度器。"
+    }
   }
 }

--- a/plugins.v3/embyactorsync/__init__.py
+++ b/plugins.v3/embyactorsync/__init__.py
@@ -1,0 +1,516 @@
+from __future__ import annotations
+
+import re
+import threading
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytz
+
+from app.plugins import _PluginBase
+from app.schemas.types import EventType, MediaType
+from app.sdk.config import settings
+from app.sdk.events import Event, eventmanager
+from app.sdk.logging import logger
+from app.sdk.network import RequestUtils
+from app.sdk.services import MediaServerHelper
+
+
+@dataclass(frozen=True)
+class _EmbyContext:
+    """保存单个 Emby 服务的请求上下文，避免并发任务共享可变连接参数。"""
+
+    name: str
+    host: str
+    user: str
+    api_key: str
+
+
+class EmbyActorSync(_PluginBase):
+    """将剧集或季的演员信息同步到其下属集的 Emby 条目。"""
+
+    plugin_name = "Emby剧集演员同步"
+    plugin_desc = "同步剧演员信息到集演员信息。"
+    plugin_icon = "https://raw.githubusercontent.com/thsrite/MoviePilot-Plugins/main/icons/embyactorsync.png"
+    plugin_version = "2.0.0"
+    plugin_author = "thsrite"
+    author_url = "https://github.com/thsrite"
+    plugin_config_prefix = "embyactorsync_"
+    plugin_order = 32
+    auth_level = 1
+
+    def __init__(self) -> None:
+        """初始化插件状态和单实例任务互斥门禁。"""
+        super().__init__()
+        self._onlyonce = False
+        self._run_once = False
+        self._enabled = False
+        self._mediaservers: List[str] = []
+        self.mediaserver_helper: Optional[MediaServerHelper] = None
+        self._run_lock = threading.Lock()
+        self._run_once_lock = threading.Lock()
+
+    def init_plugin(self, config: Optional[dict] = None) -> None:
+        """读取配置并准备由宿主调度器管理的一次性同步任务。"""
+        self.stop_service()
+        with self._run_lock:
+            self.__init_plugin(config)
+
+    def __init_plugin(self, config: Optional[dict]) -> None:
+        """在没有同步任务运行时更新插件配置。"""
+        self.mediaserver_helper = MediaServerHelper()
+
+        config = config or {}
+        self._enabled = bool(config.get("enabled"))
+        self._onlyonce = bool(config.get("onlyonce"))
+        self._run_once = self._onlyonce
+        self._mediaservers = [
+            str(name) for name in (config.get("mediaservers") or []) if name
+        ]
+
+        if self._run_once:
+            logger.info("Emby剧集演员同步服务启动，立即运行一次")
+            self._onlyonce = False
+            self.__update_config()
+
+    def get_state(self) -> bool:
+        """返回插件是否启用或仍有待消费的一次性任务。"""
+        return self._enabled or self._run_once
+
+    def _run_once_sync(self) -> None:
+        """消费一次性服务标记，再执行一轮演员同步。"""
+        with self._run_once_lock:
+            if not self._run_once:
+                return
+            self._run_once = False
+        self.sync()
+
+    def __update_config(self) -> None:
+        """保存一次性开关归一化后的插件配置。"""
+        self.update_config(
+            {
+                "enabled": self._enabled,
+                "onlyonce": self._onlyonce,
+                "mediaservers": list(self._mediaservers),
+            }
+        )
+
+    @eventmanager.register(EventType.PluginAction)
+    def sync_actor(self, event: Optional[Event] = None) -> None:
+        """响应 /as 命令，按媒体库和剧集名称执行一次同步。"""
+        if not self._enabled or not event:
+            return
+
+        event_data = event.event_data
+        if not isinstance(event_data, dict) or event_data.get("action") != "actorsync":
+            return
+
+        args = event_data.get("arg_str")
+        if not isinstance(args, str) or not args.strip():
+            logger.error("缺少参数：%s", event_data)
+            return
+
+        args_list = args.strip().split(maxsplit=1)
+        if len(args_list) != 2:
+            logger.error("参数错误：%s", args_list)
+            self.post_message(
+                channel=event_data.get("channel"),
+                title="参数错误！ /as 媒体库名 剧集名",
+                userid=event_data.get("user"),
+            )
+            return
+
+        self.sync(args_list[0], args_list[1], event)
+
+    def sync(
+        self,
+        library_name: Optional[str] = None,
+        media_name: Optional[str] = None,
+        event: Optional[Event] = None,
+    ) -> None:
+        """在选定的 Emby 服务中复制剧集演员到各集，并串行保护服务上下文。"""
+        if not self._run_lock.acquire(blocking=False):
+            logger.warning("Emby剧集演员同步任务正在运行，本次触发已跳过")
+            return
+
+        try:
+            self.__sync(library_name, media_name, event)
+        finally:
+            self._run_lock.release()
+
+    def __sync(
+        self,
+        library_name: Optional[str],
+        media_name: Optional[str],
+        event: Optional[Event],
+    ) -> None:
+        """执行一次完整同步；每个媒体服务器使用独立的不可变请求上下文。"""
+        helper = self.mediaserver_helper or MediaServerHelper()
+        emby_servers = helper.get_services(
+            name_filters=self._mediaservers,
+            type_filter="emby",
+        )
+        if not emby_servers:
+            logger.error("未配置Emby媒体服务器")
+            return
+
+        for emby_name, emby_server in emby_servers.items():
+            instance = emby_server.instance if emby_server else None
+            config = emby_server.config.config if emby_server and emby_server.config else {}
+            context = self.__build_context(emby_name, instance, config)
+            if not context:
+                continue
+
+            logger.info("开始处理媒体服务器 %s", emby_name)
+            libraries = instance.get_librarys() or []
+            for library in libraries:
+                if library.type != MediaType.TV.value:
+                    continue
+                if library_name and library.name != library_name:
+                    continue
+
+                library_items = self.__get_items(context, library.id)
+                if not library_items:
+                    logger.error("获取媒体库：%s 的媒体列表失败", library.name)
+                    continue
+
+                logger.info("开始同步媒体库：%s，ID：%s", library.name, library.id)
+                for item in library_items:
+                    if not self.__matches_media_name(item, media_name):
+                        continue
+                    self.__sync_series(context, item)
+
+            logger.info("%s 剧集演员同步完成", emby_name)
+            if event:
+                event_data = event.event_data
+                self.post_message(
+                    channel=event_data.get("channel"),
+                    title=f"{library_name} {media_name} 同步完成",
+                    userid=event_data.get("user"),
+                )
+
+    @staticmethod
+    def __build_context(
+        name: str,
+        instance: Any,
+        config: Any,
+    ) -> Optional[_EmbyContext]:
+        """从服务发现结果构造单服务器上下文，缺少必要字段时跳过该服务。"""
+        if not instance or not isinstance(config, dict):
+            logger.warning("媒体服务器 %s 配置或实例不可用", name)
+            return None
+
+        host = str(config.get("host") or "").strip()
+        api_key = str(config.get("apikey") or "").strip()
+        if not host or not api_key:
+            logger.warning("媒体服务器 %s 缺少 Emby 地址或 API 密钥", name)
+            return None
+        if not host.startswith(("http://", "https://")):
+            host = f"http://{host}"
+        host = host.rstrip("/")
+
+        try:
+            user = instance.get_user()
+        except Exception as error:
+            logger.error("获取媒体服务器 %s 用户失败：%s", name, error)
+            return None
+        if user is None or not str(user).strip():
+            logger.warning("媒体服务器 %s 未找到可用 Emby 用户", name)
+            return None
+
+        return _EmbyContext(
+            name=str(name),
+            host=host,
+            user=str(user),
+            api_key=api_key,
+        )
+
+    @staticmethod
+    def __matches_media_name(item: Any, media_name: Optional[str]) -> bool:
+        """按旧命令约定匹配剧集标题，并兼容 Emby 标题中的年份后缀。"""
+        if not media_name:
+            return True
+        if not isinstance(item, dict):
+            return False
+        item_name = str(item.get("Name") or "").strip()
+        if not item_name:
+            return False
+        match = re.fullmatch(r"(.+?)\s+\(\d{4}\)", item_name)
+        return (match.group(1) if match else item_name) == media_name
+
+    def __sync_series(self, context: _EmbyContext, item: dict) -> None:
+        """同步一个剧集及其所有季、集条目，缺失演员信息时保持远端数据不变。"""
+        item_id = item.get("Id")
+        if not item_id:
+            logger.warning("Emby 剧集条目缺少 ID：%s", item)
+            return
+
+        logger.info("开始同步媒体：%s，ID：%s", item.get("Name"), item_id)
+        item_info = self.__get_item_info(context, item_id)
+        if not item_info:
+            logger.error("获取媒体详情失败：%s", item_id)
+            return
+
+        for season in self.__get_items(context, item_id):
+            season_id = season.get("Id") if isinstance(season, dict) else None
+            if not season_id:
+                continue
+            season_info = self.__get_item_info(context, season_id)
+            if not season_info:
+                logger.error("获取季详情失败：%s", season_id)
+                continue
+
+            people = season_info.get("People") or item_info.get("People")
+            if not people:
+                logger.warning("媒体 %s 未找到演员信息，跳过季 %s", item_id, season_id)
+                continue
+
+            for episode in self.__get_items(context, season_id):
+                episode_id = episode.get("Id") if isinstance(episode, dict) else None
+                if episode_id:
+                    self.__sync_episode(context, item, episode_id, people)
+
+    def __sync_episode(
+        self,
+        context: _EmbyContext,
+        series: dict,
+        episode_id: str,
+        people: Any,
+    ) -> None:
+        """重试单集更新，并只在成功时停止重试。"""
+        for attempt in range(1, 4):
+            episode_info = self.__get_item_info(context, episode_id)
+            if not episode_info:
+                logger.error("获取集详情失败：%s（第 %s/3 次）", episode_id, attempt)
+                continue
+            if episode_info.get("People") == people:
+                logger.info("媒体：%s 的集演员信息已更新", series.get("Name"))
+                return
+
+            payload = dict(episode_info)
+            locked_fields = payload.get("LockedFields")
+            payload["LockedFields"] = (
+                list(locked_fields) if isinstance(locked_fields, list) else []
+            )
+            if "Cast" not in payload["LockedFields"]:
+                payload["LockedFields"].append("Cast")
+            payload["People"] = people
+
+            updated = self.__update_item_info(context, episode_id, payload)
+            logger.info(
+                "更新媒体：%s 的集 %s 成功：%s",
+                series.get("Name"),
+                episode_id,
+                updated,
+            )
+            if updated:
+                time.sleep(0.5)
+                return
+            logger.warning("更新集信息失败：%s（第 %s/3 次）", episode_id, attempt)
+
+    def __request_json(
+        self,
+        context: _EmbyContext,
+        path: str,
+        params: Optional[dict] = None,
+    ) -> Optional[dict]:
+        """通过 V3 网络 SDK 请求 Emby JSON，并始终释放响应连接。"""
+        response = None
+        try:
+            request_params = dict(params or {})
+            request_params["api_key"] = context.api_key
+            response = RequestUtils().get_res(
+                url=f"{context.host}/{path.lstrip('/')}",
+                params=request_params,
+            )
+            if response is None or response.status_code != 200:
+                return None
+            result = response.json()
+            return result if isinstance(result, dict) else None
+        except Exception as error:
+            logger.error("请求 Emby 接口 %s 出错：%s", path, error)
+            return None
+        finally:
+            if response is not None:
+                response.close()
+
+    def __get_items(self, context: _EmbyContext, parent_id: Any) -> List[dict]:
+        """获取 Emby 父条目的直接子项。"""
+        if parent_id is None:
+            return []
+        result = self.__request_json(
+            context,
+            f"emby/Users/{context.user}/Items",
+            {"ParentId": parent_id},
+        )
+        items = result.get("Items") if result else None
+        return items if isinstance(items, list) else []
+
+    def __get_item_info(self, context: _EmbyContext, item_id: Any) -> dict:
+        """获取单个 Emby 条目详情。"""
+        if item_id is None:
+            return {}
+        result = self.__request_json(
+            context,
+            f"emby/Users/{context.user}/Items/{item_id}",
+        )
+        return result or {}
+
+    def __update_item_info(
+        self,
+        context: _EmbyContext,
+        item_id: Any,
+        data: dict,
+    ) -> bool:
+        """提交单集详情更新，并始终释放 Emby 写请求响应。"""
+        response = None
+        try:
+            response = RequestUtils(
+                headers={"accept": "*/*", "Content-Type": "application/json"}
+            ).post_res(
+                url=f"{context.host}/emby/Items/{item_id}",
+                params={"api_key": context.api_key},
+                json=data,
+            )
+            return response is not None and response.status_code == 204
+        except Exception as error:
+            logger.error("更新 Emby 条目 %s 出错：%s", item_id, error)
+            return False
+        finally:
+            if response is not None:
+                response.close()
+
+    @staticmethod
+    def get_command() -> List[Dict[str, Any]]:
+        """定义远程控制命令。"""
+        return [
+            {
+                "cmd": "/as",
+                "event": EventType.PluginAction,
+                "desc": "Emby剧集演员同步",
+                "category": "",
+                "data": {"action": "actorsync"},
+            }
+        ]
+
+    def get_api(self) -> List[Dict[str, Any]]:
+        """插件不暴露额外 HTTP API。"""
+        return []
+
+    def get_service(self) -> List[Dict[str, Any]]:
+        """通过 V3 宿主服务合同注册一次性演员同步任务。"""
+        if not self._run_once:
+            return []
+        return [
+            {
+                "id": "EmbyActorSync.Once",
+                "name": "Emby剧集演员同步（立即运行）",
+                "trigger": "date",
+                "func": self._run_once_sync,
+                "kwargs": {
+                    "run_date": datetime.now(tz=pytz.timezone(str(settings.TZ)))
+                    + timedelta(seconds=3)
+                },
+            }
+        ]
+
+    def get_form(self) -> Tuple[List[dict], Dict[str, Any]]:
+        """返回插件配置页面和默认配置。"""
+        helper = self.mediaserver_helper or MediaServerHelper()
+        media_servers = [
+            {"title": config.name, "value": config.name}
+            for config in helper.get_configs().values()
+            if config.type == "emby"
+        ]
+        return [
+            {
+                "component": "VForm",
+                "content": [
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 4},
+                                "content": [
+                                    {
+                                        "component": "VSwitch",
+                                        "props": {
+                                            "model": "enabled",
+                                            "label": "启用插件",
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 4},
+                                "content": [
+                                    {
+                                        "component": "VSwitch",
+                                        "props": {
+                                            "model": "onlyonce",
+                                            "label": "立即运行一次",
+                                        },
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12},
+                                "content": [
+                                    {
+                                        "component": "VSelect",
+                                        "props": {
+                                            "multiple": True,
+                                            "chips": True,
+                                            "clearable": True,
+                                            "model": "mediaservers",
+                                            "label": "媒体服务器",
+                                            "items": media_servers,
+                                        },
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12},
+                                "content": [
+                                    {
+                                        "component": "VAlert",
+                                        "props": {
+                                            "type": "info",
+                                            "variant": "tonal",
+                                            "text": "可选同步媒体库，不选同步所有剧集媒体库。注：只支持Emby。",
+                                        },
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                ],
+            }
+        ], {
+            "enabled": False,
+            "onlyonce": False,
+            "mediaservers": [],
+        }
+
+    def get_page(self) -> List[dict]:
+        """插件不提供额外详情页。"""
+        return []
+
+    def stop_service(self) -> None:
+        """公共调度任务由宿主撤销，插件没有额外后台资源需要释放。"""

--- a/plugins.v3/embyaudiobook/__init__.py
+++ b/plugins.v3/embyaudiobook/__init__.py
@@ -1,0 +1,985 @@
+"""Emby 有声书媒体信息整理插件的 V3 实现。"""
+
+from __future__ import annotations
+
+import datetime
+import re
+import threading
+import time
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytz
+from apscheduler.triggers.cron import CronTrigger
+
+from app.plugins import _PluginBase
+from app.schemas.types import EventType, MessageType
+from app.sdk.config import settings
+from app.sdk.events import Event, eventmanager
+from app.sdk.logging import logger
+from app.sdk.network import RequestUtils
+from app.sdk.services import MediaServerHelper
+
+
+# 配置、调度器和当前 Emby 请求上下文属于同一个插件生命周期，不能拆成互相独立的全局状态。
+# pylint: disable=too-many-instance-attributes
+class EmbyAudioBook(_PluginBase):
+    """同步 Emby 有声书的专辑和剧集信息，并支持交互修正作者。"""
+
+    plugin_name = "Emby有声书整理"
+    plugin_desc = "还在为Emby有声书整理烦恼吗？入库存在很多单集？"
+    plugin_icon = (
+        "https://raw.githubusercontent.com/thsrite/MoviePilot-Plugins/main/icons/audiobook.png"
+    )
+    plugin_version = "2.0.0"
+    plugin_author = "thsrite"
+    author_url = "https://github.com/thsrite"
+    plugin_config_prefix = "embyaudiobook_"
+    plugin_order = 30
+    auth_level = 1
+
+    _metadata_fields = (
+        "Album",
+        "AlbumId",
+        "AlbumPrimaryImageTag",
+        "Artists",
+        "ArtistItems",
+        "Composers",
+        "AlbumArtist",
+        "AlbumArtists",
+        "ParentIndexNumber",
+    )
+
+    def __init__(self) -> None:
+        """初始化实例级状态，避免热重载复用上一份调度器或服务器上下文。"""
+        super().__init__()
+        self._run_lock = threading.Lock()
+        self._run_once_lock = threading.Lock()
+        self._enabled = False
+        self._notify = False
+        self._rename = False
+        self._onlyonce = False
+        self._run_once = False
+        self._cron = ""
+        self._library_id = ""
+        self._msgtype: Optional[str] = None
+        self._mediaservers: List[str] = []
+        self._mediaserver_helper = MediaServerHelper()
+        self._emby_host = ""
+        self._emby_user = ""
+        self._emby_api_key = ""
+
+    def init_plugin(self, config: Optional[dict] = None) -> None:
+        """停止旧任务、读取配置并按开关重建后台调度器。"""
+        self.stop_service()
+        with self._run_lock:
+            self.__init_plugin(config)
+
+    def __init_plugin(self, config: Optional[dict]) -> None:
+        """在没有整理任务运行时更新配置和调度器。"""
+        config = dict(config or {})
+        self._mediaserver_helper = MediaServerHelper()
+        self._enabled = bool(config.get("enabled"))
+        self._notify = bool(config.get("notify"))
+        self._rename = bool(config.get("rename"))
+        self._onlyonce = bool(config.get("onlyonce"))
+        self._run_once = self._onlyonce
+        self._cron = str(config.get("cron") or "").strip()
+        self._library_id = str(config.get("library_id") or "").strip()
+        self._msgtype = config.get("msgtype") or MessageType.Manual.name
+        self._mediaservers = self._normalize_string_list(config.get("mediaservers"))
+
+        if self._run_once:
+            logger.info("Emby有声书整理服务启动，立即运行一次")
+            self._onlyonce = False
+            self.__update_config()
+
+    @staticmethod
+    def _normalize_string_list(value: Any) -> List[str]:
+        """把配置中的媒体服务器列表规范为去重后的非空字符串。"""
+        if isinstance(value, str):
+            values = value.split(",")
+        elif isinstance(value, (list, tuple, set)):
+            values = value
+        else:
+            values = []
+        result = []
+        for item in values:
+            item = str(item or "").strip()
+            if item and item not in result:
+                result.append(item)
+        return result
+
+    def __update_config(self) -> None:
+        """保存一次性开关归零后的插件配置。"""
+        self.update_config(
+            {
+                "enabled": self._enabled,
+                "onlyonce": self._onlyonce,
+                "library_id": self._library_id,
+                "rename": self._rename,
+                "cron": self._cron,
+                "notify": self._notify,
+                "msgtype": self._msgtype,
+                "mediaservers": self._mediaservers,
+            }
+        )
+
+    def get_state(self) -> bool:
+        """返回插件是否启用或仍有待消费的一次性任务。"""
+        return self._enabled or self._run_once
+
+    def _run_once_check(self) -> None:
+        """消费一次性服务标记，再执行一轮有声书整理。"""
+        with self._run_once_lock:
+            if not self._run_once:
+                return
+            self._run_once = False
+        self.check()
+
+    def check(self) -> None:
+        """串行执行一次全量检查，避免并发切换共享 Emby 请求上下文。"""
+        if not self._run_lock.acquire(  # pylint: disable=consider-using-with
+            blocking=False
+        ):
+            logger.warning("Emby有声书整理任务正在运行，本次触发已跳过")
+            return
+        try:
+            self.__check()
+        finally:
+            self._run_lock.release()
+
+    def __check(self) -> None:  # pylint: disable=too-many-branches
+        """检查配置媒体库中的有声书，并锁定已经整理完成的专辑。"""
+        if not self._library_id:
+            logger.error("请设置有声书文件夹ID！")
+            return
+
+        emby_servers = self._mediaserver_helper.get_services(
+            name_filters=self._mediaservers,
+            type_filter="emby",
+        )
+        if not emby_servers:
+            logger.error("未配置Emby媒体服务器")
+            return
+
+        for emby_name, emby_server in emby_servers.items():
+            if not emby_server.instance:
+                logger.warning(f"Emby媒体服务器 {emby_name} 未连接")
+                continue
+            if not self.__set_server_context(emby_server):
+                logger.warning(f"Emby媒体服务器 {emby_name} 配置不完整")
+                continue
+
+            logger.info(f"开始处理媒体服务器 {emby_name}")
+            books = self.__get_items(self._library_id)
+            if not books:
+                logger.error(f"获取媒体库 {self._library_id} 有声书列表失败！")
+                continue
+
+            for book in books:
+                if not isinstance(book, dict):
+                    continue
+                book_id = book.get("Id")
+                book_name = book.get("Name") or book_id
+                if not book_id:
+                    logger.warning(f"媒体服务器 {emby_name} 存在缺少 ID 的有声书，已跳过")
+                    continue
+                episodes = self.__get_items(book_id)
+                if not episodes:
+                    logger.error(f"获取 {book_name} {book_id} 有声书失败！")
+                    continue
+
+                needs_organize = any(not episode.get("AlbumId") for episode in episodes)
+                if needs_organize:
+                    logger.info(f"有声书 {book_name} 需要整理，共 {len(episodes)} 集")
+                    if self._notify:
+                        self.post_message(
+                            title="Emby有声书整理",
+                            mtype=self._message_type(),
+                            text=f"有声书 {book_name} 需要整理，共 {len(episodes)} 集",
+                        )
+                    continue
+
+                book_info = self.__get_item_info(book_id)
+                if not book_info:
+                    logger.warning(f"获取有声书 {book_name} 详情失败，未锁定")
+                    continue
+                book_info["LockData"] = True
+                updated = self.__update_item_info(book_id, book_info)
+                logger.info(
+                    f"有声书 {book_name} 不需要整理，已{'锁定' if updated else '尝试锁定'}"
+                )
+
+            logger.info(f"{emby_name} 有声书整理服务执行完毕")
+
+    def __set_server_context(self, emby_server: Any) -> bool:
+        """读取当前服务的 Emby 地址、用户和 API key，并规范化地址。"""
+        self._emby_host = ""
+        self._emby_user = ""
+        self._emby_api_key = ""
+        if not emby_server.instance:
+            return False
+        server_config = (
+            emby_server.config.config
+            if emby_server.config and emby_server.config.config
+            else {}
+        )
+        if not isinstance(server_config, Mapping):
+            return False
+
+        host = self._normalize_host(server_config.get("host"))
+        api_key = str(server_config.get("apikey") or "").strip()
+        try:
+            user = str(emby_server.instance.get_user() or "").strip()
+        except Exception as err:  # pylint: disable=broad-exception-caught
+            logger.error(f"读取 Emby 用户失败：{err}")
+            return False
+        if not host or not api_key or not user:
+            return False
+
+        self._emby_host = host
+        self._emby_user = user
+        self._emby_api_key = api_key
+        return True
+
+    @staticmethod
+    def _normalize_host(host: Any) -> str:
+        """把 Emby 地址规范为带单个尾斜杠的 HTTP URL。"""
+        host = str(host or "").strip()
+        if not host:
+            return ""
+        if not host.startswith(("http://", "https://")):
+            host = f"http://{host}"
+        return host.rstrip("/") + "/"
+
+    @staticmethod
+    def _event_data(event: Optional[Event], action: str) -> Optional[Dict[str, Any]]:
+        """读取并校验插件动作载荷，拒绝其他动作或非映射对象。"""
+        if not event or not isinstance(event.event_data, Mapping):
+            return None
+        data = dict(event.event_data)
+        return data if data.get("action") == action else None
+
+    def _command_args(self, data: Mapping[str, Any]) -> Optional[List[str]]:
+        """按远程命令约定解析媒体库、书名和修正参数。"""
+        raw_args = str(data.get("arg_str") or "").strip()
+        if not raw_args:
+            return None
+
+        # 媒体服务器和书名允许包含空格；优先使用已配置服务名确定第一段边界，
+        # 再从右侧拆出集数或演播作者，避免把合法名称误拆成多个参数。
+        servers = self._mediaserver_helper.get_services(
+            name_filters=self._mediaservers,
+            type_filter="emby",
+        )
+        for server_name in sorted(
+            (str(name).strip() for name in (servers or {})),
+            key=len,
+            reverse=True,
+        ):
+            prefix = f"{server_name} "
+            if raw_args.casefold().startswith(prefix.casefold()):
+                remainder = raw_args[len(prefix) :].strip()
+                parts = remainder.rsplit(maxsplit=1)
+                if len(parts) == 2 and all(parts):
+                    return [server_name, parts[0], parts[1]]
+
+        args = raw_args.split()
+        return args if len(args) == 3 else None
+
+    def _message_type(self) -> MessageType:
+        """把配置中的消息类型名称或旧值转换为 V3 消息枚举。"""
+        value = self._msgtype
+        if isinstance(value, MessageType):
+            return value
+        for message_type in MessageType:
+            if value in (message_type.name, message_type.value):
+                return message_type
+        return MessageType.Manual
+
+    def _send_command_message(
+        self,
+        data: Mapping[str, Any],
+        title: str,
+        text: Optional[str] = None,
+    ) -> None:
+        """向触发命令的渠道回复结果，并沿用宿主消息类型配置。"""
+        self.post_message(
+            channel=data.get("channel"),
+            mtype=self._message_type(),
+            title=title,
+            text=text,
+            userid=data.get("user"),
+        )
+
+    @eventmanager.register(EventType.PluginAction)
+    def audiobook(self, event: Optional[Event] = None) -> None:
+        """响应 `/ab 媒体库 书名 正确信息集数` 命令。"""
+        data = self._event_data(event, "audiobook")
+        if data is None or not self._enabled:
+            return
+        if not self._run_lock.acquire(  # pylint: disable=consider-using-with
+            blocking=False
+        ):
+            logger.warning("Emby有声书整理任务正在运行，本次命令已跳过")
+            return
+        try:
+            self.__handle_audiobook(data)
+        finally:
+            self._run_lock.release()
+
+    @eventmanager.register(EventType.PluginAction)
+    def audiobook_artist(self, event: Optional[Event] = None) -> None:
+        """响应 `/aba 媒体库 书名 正确的演播作者名称` 命令。"""
+        data = self._event_data(event, "audiobook_artist")
+        if data is None or not self._enabled:
+            return
+        if not self._run_lock.acquire(  # pylint: disable=consider-using-with
+            blocking=False
+        ):
+            logger.warning("Emby有声书整理任务正在运行，本次命令已跳过")
+            return
+        try:
+            self.__handle_audiobook_artist(data)
+        finally:
+            self._run_lock.release()
+
+    def __handle_audiobook(  # pylint: disable=too-many-branches,too-many-locals,too-many-return-statements,too-many-statements
+        self, data: Mapping[str, Any]
+    ) -> None:
+        """从指定剧集提取信息并同步到整本有声书。"""
+        if not self._library_id:
+            logger.error("请设置有声书文件夹ID！")
+            self._send_command_message(data, "请设置有声书文件夹ID！")
+            return
+
+        args = self._command_args(data)
+        if args is None:
+            logger.error(f"参数错误：{data.get('arg_str')}")
+            self._send_command_message(data, "参数错误！ /ab 媒体库 书名 正确信息集数")
+            return
+        library_name, book_name, book_index_text = args
+        try:
+            book_index = int(book_index_text)
+        except ValueError:
+            self._send_command_message(data, "集数必须是数字！")
+            return
+
+        server = self.__find_server(library_name)
+        if server is None:
+            self._send_command_message(data, f"未找到 {library_name} Emby媒体服务器！")
+            return
+        if not self.__set_server_context(server):
+            self._send_command_message(data, f"Emby媒体服务器 {library_name} 配置不完整！")
+            return
+
+        books = self.__get_items(self._library_id)
+        book = self.__find_book(books, book_name)
+        if book is None:
+            logger.error(f"未找到 {book_name} 有声书！")
+            self._send_command_message(data, f"未找到 {book_name} 有声书！")
+            return
+
+        book_id = book.get("Id")
+        episodes = self.__get_items(book_id)
+        if not book_id or not episodes:
+            logger.error(f"获取 {book_name} {book_id} 有声书失败！")
+            self._send_command_message(data, f"获取 {book_name} 有声书失败！")
+            return
+
+        if not self.__organize_items(episodes, book_index):
+            self._send_command_message(data, f"{book_name} 有声书整理失败！")
+            return
+
+        book_info = self.__get_item_info(book_id)
+        if book_info:
+            book_info["LockData"] = True
+            self.__update_item_info(book_id, book_info)
+        self._send_command_message(data, f"{book_name} 有声书整理完成！")
+
+    def __handle_audiobook_artist(  # pylint: disable=too-many-branches,too-many-locals,too-many-return-statements,too-many-statements
+        self, data: Mapping[str, Any]
+    ) -> None:
+        """把指定演播作者写入有声书及其全部剧集。"""
+        if not self._library_id:
+            logger.error("请设置有声书文件夹ID！")
+            self._send_command_message(data, "请设置有声书文件夹ID！")
+            return
+
+        args = self._command_args(data)
+        if args is None:
+            logger.error(f"参数错误：{data.get('arg_str')}")
+            self._send_command_message(
+                data,
+                "参数错误！ /aba 媒体库 书名 正确的演播作者名称",
+            )
+            return
+        library_name, book_name, book_artist = args
+        server = self.__find_server(library_name)
+        if server is None:
+            self._send_command_message(data, f"未找到 {library_name} Emby媒体服务器！")
+            return
+        if not self.__set_server_context(server):
+            self._send_command_message(data, f"Emby媒体服务器 {library_name} 配置不完整！")
+            return
+
+        books = self.__get_items(self._library_id)
+        book = self.__find_book(books, book_name)
+        if book is None or not book.get("Id"):
+            logger.error(f"未找到 {book_name} 有声书！")
+            self._send_command_message(data, f"未找到 {book_name} 有声书！")
+            return
+        book_id = book["Id"]
+        book_info = self.__get_item_info(book_id)
+        if not book_info:
+            self._send_command_message(data, f"获取 {book_name} 有声书详情失败！")
+            return
+
+        artist = next(
+            (
+            item
+            for item in self.__get_artists()
+            if isinstance(item, Mapping)
+            if str(item.get("Name") or "") == book_artist
+            ),
+            None,
+        )
+        if not artist or not artist.get("Id"):
+            logger.error(f"未找到 {book_artist} 作者！")
+            self._send_command_message(data, f"未找到 {book_artist} 作者！")
+            return
+
+        artist_item = {"Id": artist["Id"], "Name": book_artist}
+        old_artists = [
+            item
+            for item in self.__artist_items(book_info)
+            if item.get("Name") != book_artist
+        ]
+        self.__set_artist_fields(book_info, artist_item)
+        book_info["LockData"] = True
+        if not self.__update_item_info(book_id, book_info):
+            logger.error(f"更新 {book_name} 作者信息-> {book_artist} 失败！")
+            self._send_command_message(data, f"更新 {book_name} 作者信息-> {book_artist} 失败！")
+            return
+
+        episodes = self.__get_items(book_id)
+        if not episodes:
+            logger.error(f"获取有声书 {book_name} 剧集失败！")
+            self._send_command_message(data, f"获取有声书 {book_name} 剧集失败！")
+            return
+
+        failed = False
+        for episode in episodes:
+            episode_id = episode.get("Id") if isinstance(episode, dict) else None
+            episode_info = self.__get_item_info(episode_id)
+            if not episode_info:
+                failed = True
+                logger.error(f"获取有声书 {book_name} 剧集 {episode_id} 详情失败！")
+                continue
+            self.__set_artist_fields(episode_info, artist_item)
+            episode_info["LockData"] = True
+            updated = self.__update_item_info(episode_id, episode_info)
+            failed = failed or not updated
+            logger.info(
+                f"更新 {book_name} 剧集 {episode.get('Name')} 作者信息-> {book_artist} "
+                f"{'成功' if updated else '失败'}！"
+            )
+
+        for old_artist in old_artists:
+            old_id = old_artist.get("Id")
+            if not old_id:
+                continue
+            deleted = self.__delete_by_id(old_id)
+            logger.info(
+                f"删除 {book_name} 原作者信息-> {old_artist.get('Name')} "
+                f"{'成功' if deleted else '失败'}！"
+            )
+
+        if failed:
+            self._send_command_message(data, f"更新 {book_name} 作者信息-> {book_artist} 部分失败！")
+        else:
+            self._send_command_message(data, f"更新 {book_name} 作者信息-> {book_artist} 成功！")
+
+    @staticmethod
+    def __find_book(items: List[dict], book_name: str) -> Optional[dict]:
+        """从媒体库项目中按名称片段选择有声书。"""
+        return next(
+            (
+                item
+                for item in items
+                if isinstance(item, dict)
+                and book_name in str(item.get("Name") or "")
+            ),
+            None,
+        )
+
+    def __find_server(self, name: str) -> Any:
+        """按交互命令中的媒体库名称选择 Emby 服务。"""
+        servers = self._mediaserver_helper.get_services(
+            name_filters=self._mediaservers,
+            type_filter="emby",
+        )
+        name_casefold = name.casefold()
+        return next(
+            (
+                server
+                for server_name, server in (servers or {}).items()
+                if str(server_name).casefold() == name_casefold
+            ),
+            None,
+        )
+
+    def __organize_items(self, items: List[dict], book_index: int) -> bool:
+        """从指定剧集提取元数据并写回全部剧集，返回是否全部成功。"""
+        source = self.__source_item(items, book_index)
+        if source is None:
+            logger.error("未找到可用的有声书信息来源剧集")
+            return False
+
+        source_metadata = {
+            key: source.get(key) for key in self._metadata_fields
+        }
+        failed = False
+        for index, item in enumerate(items, start=1):
+            if not isinstance(item, dict) or not item.get("Id"):
+                failed = True
+                continue
+            episode = self.__episode_number(item, index)
+            metadata_matches = all(
+                source_metadata[key] == item.get(key) for key in self._metadata_fields
+            )
+            if metadata_matches and not self._rename:
+                logger.info(f"有声书 第{episode}集 {item.get('Name')} 信息完整，跳过！")
+                continue
+
+            item_info = None
+            for retry in range(3):
+                item_info = self.__get_item_info(item["Id"])
+                if item_info:
+                    break
+                logger.error(
+                    f"更新有声书 第{episode}集 {item.get('Name')} 信息出错，"
+                    f"开始重试...{retry + 1} / 3"
+                )
+            if not item_info:
+                failed = True
+                continue
+
+            if self._rename or item_info.get("Name") == "filename":
+                path = str(item_info.get("Path") or "")
+                if path:
+                    item_info["Name"] = Path(path).stem
+            item_info.update(source_metadata)
+            item_info.update(
+                {
+                    "IndexNumber": episode,
+                    "LockData": True,
+                }
+            )
+            updated = self.__update_item_info(item["Id"], item_info)
+            failed = failed or not updated
+            logger.info(
+                f"{source_metadata.get('Album')} 第{episode}集 "
+                f"{item_info.get('Name')} 更新{'成功' if updated else '失败'}"
+            )
+            time.sleep(0.5)
+        return not failed
+
+    @staticmethod
+    def __source_item(items: List[dict], book_index: int) -> Optional[dict]:
+        """选择指定剧集，或选择第一条具备完整专辑信息的剧集。"""
+        if book_index == -1:
+            return next(
+                (
+                    item
+                    for item in items
+                    if isinstance(item, dict)
+                    and item.get("AlbumId")
+                    and item.get("Album")
+                    and item.get("Artists")
+                    and item.get("AlbumArtist")
+                    and item.get("AlbumArtists")
+                    and item.get("ParentIndexNumber")
+                ),
+                None,
+            )
+        if book_index < 1 or book_index > len(items):
+            return None
+        item = items[book_index - 1]
+        return item if isinstance(item, dict) else None
+
+    @staticmethod
+    def __episode_number(item: Mapping[str, Any], fallback: int) -> int:
+        """从中文集数或文件名数字中提取集数，提取失败时使用列表序号。"""
+        name = str(item.get("Name") or "")
+        match = re.search(r"第(\d+)集", name)
+        if match:
+            return int(match.group(1))
+        match = re.search(r"\d+", name)
+        return int(match.group()) if match else fallback
+
+    @staticmethod
+    def __set_artist_fields(item_info: Dict[str, Any], artist_item: Dict[str, Any]) -> None:
+        """写入 Emby 有声书作者字段，保持旧版接口所需的数据形状。"""
+        item_info.update(
+            {
+                "Artists": [artist_item["Name"]],
+                "AlbumArtist": artist_item["Name"],
+                "ArtistItems": dict(artist_item),
+                "Composers": dict(artist_item),
+                "AlbumArtists": dict(artist_item),
+            }
+        )
+
+    @staticmethod
+    def __artist_items(item_info: Mapping[str, Any]) -> List[Dict[str, Any]]:
+        """兼容 Emby 作者字段返回单对象或对象列表的两种形状。"""
+        result: List[Dict[str, Any]] = []
+        seen = set()
+        for key in ("ArtistItems", "Composers", "AlbumArtists"):
+            value = item_info.get(key)
+            values = [value] if isinstance(value, Mapping) else value
+            if not isinstance(values, (list, tuple)):
+                continue
+            for artist in values:
+                if not isinstance(artist, Mapping):
+                    continue
+                artist_id = str(artist.get("Id") or "")
+                artist_name = str(artist.get("Name") or "")
+                identity = artist_id or artist_name
+                if identity and identity not in seen:
+                    result.append(dict(artist))
+                    seen.add(identity)
+        return result
+
+    def __request_json(
+        self,
+        path: str,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """通过 SDK 网络门面读取 Emby JSON，并始终释放响应连接。"""
+        if not self._emby_host or not self._emby_api_key:
+            return None
+        request_params = dict(params or {})
+        request_params["api_key"] = self._emby_api_key
+        try:
+            with RequestUtils().response_manager(
+                "GET",
+                self._emby_host + path.lstrip("/"),
+                params=request_params,
+            ) as response:
+                if response is None or response.status_code != 200:
+                    return None
+                payload = response.json()
+                return payload if isinstance(payload, dict) else None
+        except Exception as err:  # pylint: disable=broad-exception-caught
+            logger.error(f"连接 Emby 接口 {path} 出错：{err}")
+            return None
+
+    def __get_items(self, parent_id: Any) -> List[dict]:
+        """读取指定父项目下的 Emby 项目列表。"""
+        if not parent_id or not self._emby_user:
+            return []
+        payload = self.__request_json(
+            f"emby/Users/{self._emby_user}/Items",
+            {"ParentId": parent_id},
+        )
+        items = payload.get("Items") if payload else None
+        return [item for item in items if isinstance(item, dict)] if isinstance(items, list) else []
+
+    def __get_item_info(self, item_id: Any) -> Dict[str, Any]:
+        """读取单个 Emby 项目的完整更新数据。"""
+        if not item_id or not self._emby_user:
+            return {}
+        payload = self.__request_json(
+            f"emby/Users/{self._emby_user}/Items/{item_id}",
+            {
+                "fields": "ShareLevel",
+                "ExcludeFields": "Chapters,Overview,People,MediaStreams,Subviews",
+            },
+        )
+        return payload or {}
+
+    def __get_artists(self) -> List[dict]:
+        """读取 Emby 作者列表。"""
+        payload = self.__request_json("emby/Artists")
+        artists = payload.get("Items") if payload else None
+        return artists if isinstance(artists, list) else []
+
+    def __update_item_info(self, item_id: Any, data: Dict[str, Any]) -> bool:
+        """通过 Emby 更新接口提交项目元数据，并释放响应连接。"""
+        if not item_id or not self._emby_host or not self._emby_api_key:
+            return False
+        try:
+            with RequestUtils(content_type="application/json").response_manager(
+                "POST",
+                f"{self._emby_host}emby/Items/{item_id}",
+                params={"api_key": self._emby_api_key},
+                json=data,
+            ) as response:
+                return response is not None and response.status_code == 204
+        except Exception as err:  # pylint: disable=broad-exception-caught
+            logger.error(f"更新 Emby 项目 {item_id} 出错：{err}")
+            return False
+
+    def __delete_by_id(self, item_id: Any) -> bool:
+        """删除旧作者项目，避免修改作者后残留重复条目。"""
+        if not item_id or not self._emby_host or not self._emby_api_key:
+            return False
+        try:
+            with RequestUtils().response_manager(
+                "POST",
+                f"{self._emby_host}emby/Items/Delete",
+                params={"Ids": item_id, "api_key": self._emby_api_key},
+            ) as response:
+                return response is not None and response.status_code == 204
+        except Exception as err:  # pylint: disable=broad-exception-caught
+            logger.error(f"删除 Emby 作者 {item_id} 出错：{err}")
+            return False
+
+    @staticmethod
+    def get_command() -> List[Dict[str, Any]]:
+        """注册有声书整理和演播作者修正命令。"""
+        return [
+            {
+                "cmd": "/ab",
+                "event": EventType.PluginAction,
+                "desc": "emby有声书整理",
+                "category": "",
+                "data": {"action": "audiobook"},
+            },
+            {
+                "cmd": "/aba",
+                "event": EventType.PluginAction,
+                "desc": "emby有声书演播者整理",
+                "category": "",
+                "data": {"action": "audiobook_artist"},
+            },
+        ]
+
+    def get_api(self) -> List[Dict[str, Any]]:
+        """该插件不暴露 MoviePilot REST API。"""
+        return []
+
+    def get_service(self) -> List[Dict[str, Any]]:
+        """通过 V3 宿主服务合同注册一次性和周期整理任务。"""
+        services: List[Dict[str, Any]] = []
+        if self._run_once:
+            services.append(
+                {
+                    "id": "EmbyAudioBook.Once",
+                    "name": "Emby有声书整理（立即运行）",
+                    "trigger": "date",
+                    "func": self._run_once_check,
+                    "kwargs": {
+                        "run_date": datetime.datetime.now(
+                            tz=pytz.timezone(str(settings.TZ))
+                        )
+                        + datetime.timedelta(seconds=3)
+                    },
+                }
+            )
+        if self._enabled and self._cron:
+            try:
+                services.append(
+                    {
+                        "id": "EmbyAudioBook",
+                        "name": "Emby有声书整理",
+                        "trigger": CronTrigger.from_crontab(
+                            self._cron,
+                            timezone=pytz.timezone(str(settings.TZ)),
+                        ),
+                        "func": self.check,
+                        "kwargs": {},
+                    }
+                )
+            except (TypeError, ValueError) as err:
+                logger.error(f"定时任务配置错误：{err}")
+                self.systemmessage.put(f"执行周期配置错误：{err}")
+        return services
+
+    def get_form(self) -> Tuple[List[dict], Dict[str, Any]]:
+        """构造 V3 Vuetify 配置表单。"""
+        message_type_options = [
+            {"title": item.value, "value": item.name} for item in MessageType
+        ]
+        emby_configs = [
+            {"title": config.name, "value": config.name}
+            for config in self._mediaserver_helper.get_configs().values()
+            if config.type == "emby"
+        ]
+        return [
+            {
+                "component": "VForm",
+                "content": [
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 3},
+                                "content": [
+                                    {
+                                        "component": "VSwitch",
+                                        "props": {
+                                            "model": "enabled",
+                                            "label": "启用插件",
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 3},
+                                "content": [
+                                    {
+                                        "component": "VSwitch",
+                                        "props": {
+                                            "model": "onlyonce",
+                                            "label": "立即运行一次",
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 3},
+                                "content": [
+                                    {
+                                        "component": "VSwitch",
+                                        "props": {
+                                            "model": "notify",
+                                            "label": "开启通知",
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 3},
+                                "content": [
+                                    {
+                                        "component": "VSwitch",
+                                        "props": {
+                                            "model": "rename",
+                                            "label": "重命名有声书",
+                                        },
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 4},
+                                "content": [
+                                    {
+                                        "component": "VCronField",
+                                        "props": {
+                                            "model": "cron",
+                                            "label": "定时全量同步周期",
+                                            "placeholder": "5位cron表达式，留空关闭",
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 4},
+                                "content": [
+                                    {
+                                        "component": "VSelect",
+                                        "props": {
+                                            "multiple": False,
+                                            "chips": True,
+                                            "model": "msgtype",
+                                            "label": "消息类型",
+                                            "items": message_type_options,
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 4},
+                                "content": [
+                                    {
+                                        "component": "VTextField",
+                                        "props": {
+                                            "model": "library_id",
+                                            "label": "有声书文件夹ID",
+                                            "placeholder": "媒体库有声书-->文件夹-->看URL里的ParentId",
+                                        },
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12},
+                                "content": [
+                                    {
+                                        "component": "VSelect",
+                                        "props": {
+                                            "multiple": True,
+                                            "chips": True,
+                                            "clearable": True,
+                                            "model": "mediaservers",
+                                            "label": "媒体服务器",
+                                            "items": emby_configs,
+                                        },
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12},
+                                "content": [
+                                    {
+                                        "component": "VAlert",
+                                        "props": {
+                                            "type": "info",
+                                            "variant": "tonal",
+                                            "text": (
+                                                "仅支持交互命令运行：/ab 媒体库 书名 正确信息集数；"
+                                                "/aba 媒体库 书名 正确的演播作者名称。"
+                                            ),
+                                        },
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                ],
+            }
+        ], {
+            "enabled": False,
+            "notify": False,
+            "onlyonce": False,
+            "rename": False,
+            "cron": "",
+            "msgtype": "",
+            "library_id": "",
+            "mediaservers": [],
+        }
+
+    def get_page(self) -> List[dict]:
+        """该插件不提供详情页。"""
+        return []
+
+    def stop_service(self) -> None:
+        """公共调度任务由宿主撤销，插件没有额外后台资源需要释放。"""

--- a/plugins.v3/embycollectionsort/__init__.py
+++ b/plugins.v3/embycollectionsort/__init__.py
@@ -1,0 +1,715 @@
+"""按发布日期重排 Emby 合集媒体的入库时间。"""
+
+from __future__ import annotations
+
+import re
+import threading
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+import pytz
+from apscheduler.triggers.cron import CronTrigger
+
+from app.plugins import _PluginBase
+from app.schemas.types import EventType
+from app.sdk.config import settings
+from app.sdk.events import Event, eventmanager
+from app.sdk.logging import logger
+from app.sdk.network import RequestUtils
+from app.sdk.services import MediaServerHelper
+
+
+@dataclass(frozen=True)
+class _EmbyConnection:
+    """保存一次排序任务使用的 Emby 连接参数。"""
+
+    host: str
+    user_id: str
+    api_key: str
+
+
+class EmbyCollectionSort(_PluginBase):
+    """按发布日期重排 Emby 合集媒体的入库时间。"""
+
+    plugin_name = "Emby合集媒体排序"
+    plugin_desc = "Emby保留按照加入时间倒序的前提下，把合集中的媒体按照发布日期排序，修改加入时间已到达顺序排列的目的。"
+    plugin_icon = "Element_A.png"
+    plugin_version = "2.0.0"
+    plugin_author = "thsrite"
+    author_url = "https://github.com/thsrite"
+    plugin_config_prefix = "embycollectionsort_"
+    plugin_order = 15
+    auth_level = 1
+
+    def __init__(self) -> None:
+        """初始化插件状态，避免热重载复用旧配置和远端连接。"""
+        super().__init__()
+        self._enabled = False
+        self._onlyonce = False
+        self._run_once = False
+        self._cron: Optional[str] = None
+        self._sort_type = "asc"
+        self._collection_library_id: Optional[str] = None
+        self._black_collection = ""
+        self._mediaservers: list[str] = []
+        self._mediaserver_helper: Optional[MediaServerHelper] = None
+        self._connection: Optional[_EmbyConnection] = None
+        # 请求帮助方法只读取当前任务的连接投影，任务结束后必须整体清空。
+        self._EMBY_HOST: Optional[str] = None
+        self._EMBY_USER: Optional[str] = None
+        self._EMBY_APIKEY: Optional[str] = None
+        self._run_lock = threading.Lock()
+        self._run_once_lock = threading.Lock()
+
+    def init_plugin(self, config: Optional[dict] = None) -> None:
+        """读取配置，并把调度任务交给宿主公共服务投影。"""
+        with self._run_lock:
+            self.__clear_connection()
+            self.__init_plugin(config)
+
+    def __init_plugin(self, config: Optional[dict]) -> None:
+        """在没有排序任务运行时更新插件配置。"""
+        config = dict(config or {})
+
+        self._enabled = bool(config.get("enabled"))
+        self._onlyonce = bool(config.get("onlyonce"))
+        self._run_once = self._onlyonce
+        self._cron = self._normalize_cron(config.get("cron"))
+        self._sort_type = str(config.get("sort_type") or "asc").strip()
+        self._collection_library_id = str(
+            config.get("collection_library_id") or ""
+        ).strip() or None
+        self._black_collection = str(config.get("black_collection") or "").strip()
+        self._mediaservers = self._normalize_string_list(config.get("mediaservers"))
+        self._mediaserver_helper = MediaServerHelper()
+
+        if self._run_once:
+            # 一次性标志由配置触发、由宿主服务消费；写回配置避免热重载重复执行。
+            self._onlyonce = False
+            self.__update_config()
+
+    def get_state(self) -> bool:
+        """返回插件是否启用或仍有待执行的一次性任务。"""
+        return self._enabled or self._run_once
+
+    def __update_config(self) -> None:
+        """保存归一化配置，并清除已消费的一次性开关。"""
+        self.update_config(
+            {
+                "onlyonce": self._onlyonce,
+                "cron": self._cron or "",
+                "enabled": self._enabled,
+                "sort_type": self._sort_type,
+                "collection_library_id": self._collection_library_id or "",
+                "mediaservers": self._mediaservers,
+                "black_collection": self._black_collection,
+            }
+        )
+
+    def collection_sort(self) -> bool:
+        """执行一次合集排序；已有任务运行时拒绝并发执行。"""
+        if not self._run_lock.acquire(blocking=False):
+            logger.warning("Emby合集媒体排序任务正在运行，本次触发已跳过")
+            return False
+        try:
+            return self.__collection_sort()
+        finally:
+            self._run_lock.release()
+
+    def __run_once_sort(self) -> bool:
+        """消费一次性任务标志后执行排序，避免重复调度重复处理。"""
+        with self._run_once_lock:
+            if not self._run_once:
+                return False
+            self._run_once = False
+        return self.collection_sort()
+
+    def __collection_sort(self) -> bool:
+        """遍历启用的 Emby 服务，并隔离每个服务的请求上下文。"""
+        if not self._collection_library_id:
+            logger.error("未配置合集所在媒体库")
+            return False
+
+        helper = self._mediaserver_helper or MediaServerHelper()
+        try:
+            emby_servers = helper.get_services(
+                name_filters=self._mediaservers,
+                type_filter="emby",
+            )
+        except (RuntimeError, TypeError, AttributeError) as error:
+            logger.error("获取Emby媒体服务器失败：%s", error)
+            return False
+        if not emby_servers:
+            logger.error("未配置Emby媒体服务器")
+            return False
+
+        processed_server = False
+        for emby_name, emby_server in emby_servers.items():
+            connection = self.__select_server(emby_server)
+            if connection is None:
+                logger.warning("媒体服务器 %s 缺少有效连接配置，已跳过", emby_name)
+                continue
+
+            processed_server = True
+            try:
+                logger.info("开始处理媒体服务器 %s", emby_name)
+                # 不同 Emby 实例的时间线彼此独立，不能互相占用时间点。
+                handled_times: set[datetime] = set()
+                collections = self.__get_items(self._collection_library_id)
+                for collection in collections:
+                    self.__sort_collection(collection, handled_times)
+                logger.info("更新 %s 合集媒体排序完成", emby_name)
+            finally:
+                self.__clear_connection()
+
+        return processed_server
+
+    def __sort_collection(
+        self, collection: dict, handled_times: set[datetime]
+    ) -> None:
+        """读取一个合集并提交按发布日期生成的入库时间。"""
+        collection_name = str(collection.get("Name") or "")
+        collection_id = collection.get("Id")
+        if not collection_id:
+            logger.warning("合集 %s 缺少有效 ID，已跳过", collection_name)
+            return
+        if self._is_blacklisted(collection_name, self._black_collection):
+            logger.info("跳过黑名单合集: %s %s", collection_name, collection_id)
+            return
+
+        try:
+            logger.info("开始处理合集: %s %s", collection_name, collection_id)
+            sorted_items = self.__sorted_items(self.__get_items(collection_id))
+            if not sorted_items:
+                logger.info("合集 %s 没有可排序的有效媒体", collection_name)
+                return
+
+            # 用合集当前最大的入库时间作为新序列起点，保持 Emby 倒序列表的顺序。
+            current_time = max(item["created"] for item in sorted_items)
+            updated_items: list[dict[str, Any]] = []
+            for item in sorted_items:
+                while current_time in handled_times:
+                    current_time += timedelta(seconds=1)
+                new_date_created = self.__format_emby_datetime(current_time)
+                item_info = item["item_info"]
+                if item_info.get("DateCreated") != new_date_created:
+                    updated_info = dict(item_info)
+                    updated_info["DateCreated"] = new_date_created
+                    updated_items.append(updated_info)
+                    logger.debug(
+                        "合集媒体: %s 原入库时间 %s 新入库时间 %s",
+                        item.get("Name"),
+                        item.get("original_date_created"),
+                        new_date_created,
+                    )
+                handled_times.add(current_time)
+                current_time -= timedelta(seconds=1)
+
+            if not updated_items:
+                logger.warning("合集: %s %s 无需更新入库时间", collection_name, collection_id)
+                return
+
+            for item_info in updated_items:
+                item_id = item_info.get("Id")
+                update_flag = self.__update_item_info(item_id, item_info)
+                if update_flag:
+                    logger.info(
+                        "%s 更新入库时间到%s成功",
+                        item_info.get("Name"),
+                        item_info.get("DateCreated"),
+                    )
+                else:
+                    logger.error(
+                        "%s 更新入库时间到%s失败",
+                        item_info.get("Name"),
+                        item_info.get("DateCreated"),
+                    )
+            logger.info("合集处理完成: %s %s", collection_name, collection_id)
+        except Exception as error:  # 外部 Emby 单个合集异常不应中断其它合集
+            logger.error("处理合集 %s %s 失败: %s", collection_name, collection_id, error)
+
+    @staticmethod
+    def _is_blacklisted(collection_name: str, blacklist: Any = None) -> bool:
+        """判断合集名称是否命中逗号分隔的黑名单。"""
+        if not blacklist:
+            return False
+        keywords = (
+            blacklist
+            if isinstance(blacklist, (list, tuple, set))
+            else str(blacklist).split(",")
+        )
+        return any(
+            str(keyword).strip() and str(keyword).strip() in collection_name
+            for keyword in keywords
+        )
+
+    def __sorted_items(self, items: Optional[list[dict]]) -> list[dict[str, Any]]:
+        """过滤缺少日期的条目，并按 Emby 首映日期排序。"""
+        result: list[dict[str, Any]] = []
+        for item in items or []:
+            if not isinstance(item, dict):
+                continue
+            item_id = item.get("Id")
+            item_info = self.__get_item_info(item_id)
+            if not isinstance(item_info, dict):
+                item_info = {}
+            premiere = self.__parse_emby_datetime(item_info.get("PremiereDate"))
+            created = self.__parse_emby_datetime(item_info.get("DateCreated"))
+            if not item_id or not premiere or not created:
+                logger.warning(
+                    "媒体 %s 缺少有效 PremiereDate/DateCreated，已跳过",
+                    item.get("Name"),
+                )
+                continue
+            result.append(
+                {
+                    "Name": item.get("Name"),
+                    "Id": item_id,
+                    "item_info": item_info,
+                    "premiere": premiere,
+                    "created": created,
+                    "original_date_created": item_info.get("DateCreated"),
+                }
+            )
+        return sorted(
+            result,
+            key=lambda item: item["premiere"],
+            reverse=str(self._sort_type).strip().lower()
+            in {"降序", "desc", "descending"},
+        )
+
+    def __select_server(self, service: Any) -> Optional[_EmbyConnection]:
+        """从 V3 服务投影提取当前 Emby 的地址、用户和 API key。"""
+        if not service or not service.config:
+            return None
+        config = service.config.config
+        if not isinstance(config, dict):
+            return None
+        host = self._normalize_host(config.get("host"))
+        api_key = str(config.get("apikey") or "").strip()
+        instance = service.instance
+        if not host or not api_key or not instance:
+            return None
+        try:
+            user = instance.get_user()
+        except (AttributeError, TypeError, ValueError) as error:
+            logger.warning("获取 Emby 用户 ID 失败：%s", error)
+            return None
+        user_id = str(user or "").strip()
+        if not user_id:
+            return None
+
+        connection = _EmbyConnection(host=host, user_id=user_id, api_key=api_key)
+        self._connection = connection
+        self._EMBY_HOST = connection.host
+        self._EMBY_USER = connection.user_id
+        self._EMBY_APIKEY = connection.api_key
+        return connection
+
+    def __clear_connection(self) -> None:
+        """清理一次媒体服务器任务结束后的连接投影。"""
+        self._connection = None
+        self._EMBY_HOST = None
+        self._EMBY_USER = None
+        self._EMBY_APIKEY = None
+
+    @staticmethod
+    def _normalize_host(value: Any) -> str:
+        """把 Emby 地址规范化为不带尾部斜杠的 HTTP 基地址。"""
+        host = str(value or "").strip()
+        if not host:
+            return ""
+        if not host.lower().startswith(("http://", "https://")):
+            host = f"http://{host}"
+        return host.rstrip("/")
+
+    @staticmethod
+    def __parse_emby_datetime(value: Any) -> Optional[datetime]:
+        """解析 Emby ISO 时间，兼容七位小数秒和 UTC 偏移。"""
+        text = str(value or "").strip()
+        if not text:
+            return None
+        match = re.match(
+            r"^(?P<date>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})"
+            r"(?:\.(?P<fraction>\d+))?(?P<zone>Z|[+-]\d{2}:?\d{2})?$",
+            text,
+        )
+        if not match:
+            return None
+        fraction = (match.group("fraction") or "")[:6]
+        normalized = match.group("date")
+        if fraction:
+            normalized += f".{fraction.ljust(6, '0')}"
+        zone = match.group("zone")
+        if zone:
+            normalized += "+00:00" if zone == "Z" else zone
+        try:
+            parsed = datetime.fromisoformat(normalized)
+        except ValueError:
+            return None
+        if parsed.tzinfo:
+            return parsed.astimezone(timezone.utc).replace(tzinfo=None)
+        return parsed
+
+    @staticmethod
+    def __format_emby_datetime(value: datetime) -> str:
+        """将排序时间写回 Emby 接受的七位小数秒格式。"""
+        return value.strftime("%Y-%m-%dT%H:%M:%S.%f0Z")
+
+    @staticmethod
+    def __event_data(event: Optional[Event]) -> dict[str, Any]:
+        """读取字典或 V3 类型化事件中的动作字段。"""
+        if event is None:
+            return {}
+        payload = event.event_data
+        if isinstance(payload, dict):
+            return payload
+        if payload is None:
+            return {}
+        model_dump = getattr(payload, "model_dump", None)
+        if callable(model_dump):
+            dumped = model_dump(mode="python")
+            return dumped if isinstance(dumped, dict) else {}
+        return {
+            key: getattr(payload, key, None)
+            for key in ("action", "channel", "user")
+        }
+
+    @eventmanager.register(EventType.PluginAction)
+    def remote_sync(self, event: Optional[Event] = None) -> None:
+        """响应远程命令并执行一次合集排序。"""
+        event_data = self.__event_data(event)
+        if event is not None and event_data.get("action") != "collection_sort":
+            return
+        if event is not None:
+            self.post_message(
+                channel=event_data.get("channel"),
+                title="开始更新Emby合集媒体排序 ...",
+                userid=event_data.get("user"),
+            )
+        success = self.collection_sort()
+        if event is not None:
+            self.post_message(
+                channel=event_data.get("channel"),
+                title="更新Emby合集媒体排序完成！" if success else "更新Emby合集媒体排序失败！",
+                userid=event_data.get("user"),
+            )
+
+    def __request_json(
+        self, path: str, params: Optional[dict[str, Any]] = None
+    ) -> Optional[dict]:
+        """通过 V3 网络 SDK 读取 Emby JSON，并始终释放响应连接。"""
+        if not self._EMBY_HOST or not self._EMBY_USER or not self._EMBY_APIKEY:
+            return None
+        response = None
+        try:
+            request_params = dict(params or {})
+            request_params["api_key"] = self._EMBY_APIKEY
+            response = RequestUtils().get_res(
+                url=f"{self._EMBY_HOST}/{path.lstrip('/')}",
+                params=request_params,
+            )
+            if response is None or response.status_code != 200:
+                return None
+            payload = response.json()
+            return payload if isinstance(payload, dict) else None
+        except Exception as error:  # 外部 Emby 响应异常按空结果处理
+            logger.warning("请求 Emby 接口 %s 出错：%s", path, error)
+            return None
+        finally:
+            if response is not None:
+                try:
+                    response.close()
+                except Exception:
+                    pass
+
+    def __post_json(self, path: str, payload: dict[str, Any]) -> bool:
+        """通过 V3 网络 SDK 写入 Emby JSON，并始终释放响应连接。"""
+        if not self._EMBY_HOST or not self._EMBY_APIKEY:
+            return False
+        response = None
+        try:
+            response = RequestUtils(content_type="application/json").post_res(
+                url=f"{self._EMBY_HOST}/{path.lstrip('/')}",
+                params={"api_key": self._EMBY_APIKEY},
+                json=payload,
+            )
+            return response is not None and response.status_code in (200, 204)
+        except Exception as error:  # 外部 Emby 写入异常按失败处理
+            logger.warning("请求 Emby 接口 %s 出错：%s", path, error)
+            return False
+        finally:
+            if response is not None:
+                try:
+                    response.close()
+                except Exception:
+                    pass
+
+    def __get_items(self, parent_id: Any) -> list[dict]:
+        """读取 Emby 父条目下的媒体列表。"""
+        if not parent_id or not self._EMBY_USER:
+            return []
+        result = self.__request_json(
+            f"emby/Users/{self._EMBY_USER}/Items",
+            {"ParentId": parent_id},
+        )
+        items = result.get("Items") if result else []
+        return (
+            [item for item in items if isinstance(item, dict)]
+            if isinstance(items, list)
+            else []
+        )
+
+    def __get_item_info(self, item_id: Any) -> dict[str, Any]:
+        """读取单个 Emby 条目详情。"""
+        if not item_id or not self._EMBY_USER:
+            return {}
+        return self.__request_json(
+            f"emby/Users/{self._EMBY_USER}/Items/{item_id}"
+        ) or {}
+
+    def __update_item_info(self, item_id: Any, data: dict[str, Any]) -> bool:
+        """更新 Emby 条目的入库时间。"""
+        if not item_id:
+            return False
+        return self.__post_json(f"emby/Items/{item_id}", data)
+
+    @staticmethod
+    def get_command() -> list[dict[str, Any]]:
+        """注册远程合集排序命令。"""
+        return [
+            {
+                "cmd": "/collection_sort",
+                "event": EventType.PluginAction,
+                "desc": "更新Emby合集媒体排序",
+                "category": "",
+                "data": {"action": "collection_sort"},
+            }
+        ]
+
+    def get_api(self) -> list[dict[str, Any]]:
+        """本插件不暴露额外 HTTP API。"""
+        return []
+
+    def get_service(self) -> list[dict[str, Any]]:
+        """按 V3 公共服务合同注册一次性和周期排序任务。"""
+        services: list[dict[str, Any]] = []
+        if self._run_once:
+            services.append(
+                {
+                    "id": "EmbyCollectionSort.Once",
+                    "name": "Emby合集媒体排序（立即运行）",
+                    "trigger": "date",
+                    "func": self.__run_once_sort,
+                    "kwargs": {
+                        "run_date": datetime.now(
+                            pytz.timezone(str(settings.TZ))
+                        )
+                        + timedelta(seconds=3)
+                    },
+                }
+            )
+        if self._enabled and self._cron:
+            try:
+                services.append(
+                    {
+                        "id": "EmbyCollectionSort",
+                        "name": "Emby合集媒体排序",
+                        "trigger": CronTrigger.from_crontab(
+                            self._cron,
+                            timezone=pytz.timezone(str(settings.TZ)),
+                        ),
+                        "func": self.collection_sort,
+                        "kwargs": {},
+                    }
+                )
+            except (TypeError, ValueError) as error:
+                logger.error("定时任务配置错误：%s", error)
+                self.systemmessage.put(f"执行周期配置错误：{error}")
+        return services
+
+    def get_form(self) -> tuple[list[dict], dict[str, Any]]:
+        """返回插件配置表单和默认配置。"""
+        media_server_items: list[dict[str, str]] = []
+        helper = self._mediaserver_helper or MediaServerHelper()
+        try:
+            media_server_items = [
+                {"title": config.name, "value": config.name}
+                for config in helper.get_configs().values()
+                if config.type == "emby"
+            ]
+        except (RuntimeError, TypeError, AttributeError):
+            # 配置组合根尚未装配时仍返回静态表单。
+            media_server_items = []
+
+        return [
+            {
+                "component": "VForm",
+                "content": [
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 4},
+                                "content": [
+                                    {
+                                        "component": "VSwitch",
+                                        "props": {"model": "enabled", "label": "启用插件"},
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 4},
+                                "content": [
+                                    {
+                                        "component": "VSwitch",
+                                        "props": {"model": "onlyonce", "label": "立即运行一次"},
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 4},
+                                "content": [
+                                    {
+                                        "component": "VCronField",
+                                        "props": {
+                                            "model": "cron",
+                                            "label": "执行周期",
+                                            "placeholder": "5位cron表达式，留空自动",
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 4},
+                                "content": [
+                                    {
+                                        "component": "VTextField",
+                                        "props": {"model": "collection_library_id", "label": "合集媒体库ID"},
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 4},
+                                "content": [
+                                    {
+                                        "component": "VSelect",
+                                        "props": {
+                                            "model": "sort_type",
+                                            "label": "发布日期",
+                                            "items": [
+                                                {"title": "升序", "value": "升序"},
+                                                {"title": "降序", "value": "降序"},
+                                            ],
+                                        },
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12},
+                                "content": [
+                                    {
+                                        "component": "VSelect",
+                                        "props": {
+                                            "multiple": True,
+                                            "chips": True,
+                                            "clearable": True,
+                                            "model": "mediaservers",
+                                            "label": "媒体服务器",
+                                            "items": media_server_items,
+                                        },
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12},
+                                "content": [
+                                    {
+                                        "component": "VTextField",
+                                        "props": {
+                                            "model": "black_collection",
+                                            "label": "黑名单合集名称",
+                                            "placeholder": "多个名称用英文逗号分隔",
+                                        },
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12},
+                                "content": [
+                                    {
+                                        "component": "VAlert",
+                                        "props": {
+                                            "type": "info",
+                                            "variant": "tonal",
+                                            "text": "保留按照加入时间倒序的前提下，把合集中的媒体放一块，不用到处找。注：只支持Emby。",
+                                        },
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                ],
+            }
+        ], {
+            "enabled": False,
+            "onlyonce": False,
+            "sort_type": "降序",
+            "cron": "5 1 * * *",
+            "collection_library_id": "",
+            "black_collection": "",
+            "mediaservers": [],
+        }
+
+    def get_page(self) -> list[dict]:
+        """本插件不提供详情页。"""
+        return []
+
+    def stop_service(self) -> None:
+        """释放插件自有的连接投影；公共调度任务由宿主统一撤销。"""
+        with self._run_lock:
+            self.__clear_connection()
+
+    @staticmethod
+    def _normalize_cron(value: Any) -> Optional[str]:
+        """规范化可选五段 cron 文本，空值表示不注册周期任务。"""
+        normalized = " ".join(str(value or "").split())
+        return normalized or None
+
+    @staticmethod
+    def _normalize_string_list(value: Any) -> list[str]:
+        """把配置中的字符串或列表归一为非空服务名称列表。"""
+        if isinstance(value, str):
+            value = value.split(",")
+        if not isinstance(value, (list, tuple, set)):
+            return []
+        return [str(item).strip() for item in value if str(item).strip()]

--- a/plugins.v3/embydanmu/__init__.py
+++ b/plugins.v3/embydanmu/__init__.py
@@ -1,0 +1,798 @@
+from __future__ import annotations
+
+import re
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from app.plugins import _PluginBase
+from app.schemas.types import EventType
+from app.sdk.events import Event, eventmanager
+from app.sdk.logging import logger
+from app.sdk.network import RequestUtils
+from app.sdk.services import MediaServerHelper
+
+
+class EmbyDanmu(_PluginBase):
+    """通知 Emby Danmu 插件为媒体库中的电影或剧集下载弹幕。"""
+
+    plugin_name = "Emby弹幕下载"
+    plugin_desc = "通知Emby Danmu插件下载弹幕。"
+    plugin_icon = "https://raw.githubusercontent.com/thsrite/MoviePilot-Plugins/main/icons/danmu.png"
+    plugin_version = "3.0.0"
+    plugin_author = "thsrite"
+    author_url = "https://github.com/thsrite"
+    plugin_config_prefix = "embydanmu_"
+    plugin_order = 30
+    auth_level = 1
+
+    def __init__(self) -> None:
+        """初始化插件状态；所有外部连接均延迟到命令执行时建立。"""
+        super().__init__()
+        self._run_lock = threading.Lock()
+        self._enabled = False
+        self._disabled = False
+        self._mediaservers: List[str] = []
+        self._paths: Dict[str, str] = {}
+        self._library_task: Dict[Tuple[str, str], List[str]] = {}
+        self._danmu_source: List[str] = []
+        self._emby_host = ""
+        self._emby_user: Optional[str] = None
+        self._emby_api_key: Optional[str] = None
+        self.mediaserver_helper: Optional[MediaServerHelper] = None
+
+    def init_plugin(self, config: dict = None) -> None:
+        """读取配置并重建运行态，允许宿主重复初始化插件。"""
+        with self._run_lock:
+            config = config or {}
+            self._library_task.clear()
+            self._enabled = bool(config.get("enabled"))
+            self._disabled = bool(config.get("disabled"))
+            self._mediaservers = list(config.get("mediaservers") or [])
+            self._paths = self.__parse_path_mappings(config.get("dirs"))
+            self._danmu_source = []
+            self._emby_host = ""
+            self._emby_user = None
+            self._emby_api_key = None
+            self.mediaserver_helper = MediaServerHelper()
+
+    @staticmethod
+    def __parse_path_mappings(value: Optional[str]) -> Dict[str, str]:
+        """解析每行一个的 Emby 路径到 MoviePilot 路径映射。"""
+        mappings: Dict[str, str] = {}
+        for line in str(value or "").splitlines():
+            source, separator, target = line.partition(":")
+            source = source.strip()
+            target = target.strip()
+            if separator and source and target:
+                mappings[source] = target
+        return mappings
+
+    @staticmethod
+    def __normalize_host(value: Any) -> str:
+        """规范化媒体服务器地址，避免请求路径出现重复或缺少斜杠。"""
+        host = str(value or "").strip().rstrip("/")
+        if not host:
+            return ""
+        if not host.startswith(("http://", "https://")):
+            host = f"http://{host}"
+        return f"{host}/"
+
+    def __set_server_context(self, service: Any) -> bool:
+        """从服务发现结果绑定本次命令使用的 Emby 连接参数。"""
+        config = service.config.config if service.config else {}
+        self._emby_host = self.__normalize_host(config.get("host"))
+        self._emby_api_key = str(config.get("apikey") or "") or None
+        self._emby_user = None
+        if service.instance:
+            try:
+                self._emby_user = service.instance.get_user()
+            except Exception as error:
+                logger.error(f"获取 Emby 用户 ID 出错：{error}")
+        return bool(self._emby_host and self._emby_api_key and self._emby_user)
+
+    def __request_response(
+        self,
+        method: str,
+        path: str,
+        params: Optional[dict] = None,
+        payload: Optional[dict] = None,
+    ) -> Any:
+        """通过 V3 网络 SDK 调用 Emby 外部 API，并隐藏 API key 不写入日志。"""
+        if not self._emby_host or not self._emby_api_key:
+            return None
+
+        request_params = dict(params or {})
+        request_params["api_key"] = self._emby_api_key
+        url = f"{self._emby_host}{path.lstrip('/')}"
+        try:
+            request = RequestUtils(content_type="application/json") if payload is not None else RequestUtils()
+            if method == "GET":
+                return request.get_res(url=url, params=request_params)
+            return request.post_res(url=url, params=request_params, json=payload)
+        except Exception as error:
+            logger.error(f"请求 Emby 接口 {path} 出错：{error}")
+            return None
+
+    def __get_json(
+        self,
+        path: str,
+        params: Optional[dict] = None,
+        expected_status: Tuple[int, ...] = (200,),
+    ) -> Any:
+        """读取 Emby JSON 响应，错误状态和解析失败均按空结果处理。"""
+        response = self.__request_response("GET", path, params=params)
+        try:
+            if response is None or response.status_code not in expected_status:
+                return None
+            return response.json()
+        except Exception as error:
+            logger.error(f"解析 Emby 接口 {path} 响应出错：{error}")
+            return None
+        finally:
+            if response is not None:
+                response.close()
+
+    def __get_text(self, path: str, params: Optional[dict] = None) -> str:
+        """读取 Emby 文本响应并保证连接释放。"""
+        response = self.__request_response("GET", path, params=params)
+        try:
+            if response is None or response.status_code != 200:
+                return ""
+            return str(response.text or "")
+        except Exception as error:
+            logger.error(f"读取 Emby 接口 {path} 响应出错：{error}")
+            return ""
+        finally:
+            if response is not None:
+                response.close()
+
+    def __post_json(
+        self,
+        path: str,
+        payload: dict,
+        expected_status: Tuple[int, ...] = (200, 204),
+    ) -> bool:
+        """提交 Emby JSON 请求，并按 HTTP 状态判断写入是否成功。"""
+        response = self.__request_response("POST", path, payload=payload)
+        try:
+            return response is not None and response.status_code in expected_status
+        except Exception as error:
+            logger.error(f"读取 Emby 接口 {path} 状态出错：{error}")
+            return False
+        finally:
+            if response is not None:
+                response.close()
+
+    @eventmanager.register(EventType.PluginAction)
+    def danmu(self, event: Event = None) -> None:
+        """处理 `/danmu 媒体库 媒体 (季)` 命令。"""
+        if not self._enabled or event is None:
+            return
+
+        event_data = event.event_data
+        if not isinstance(event_data, dict) or event_data.get("action") != "embydanmu":
+            return
+
+        if not self._run_lock.acquire(blocking=False):
+            self.__notify(event_data, "已有 Emby 弹幕下载任务正在执行，请稍后重试")
+            return
+        try:
+            self.__run_danmu(event_data)
+        finally:
+            self._run_lock.release()
+
+    def __run_danmu(self, event_data: dict) -> None:
+        """串行执行一次命令，避免不同 Emby 服务共享连接上下文。"""
+
+        args = str(event_data.get("arg_str") or "").split()
+        if not 1 <= len(args) <= 3:
+            self.__notify(event_data, "参数错误！ /danmu 媒体库名 媒体名 (季) 或 /danmu 华语电影 或 /danmu 国产剧")
+            return
+
+        season = None
+        if len(args) == 3:
+            try:
+                season = int(args[2])
+            except (TypeError, ValueError):
+                self.__notify(event_data, "季数必须是整数")
+                return
+            if season <= 0:
+                self.__notify(event_data, "季数必须大于 0")
+                return
+
+        if self.mediaserver_helper is None:
+            self.mediaserver_helper = MediaServerHelper()
+        try:
+            services = self.mediaserver_helper.get_services(
+                name_filters=self._mediaservers,
+                type_filter="emby",
+            )
+        except Exception as error:
+            logger.error(f"获取 Emby 媒体服务器失败：{error}")
+            services = {}
+        if not services:
+            logger.error("未配置 Emby 媒体服务器")
+            return
+
+        for server_name, service in services.items():
+            if not self.__set_server_context(service):
+                logger.error(f"媒体服务器 {server_name} 配置不完整")
+                continue
+            self._danmu_source = self.__get_danmu_source()
+            if not self._danmu_source:
+                logger.error(f"{server_name} 未配置弹幕源")
+                self.__notify(event_data, f"{server_name} 未正确配置弹幕源")
+                continue
+            try:
+                self.__process_server(
+                    server_name=server_name,
+                    event_data=event_data,
+                    library_name=args[0],
+                    item_name=args[1] if len(args) > 1 else None,
+                    season=season,
+                )
+            except Exception as error:
+                logger.error(f"{server_name} 获取弹幕任务出错：{error}")
+
+    def __process_server(
+        self,
+        server_name: str,
+        event_data: dict,
+        library_name: str,
+        item_name: Optional[str],
+        season: Optional[int],
+    ) -> None:
+        """在单个 Emby 服务中查找媒体库并处理目标媒体。"""
+        libraries = self.__get_librarys()
+        library = next(
+            (
+                item
+                for item in libraries
+                if item.get("Name") == library_name
+            ),
+            None,
+        )
+        if not library:
+            self.__notify(event_data, f"{server_name} 未找到媒体库：{library_name}")
+            return
+
+        library_id = library.get("Id") or library.get("ItemId")
+        library_options = library.get("LibraryOptions")
+        if not library_id or not isinstance(library_options, dict):
+            self.__notify(event_data, f"{server_name} 未找到媒体库：{library_name}")
+            return
+
+        disabled_fetchers = list(library_options.get("DisabledSubtitleFetchers") or [])
+        if "Danmu" in disabled_fetchers:
+            enabled_options = dict(library_options)
+            enabled_options["DisabledSubtitleFetchers"] = [
+                item for item in disabled_fetchers if item != "Danmu"
+            ]
+            if not self.__update_library(library_id, enabled_options):
+                self.__notify(event_data, f"{server_name} 启用媒体库：{library_name}的Danmu插件失败")
+                return
+            logger.info(f"{server_name} 已启用媒体库：{library_name}的Danmu插件")
+
+        is_special_library = item_name is None
+        task_name = library_name if is_special_library else item_name
+        task_key = (server_name, str(library_id))
+        self._library_task.setdefault(task_key, []).append(task_name or library_name)
+        try:
+            items = self.__get_items(
+                library_id,
+                name_starts_with=None if is_special_library else item_name,
+            )
+            if not items:
+                logger.error(f"{server_name} 获取媒体库：{library_name}的媒体列表失败")
+                self.__notify(event_data, f"{server_name} 获取媒体库：{library_name}的媒体列表失败")
+                return
+
+            found = False
+            library_type = library.get("CollectionType")
+            for item in items:
+                if not isinstance(item, dict):
+                    continue
+                current_name = str(item.get("Name") or "")
+                if library_type == "tvshows":
+                    if not is_special_library and current_name != item_name:
+                        continue
+                    found = True
+                    self.__process_series(
+                        server_name=server_name,
+                        event_data=event_data,
+                        library_name=library_name,
+                        series=item,
+                        season=season,
+                    )
+                else:
+                    if not is_special_library and not self.__movie_name_matches(current_name, item_name):
+                        continue
+                    found = True
+                    self.__process_movie(
+                        server_name=server_name,
+                        event_data=event_data,
+                        library_name=library_name,
+                        item=item,
+                        special_library=is_special_library,
+                    )
+                if not is_special_library:
+                    break
+
+            if not found:
+                suffix = "" if is_special_library else f" {item_name}"
+                self.__notify(event_data, f"{server_name} 未找到媒体：{library_name}{suffix}")
+        finally:
+            tasks = self._library_task.get(task_key, [])
+            if task_name in tasks:
+                tasks.remove(task_name)
+            if not tasks:
+                self._library_task.pop(task_key, None)
+            if not tasks and self._disabled:
+                disabled_options = dict(library_options)
+                final_disabled = list(disabled_options.get("DisabledSubtitleFetchers") or [])
+                if "Danmu" not in final_disabled:
+                    final_disabled.append("Danmu")
+                disabled_options["DisabledSubtitleFetchers"] = final_disabled
+                if self.__update_library(library_id, disabled_options):
+                    logger.info(f"{server_name} 已禁用媒体库：{library_name} Danmu插件")
+                else:
+                    logger.error(f"{server_name} 禁用媒体库：{library_name} Danmu插件失败")
+
+    @staticmethod
+    def __movie_name_matches(name: str, expected: Optional[str]) -> bool:
+        """按旧插件约定去掉年份后比较电影名称。"""
+        if not expected:
+            return False
+        match = re.match(r"^(.*?)(?= ?\(\d{4}\)?|$)", name)
+        return bool(match and match.group(1).strip() == expected)
+
+    def __process_series(
+        self,
+        server_name: str,
+        event_data: dict,
+        library_name: str,
+        series: dict,
+        season: Optional[int],
+    ) -> None:
+        """遍历电视剧季，并按命令参数限制处理范围。"""
+        series_id = series.get("Id")
+        if not series_id:
+            return
+        series_name = str(series.get("Name") or "")
+        seasons = self.__get_items(series_id)
+        if not seasons:
+            logger.error(f"{server_name} 获取剧集 {series_name} 的季度列表失败")
+            return
+        for season_item in seasons:
+            if not isinstance(season_item, dict):
+                continue
+            index_number = season_item.get("IndexNumber")
+            if season is not None and str(index_number) != str(season):
+                continue
+            self.__process_season(
+                server_name=server_name,
+                event_data=event_data,
+                library_name=library_name,
+                series_name=series_name,
+                season_item=season_item,
+            )
+
+    def __process_season(
+        self,
+        server_name: str,
+        event_data: dict,
+        library_name: str,
+        series_name: str,
+        season_item: dict,
+    ) -> None:
+        """检查季度弹幕文件，触发 Emby 下载并等待文件落盘。"""
+        season_id = season_item.get("Id")
+        if not season_id:
+            return
+        season_number = season_item.get("IndexNumber")
+        current_count, total_count = self.__check_danmu_exists(season_id, only_check=True)
+        if total_count > 0 and current_count >= total_count:
+            self.__notify(
+                event_data,
+                f"{server_name} {library_name} {series_name} 第{season_number}季 弹幕文件已全部存在：{current_count}/{total_count}",
+            )
+            return
+
+        if not self.__download_danmu(season_id):
+            self.__notify(
+                event_data,
+                f"{server_name} 通知Danmu插件获取 {library_name} {series_name} 第{season_number}季 的弹幕失败",
+            )
+            return
+
+        self.__notify(
+            event_data,
+            f"{server_name} 开始通知Emby下载 {library_name} {series_name} 第{season_number}季 弹幕，异步执行，请耐心等候执行完成消息",
+        )
+        current_count, total_count = self.__check_danmu_exists(season_id, only_check=False)
+        if current_count >= total_count > 0:
+            title = f"{server_name} {library_name} {series_name} 第{season_number}季 弹幕文件已全部下载完成：{current_count}/{total_count}"
+        elif current_count > 0:
+            title = f"{server_name} {library_name} {series_name} 第{season_number}季 弹幕文件未全部下载完成：{current_count}/{total_count}"
+        else:
+            title = f"{server_name} {library_name} {series_name} 第{season_number}季 Emby已配置弹幕源全部匹配弹幕失败"
+        self.__notify(event_data, title)
+
+    def __process_movie(
+        self,
+        server_name: str,
+        event_data: dict,
+        library_name: str,
+        item: dict,
+        special_library: bool,
+    ) -> None:
+        """检查电影弹幕文件，触发 Emby 下载并等待文件落盘。"""
+        item_id = item.get("Id")
+        if not item_id:
+            return
+        item_info = self.__get_item_info(item_id)
+        item_path = item_info.get("Path")
+        if not item_path:
+            logger.error(f"{server_name} 电影 {item.get('Name')} 缺少媒体路径")
+            self.__notify(event_data, f"{server_name} 获取电影：{library_name} {item.get('Name')}详情失败")
+            return
+        parent_path = Path(
+            self.__get_path(str(item_path if special_library else Path(item_path).parent))
+        )
+        pattern = "*.xml"
+        if list(parent_path.glob(pattern)):
+            self.__notify(event_data, f"{server_name} {library_name} {item.get('Name')} 弹幕已下载完成")
+            return
+        if not self.__download_danmu(item_id):
+            self.__notify(
+                event_data,
+                f"{server_name} 通知Danmu插件获取 {library_name} 电影 {item.get('Name')} {item_id} 的弹幕失败",
+            )
+            return
+
+        self.__notify(
+            event_data,
+            f"{server_name} 开始通知Emby下载 {library_name} {item.get('Name')} 弹幕，异步执行，请耐心等候执行完成消息",
+        )
+        if self.__wait_for_movie(parent_path, pattern, item_info):
+            title = f"{server_name} {library_name} {item.get('Name')} 下载弹幕文件成功"
+        else:
+            title = f"{server_name} {library_name} {item.get('Name')} 已配置弹幕源全部匹配弹幕失败"
+        self.__notify(event_data, title)
+
+    def __wait_for_movie(self, parent_path: Path, pattern: str, item_info: dict) -> bool:
+        """轮询电影目录，最多等待三次并在日志明确失败时提前结束。"""
+        for attempt in range(3):
+            if list(parent_path.glob(pattern)):
+                return True
+            if self.__check_all_failed_by_log(
+                item_name=item_info.get("Name"),
+                item_year=item_info.get("ProductionYear"),
+            ):
+                return False
+            if attempt < 2:
+                logger.warning(f"{parent_path} 下未找到弹幕文件：{pattern}，等待5秒后重试 ({2 - attempt}次)")
+                time.sleep(5)
+        return bool(list(parent_path.glob(pattern)))
+
+    def get_state(self) -> bool:
+        """返回插件是否已启用。"""
+        return self._enabled
+
+    def __get_librarys(self) -> List[dict]:
+        """读取 Emby 虚拟媒体库及其弹幕插件开关配置。"""
+        payload = self.__get_json("emby/Library/VirtualFolders/Query")
+        if isinstance(payload, dict):
+            items = payload.get("Items")
+        else:
+            items = payload
+        return [item for item in items or [] if isinstance(item, dict)]
+
+    def __get_path(self, file_path: str) -> str:
+        """按路径边界执行映射，避免 `/media` 错误匹配 `/media2`。"""
+        source_path = Path(file_path)
+        for library_path, target_path in self._paths.items():
+            source = Path(library_path)
+            try:
+                relative = source_path.relative_to(source)
+            except ValueError:
+                continue
+            return str(Path(target_path) / relative)
+        return file_path
+
+    def __update_library(self, library_id: str, library_options: dict) -> bool:
+        """更新 Emby 媒体库的 Danmu 插件开关。"""
+        return self.__post_json(
+            "emby/Library/VirtualFolders/LibraryOptions",
+            {"Id": library_id, "LibraryOptions": library_options},
+            expected_status=(200, 204),
+        )
+
+    def __get_items(
+        self,
+        parent_id: str,
+        name_starts_with: Optional[str] = None,
+    ) -> List[dict]:
+        """读取用户范围下的媒体项，并兼容 Emby 4.8.8 的接口路径。"""
+        if not self._emby_user:
+            return []
+        params: Dict[str, Any] = {"ParentId": parent_id}
+        if name_starts_with:
+            params["NameStartsWith"] = name_starts_with
+        payload = self.__get_json(f"emby/Users/{self._emby_user}/Items", params=params)
+        if payload is None:
+            return self.__get_items_488(parent_id, name_starts_with=name_starts_with)
+        items = payload.get("Items") if isinstance(payload, dict) else []
+        if items and isinstance(items[0], dict) and items[0].get("Type") == "Folder":
+            return self.__get_items_488(parent_id, name_starts_with=name_starts_with)
+        return [item for item in items or [] if isinstance(item, dict)]
+
+    def __get_items_488(
+        self,
+        parent_id: str,
+        name_starts_with: Optional[str] = None,
+    ) -> List[dict]:
+        """读取 Emby 4.8.8 使用的无用户前缀媒体项接口。"""
+        params: Dict[str, Any] = {"ParentId": parent_id}
+        if name_starts_with:
+            params["NameStartsWith"] = name_starts_with
+        payload = self.__get_json("emby/Items", params=params)
+        items = payload.get("Items") if isinstance(payload, dict) else []
+        return [item for item in items or [] if isinstance(item, dict)]
+
+    def __download_danmu(self, item_id: str) -> bool:
+        """通知 Emby Danmu 插件刷新指定项目的弹幕。"""
+        text = self.__get_text(
+            f"api/danmu/{item_id}",
+            params={"option": "Refresh"},
+        )
+        return text.strip().lower() == "ok"
+
+    def __get_item_info(self, item_id: str) -> dict:
+        """读取 Emby 项目路径及日志匹配所需的基础字段。"""
+        if not self._emby_user:
+            return {}
+        payload = self.__get_json(
+            f"emby/Users/{self._emby_user}/Items/{item_id}",
+            params={
+                "fields": "ShareLevel",
+                "ExcludeFields": "Chapters,Overview,People,MediaStreams,Subviews",
+            },
+        )
+        return payload if isinstance(payload, dict) else {}
+
+    def __check_danmu_exists(self, season_id: str, only_check: bool) -> Tuple[int, int]:
+        """统计季度目录中的弹幕文件，并在下载后轮询增量。"""
+        season_items = self.__get_items(season_id)
+        total_count = len(season_items)
+        if not season_items:
+            return 0, 0
+        first_item_id = season_items[0].get("Id")
+        item_info = self.__get_item_info(first_item_id)
+        item_path = item_info.get("Path")
+        if not item_path:
+            return 0, total_count
+        parent_path = Path(self.__get_path(str(Path(item_path).parent)))
+        pattern = "*.xml"
+        if only_check:
+            return len(list(parent_path.glob(pattern))), total_count
+
+        downloaded: set[str] = set()
+        retries = total_count
+        no_increment = 0
+        while len(downloaded) < total_count and retries > 0 and no_increment <= 3:
+            if self.__check_all_failed_by_log(
+                item_name=item_info.get("SeriesName"),
+                item_year=item_info.get("ProductionYear"),
+            ):
+                break
+            current_files = list(parent_path.glob(pattern))
+            before = len(downloaded)
+            downloaded.update(file.name for file in current_files)
+            if len(downloaded) == total_count:
+                break
+            no_increment = 0 if len(downloaded) > before else no_increment + 1
+            retries -= 1
+            if retries > 0 and no_increment <= 3:
+                logger.warning(f"{parent_path} 下弹幕文件：{pattern} 未下载完成，等待5秒后重试 ({retries}次)")
+                time.sleep(5)
+        return len(downloaded), total_count
+
+    def __get_plugins(self) -> List[dict]:
+        """读取 Emby 配置页插件列表。"""
+        payload = self.__get_json(
+            "emby/web/configurationpages",
+            params={"PageType": "PluginConfiguration", "EnableInMainMenu": "true"},
+        )
+        return [item for item in payload or [] if isinstance(item, dict)]
+
+    def __get_plugin_info(self, plugin_id: str) -> dict:
+        """读取指定 Emby 插件配置。"""
+        payload = self.__get_json(f"emby/Plugins/{plugin_id}/Configuration")
+        return payload if isinstance(payload, dict) else {}
+
+    def __get_danmu_source(self) -> List[str]:
+        """读取 Emby Danmu 插件中已启用的弹幕源名称。"""
+        plugins = self.__get_plugins()
+        plugin_id = next(
+            (plugin.get("PluginId") for plugin in plugins if plugin.get("Name") == "danmu"),
+            None,
+        )
+        if not plugin_id:
+            logger.error("弹幕配置插件未安装")
+            return []
+        scrapers = self.__get_plugin_info(plugin_id).get("Scrapers") or []
+        return [
+            str(scraper.get("Name"))
+            for scraper in scrapers
+            if isinstance(scraper, dict) and scraper.get("Enable") is True and scraper.get("Name")
+        ]
+
+    def __get_emby_log(self) -> str:
+        """读取 Emby 最新日志片段，用于识别弹幕源全部失败。"""
+        text = self.__get_text("System/Logs/embyserver.txt")
+        return "\n".join(text.splitlines()[-200:]) if text else ""
+
+    def __check_all_failed_by_log(self, item_name: Any, item_year: Any) -> bool:
+        """判断所有已启用弹幕源是否都报告匹配失败或内容过小。"""
+        emby_log = self.__get_emby_log()
+        if not emby_log or not self._danmu_source:
+            return False
+        name = re.escape(str(item_name or ""))
+        year = re.escape(str(item_year or ""))
+        for source in self._danmu_source:
+            escaped_source = re.escape(str(source))
+            match_failed = rf"\[{escaped_source}\]匹配失败：{name} \({year}\)"
+            content_small = rf"\[{escaped_source}\]弹幕内容少于1KB，忽略处理：.{name}"
+            if not re.search(match_failed, emby_log) or not re.search(content_small, emby_log):
+                return False
+        return True
+
+    def __notify(self, event_data: dict, title: str) -> None:
+        """按远程命令上下文发送一次结果通知。"""
+        self.post_message(
+            channel=event_data.get("channel"),
+            title=title,
+            userid=event_data.get("user"),
+        )
+
+    @staticmethod
+    def get_command() -> List[Dict[str, Any]]:
+        """注册 Emby 弹幕下载远程命令。"""
+        return [
+            {
+                "cmd": "/danmu",
+                "event": EventType.PluginAction,
+                "desc": "emby弹幕下载",
+                "category": "",
+                "data": {"action": "embydanmu"},
+            }
+        ]
+
+    def get_api(self) -> List[Dict[str, Any]]:
+        """本插件没有额外的 MoviePilot JSON API。"""
+        return []
+
+    def get_service(self) -> List[Dict[str, Any]]:
+        """本插件只响应远程命令，不注册后台服务。"""
+        return []
+
+    def get_form(self) -> Tuple[List[dict], Dict[str, Any]]:
+        """返回插件配置表单和默认值。"""
+        helper = self.mediaserver_helper or MediaServerHelper()
+        try:
+            media_servers = [
+                {"title": config.name, "value": config.name}
+                for config in helper.get_configs().values()
+                if config.type == "emby"
+            ]
+        except Exception:
+            media_servers = []
+        return [
+            {
+                "component": "VForm",
+                "content": [
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 6},
+                                "content": [{
+                                    "component": "VSwitch",
+                                    "props": {"model": "enabled", "label": "启用插件"},
+                                }],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 6},
+                                "content": [{
+                                    "component": "VSwitch",
+                                    "props": {"model": "disabled", "label": "是否禁用媒体库的Danmu插件"},
+                                }],
+                            },
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [{
+                            "component": "VCol",
+                            "props": {"cols": 12},
+                            "content": [{
+                                "component": "VSelect",
+                                "props": {
+                                    "multiple": True,
+                                    "chips": True,
+                                    "clearable": True,
+                                    "model": "mediaservers",
+                                    "label": "媒体服务器",
+                                    "items": media_servers,
+                                },
+                            }],
+                        }],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [{
+                            "component": "VCol",
+                            "props": {"cols": 12},
+                            "content": [{
+                                "component": "VTextarea",
+                                "props": {
+                                    "model": "dirs",
+                                    "label": "目录映射关系",
+                                    "rows": 2,
+                                    "placeholder": "emby目录:mp目录（一行一个）",
+                                },
+                            }],
+                        }],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [{
+                            "component": "VCol",
+                            "props": {"cols": 12},
+                            "content": [{
+                                "component": "VAlert",
+                                "props": {
+                                    "type": "info",
+                                    "variant": "tonal",
+                                    "text": "支持交互命令运行: /danmu 媒体库名 媒体名 (季) 或 /danmu 华语电影 或 /danmu 国产剧。 季可选，不填则获取全部季度。",
+                                },
+                            }],
+                        }],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [{
+                            "component": "VCol",
+                            "props": {"cols": 12},
+                            "content": [{
+                                "component": "VAlert",
+                                "props": {
+                                    "type": "info",
+                                    "variant": "tonal",
+                                    "text": "需Emby安装Danmu插件，并启用弹幕功能（https://github.com/fengymi/emby-plugin-danmu）。",
+                                },
+                            }],
+                        }],
+                    },
+                ],
+            }
+        ], {
+            "enabled": False,
+            "disabled": False,
+            "dirs": "",
+            "mediaservers": [],
+        }
+
+    def get_page(self) -> List[dict]:
+        """本插件不提供独立详情页。"""
+        return []
+
+    def stop_service(self) -> None:
+        """清理命令执行状态，避免重载后残留旧媒体库任务标记。"""
+        with self._run_lock:
+            self._library_task.clear()

--- a/plugins.v3/embyextendtype/__init__.py
+++ b/plugins.v3/embyextendtype/__init__.py
@@ -1,0 +1,444 @@
+"""Emby 视频类型检查插件。"""
+
+from __future__ import annotations
+
+import datetime
+import threading
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytz
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+from app.plugins import _PluginBase
+from app.schemas.types import MessageType
+from app.sdk.config import settings
+from app.sdk.logging import logger
+from app.sdk.network import RequestUtils
+from app.sdk.services import MediaServerHelper
+
+
+# 配置、调度和远端服务上下文属于同一插件生命周期，不能拆成互相独立的全局状态。
+# pylint: disable=too-many-instance-attributes
+class EmbyExtendType(_PluginBase):
+    """定期检查选定 Emby 媒体库是否包含配置的视频类型并发送通知。"""
+
+    plugin_name = "Emby视频类型检查"
+    plugin_desc = "定期检查Emby媒体库中是否包含指定的视频类型，发送通知。"
+    plugin_icon = (
+        "https://raw.githubusercontent.com/thsrite/MoviePilot-Plugins/main/icons/extendtype.png"
+    )
+    plugin_version = "2.0.0"
+    plugin_author = "thsrite"
+    author_url = "https://github.com/thsrite"
+    plugin_config_prefix = "embyextendtype_"
+    plugin_order = 30
+    auth_level = 1
+
+    _title = "Emby视频类型检查"
+    _api_path = "emby/ExtendedVideoTypes"
+
+    def __init__(self) -> None:
+        """初始化插件状态和媒体服务器服务门面。"""
+        super().__init__()
+        self._scheduler: Optional[BackgroundScheduler] = None
+        self._run_lock = threading.Lock()
+        self._enabled = False
+        self._onlyonce = False
+        self._notify = False
+        self._cron = ""
+        self._librarys: List[str] = []
+        self._extend = ""
+        self._msgtype: Optional[str] = None
+        self._mediaservers: List[str] = []
+        self._mediaserver_helper = MediaServerHelper()
+        self._emby_host = ""
+        self._emby_api_key = ""
+
+    def init_plugin(self, config: Optional[dict] = None) -> None:
+        """停止旧任务、读取配置并按开关重建后台调度器。"""
+        self.stop_service()
+        config = config or {}
+        self._enabled = bool(config.get("enabled"))
+        self._onlyonce = bool(config.get("onlyonce"))
+        self._notify = bool(config.get("notify"))
+        self._cron = str(config.get("cron") or "").strip()
+        self._librarys = self._normalize_string_list(config.get("librarys"))
+        self._extend = str(config.get("extend") or "").strip()
+        self._msgtype = config.get("msgtype") or MessageType.Manual.name
+        self._mediaservers = self._normalize_string_list(config.get("mediaservers"))
+
+        if not (self._enabled or self._onlyonce):
+            return
+
+        self._scheduler = BackgroundScheduler(timezone=settings.TZ)  # pylint: disable=consider-using-with
+        if self._cron:
+            try:
+                self._scheduler.add_job(
+                    func=self.check_extend,
+                    trigger=CronTrigger.from_crontab(self._cron),
+                    name=self._title,
+                )
+            except Exception as err:  # pylint: disable=broad-exception-caught
+                logger.error(f"定时任务配置错误：{err}")
+                self.systemmessage.put(f"执行周期配置错误：{err}")
+
+        if self._onlyonce:
+            logger.info(f"{self._title}服务启动，立即运行一次")
+            self._scheduler.add_job(
+                func=self.check_extend,
+                trigger="date",
+                run_date=datetime.datetime.now(
+                    tz=pytz.timezone(settings.TZ)
+                ) + datetime.timedelta(seconds=3),
+                name=self._title,
+            )
+            self._onlyonce = False
+            self.__update_config()
+
+        if self._scheduler.get_jobs():
+            self._scheduler.print_jobs()
+            self._scheduler.start()
+
+    def check_extend(self) -> None:
+        """检查选定 Emby 服务的媒体库类型并发送命中通知。"""
+        if not self._run_lock.acquire(blocking=False):  # pylint: disable=consider-using-with
+            logger.warning(f"{self._title}任务正在运行，本次触发已跳过")
+            return
+
+        try:
+            self.__check_extend()
+        finally:
+            self._run_lock.release()
+
+    def __check_extend(self) -> None:
+        """执行一次媒体库类型检查，按服务隔离 Emby 请求上下文。"""
+        extensions = self._parse_extensions(self._extend)
+        if not extensions:
+            logger.error("视频类型为空，不进行检查")
+            return
+
+        emby_servers = self._mediaserver_helper.get_services(
+            name_filters=self._mediaservers,
+            type_filter="emby",
+        )
+        if not emby_servers:
+            logger.error("未配置Emby媒体服务器")
+            return
+
+        for emby_name, emby_server in emby_servers.items():
+            if not emby_server.instance:
+                logger.warning(f"Emby媒体服务器 {emby_name} 未连接")
+                continue
+
+            try:
+                host, api_key = self.__set_server_context(emby_server)
+            except (AttributeError, TypeError, ValueError) as err:
+                logger.error(f"读取 Emby 媒体服务器 {emby_name} 配置失败：{err}")
+                continue
+            if not host or not api_key:
+                logger.warning(f"Emby媒体服务器 {emby_name} 配置不完整")
+                continue
+
+            logger.info(f"开始处理媒体服务器 {emby_name}")
+            try:
+                libraries = emby_server.instance.get_librarys() or []
+            except Exception as err:  # pylint: disable=broad-exception-caught
+                logger.error(f"获取媒体服务器 {emby_name} 媒体库失败：{err}")
+                continue
+            libraries = self._select_libraries(libraries)
+            for library in libraries:
+                library_id = str(library.id or "").strip()
+                library_name = str(library.name or library_id).strip()
+                if not library_id:
+                    logger.warning(f"媒体服务器 {emby_name} 存在缺少 ID 的媒体库，已跳过")
+                    continue
+
+                logger.info(
+                    f"开始检查媒体服务器 {emby_name} 的媒体库 {library_name} "
+                    f"中是否包含 {self._extend} 类型"
+                )
+                library_extensions = self.__get_extend_type(library_id)
+                extension_names = {
+                    str(item.get("Name")).strip()
+                    for item in library_extensions
+                    if isinstance(item, dict) and item.get("Name")
+                }
+                for extension in extensions:
+                    if extension not in extension_names:
+                        continue
+                    logger.info(f"媒体库 {library_name} 中包含 {extension} 类型")
+                    if self._notify:
+                        self.post_message(
+                            title=self._title,
+                            mtype=self._message_type(),
+                            text=f"媒体库 {library_name} 命中 {extension} 视频类型",
+                        )
+                logger.info(f"{emby_name} 媒体库 {library_name} 中全部视频类型检查完毕")
+
+            logger.info(f"{emby_name} 媒体库中全部视频类型检查完毕")
+
+    def __set_server_context(self, emby_server: Any) -> Tuple[str, str]:
+        """读取当前服务的 Emby 地址和 API key，并规范化地址。"""
+        server_config = (
+            emby_server.config.config
+            if emby_server.config and emby_server.config.config
+            else {}
+        )
+        if not isinstance(server_config, dict):
+            raise TypeError("Emby 服务配置不是对象")
+        host = self._normalize_host(server_config.get("host"))
+        api_key = str(server_config.get("apikey") or "").strip()
+        self._emby_host = host
+        self._emby_api_key = api_key
+        return host, api_key
+
+    def __get_extend_type(self, parent_id: str) -> List[dict]:
+        """读取一个 Emby 媒体库的 ExtendedVideoTypes 响应。"""
+        if not self._emby_host or not self._emby_api_key or not parent_id:
+            return []
+
+        response = None
+        try:
+            response = RequestUtils().get_res(
+                url=self._emby_host + self._api_path,
+                params={
+                    "ParentId": parent_id,
+                    "Recursive": "true",
+                    "IncludeItemTypes": "Episode,Movie",
+                    "Limit": 10,
+                    "api_key": self._emby_api_key,
+                },
+            )
+            if response is None or response.status_code != 200:
+                logger.error(f"获取媒体库 {parent_id} 视频类型失败，无法连接Emby")
+                return []
+
+            payload = response.json()
+            if not isinstance(payload, dict) or not isinstance(payload.get("Items"), list):
+                logger.error(f"获取媒体库 {parent_id} 视频类型失败，响应格式无效")
+                return []
+            return payload["Items"]
+        except Exception as err:  # pylint: disable=broad-exception-caught
+            logger.error(f"连接 ExtendedVideoTypes 出错：{err}")
+            return []
+        finally:
+            if response is not None:
+                response.close()
+
+    def __update_config(self) -> None:
+        """保存一次性开关归零后的插件配置。"""
+        self.update_config(
+            {
+                "enabled": self._enabled,
+                "onlyonce": self._onlyonce,
+                "notify": self._notify,
+                "cron": self._cron,
+                "extend": self._extend,
+                "msgtype": self._msgtype,
+                "librarys": self._librarys,
+                "mediaservers": self._mediaservers,
+            }
+        )
+
+    def get_state(self) -> bool:
+        """返回插件是否启用。"""
+        return self._enabled
+
+    @staticmethod
+    def get_command() -> List[Dict[str, Any]]:
+        """该插件不注册远程命令。"""
+        return []
+
+    def get_api(self) -> List[Dict[str, Any]]:
+        """该插件不暴露 MoviePilot REST API。"""
+        return []
+
+    def get_service(self) -> List[Dict[str, Any]]:
+        """调度器由插件生命周期管理，不重复注册宿主服务。"""
+        return []
+
+    def get_form(self) -> Tuple[List[dict], Dict[str, Any]]:
+        """返回插件配置表单和默认配置。"""
+        media_servers = [
+            {"title": config.name, "value": config.name}
+            for config in self._mediaserver_helper.get_configs().values()
+            if config.type == "emby"
+        ]
+        message_types = [
+            {"title": message_type.value, "value": message_type.name}
+            for message_type in MessageType
+        ]
+        return [
+            {
+                "component": "VForm",
+                "content": [
+                    {
+                        "component": "VRow",
+                        "content": [
+                            self._switch("enabled", "启用插件"),
+                            self._switch("onlyonce", "立即运行一次"),
+                            self._switch("notify", "开启通知"),
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 4},
+                                "content": [{
+                                    "component": "VCronField",
+                                    "props": {
+                                        "model": "cron",
+                                        "label": "定时全量同步周期",
+                                        "placeholder": "5位cron表达式，留空关闭",
+                                    },
+                                }],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 4},
+                                "content": [{
+                                    "component": "VSelect",
+                                    "props": {
+                                        "multiple": False,
+                                        "chips": True,
+                                        "model": "msgtype",
+                                        "label": "消息类型",
+                                        "items": message_types,
+                                    },
+                                }],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 4},
+                                "content": [{
+                                    "component": "VTextField",
+                                    "props": {
+                                        "model": "extend",
+                                        "label": "视频类型",
+                                        "placeholder": "多个英文逗号拼接",
+                                    },
+                                }],
+                            },
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [{
+                            "component": "VCol",
+                            "props": {"cols": 12},
+                            "content": [{
+                                "component": "VSelect",
+                                "props": {
+                                    "multiple": True,
+                                    "chips": True,
+                                    "clearable": True,
+                                    "model": "mediaservers",
+                                    "label": "媒体服务器",
+                                    "items": media_servers,
+                                },
+                            }],
+                        }],
+                    },
+                ],
+            }
+        ], {
+            "enabled": False,
+            "onlyonce": False,
+            "notify": False,
+            "cron": "",
+            "extend": "",
+            "msgtype": MessageType.Manual.name,
+            "librarys": [],
+            "mediaservers": [],
+        }
+
+    def get_page(self) -> List[dict]:
+        """该插件不提供详情页。"""
+        return []
+
+    def stop_service(self) -> None:
+        """停止插件调度器，避免热加载遗留后台任务。"""
+        scheduler = self._scheduler
+        self._scheduler = None
+        if not scheduler:
+            return
+        try:
+            scheduler.remove_all_jobs()
+            if scheduler.running:
+                scheduler.shutdown()
+        except Exception as err:  # pylint: disable=broad-exception-caught
+            logger.error(f"退出插件失败：{err}")
+
+    @staticmethod
+    def _normalize_string_list(value: Any) -> List[str]:
+        """把配置中的字符串或列表归一为非空字符串列表。"""
+        if isinstance(value, str):
+            value = [value]
+        if not isinstance(value, (list, tuple, set)):
+            return []
+        return [
+            str(item).strip()
+            for item in value
+            if item is not None and str(item).strip()
+        ]
+
+    @staticmethod
+    def _parse_extensions(value: str) -> List[str]:
+        """解析逗号分隔的视频类型并去重保序。"""
+        return list(dict.fromkeys(item.strip() for item in value.split(",") if item.strip()))
+
+    def _select_libraries(self, libraries: List[Any]) -> List[Any]:
+        """按历史配置筛选媒体库；未配置时保留 V2 的全库扫描行为。"""
+        if not self._librarys:
+            return libraries
+        selected_ids = set()
+        selected_names = set()
+        for value in self._librarys:
+            name, separator, library_id = value.rpartition(" ")
+            if separator and library_id:
+                selected_names.add(name.strip())
+                selected_ids.add(library_id.strip())
+            else:
+                selected_names.add(value)
+        return [
+            library
+            for library in libraries
+            if str(library.id or "").strip() in selected_ids
+            or str(library.name or "").strip() in selected_names
+        ]
+
+    @staticmethod
+    def _normalize_host(value: Any) -> str:
+        """把 Emby 地址规范化为带路径分隔符的 HTTP URL。"""
+        host = str(value or "").strip()
+        if not host:
+            return ""
+        if not host.startswith(("http://", "https://")):
+            host = f"http://{host}"
+        return f"{host.rstrip('/')}/"
+
+    def _message_type(self) -> MessageType:
+        """把配置中的消息类型名称转换为当前 V3 消息枚举。"""
+        if isinstance(self._msgtype, MessageType):
+            return self._msgtype
+        configured = str(self._msgtype or "").strip()
+        if configured:
+            for message_type in MessageType:
+                if configured in {message_type.name, message_type.value}:
+                    return message_type
+        return MessageType.Manual
+
+    @staticmethod
+    def _switch(model: str, label: str) -> dict:
+        """构造配置表单中的开关列。"""
+        return {
+            "component": "VCol",
+            "props": {"cols": 12, "md": 4},
+            "content": [{
+                "component": "VSwitch",
+                "props": {"model": model, "label": label},
+            }],
+        }

--- a/plugins.v3/embyreporter/__init__.py
+++ b/plugins.v3/embyreporter/__init__.py
@@ -1,0 +1,1054 @@
+from __future__ import annotations
+
+import random
+import threading
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from io import BytesIO
+from pathlib import Path
+from typing import Any, Optional
+
+import pytz
+from PIL import Image, ImageDraw, ImageFont
+from apscheduler.triggers.cron import CronTrigger
+
+from app.plugins import _PluginBase
+from app.schemas.types import MessageType
+from app.sdk.config import settings
+from app.sdk.logging import logger
+from app.sdk.network import RequestUtils
+from app.sdk.services import MediaServerHelper
+from app.sdk.utilities import StringUtils
+
+
+@dataclass(frozen=True)
+class _EmbyConnection:
+    """记录一次报告执行所需的 Emby 外部服务连接上下文。"""
+
+    name: str
+    host: str
+    api_key: str
+    user_id: Optional[str] = None
+
+
+class EmbyReporter(_PluginBase):
+    """从 Emby Playback Report 生成观影排行海报并发送通知。"""
+
+    plugin_name = "Emby观影报告"
+    plugin_desc = "推送Emby观影报告，需Emby安装Playback Report插件。"
+    plugin_icon = "Pydiocells_A.png"
+    plugin_version = "3.0.0"
+    plugin_author = "thsrite"
+    author_url = "https://github.com/thsrite"
+    plugin_config_prefix = "embyreporter_"
+    plugin_order = 30
+    auth_level = 1
+
+    PLAYBACK_REPORTING_TYPE_MOVIE = "ItemName"
+    PLAYBACK_REPORTING_TYPE_TVSHOWS = "substr(ItemName,0, instr(ItemName, ' - '))"
+    _REPORT_PART_HEIGHTS = (250, 330, 335)
+
+    def __init__(self) -> None:
+        """初始化插件运行状态；外部连接只在报告执行期间绑定。"""
+        super().__init__()
+        self._enabled = False
+        self._onlyonce = False
+        self._run_once = False
+        self._res_dir = ""
+        self._cron: Optional[str] = None
+        self._days = 7
+        self._type = MessageType.MediaServer.name
+        self._cnt = 10
+        self._mp_host = ""
+        self._emby_host = ""
+        self._emby_api_key = ""
+        self._show_time = True
+        self._mediaservers: list[str] = []
+        self._black_library = ""
+        self._mediaserver_helper: Optional[MediaServerHelper] = None
+        self._connection: Optional[_EmbyConnection] = None
+        self._run_lock = threading.Lock()
+        self._run_once_lock = threading.Lock()
+
+    def init_plugin(self, config: Optional[dict] = None) -> None:
+        """读取配置并准备由宿主调度器管理的报告任务。"""
+        self.stop_service()
+        config = config or {}
+
+        self._enabled = bool(config.get("enabled"))
+        self._onlyonce = bool(config.get("onlyonce"))
+        self._run_once = self._onlyonce
+        self._cron = self._normalize_cron(config.get("cron"))
+        self._res_dir = str(config.get("res_dir") or "").strip()
+        self._days = self._positive_int(config.get("days"), 7)
+        self._cnt = self._positive_int(config.get("cnt"), 10)
+        self._type = str(config.get("type") or MessageType.MediaServer.name)
+        self._mp_host = str(config.get("mp_host") or "").strip()
+        self._show_time = bool(config.get("show_time", True))
+        self._black_library = str(config.get("black_library") or "").strip()
+        self._emby_host = str(config.get("emby_host") or "").strip()
+        self._emby_api_key = str(config.get("emby_api_key") or "").strip()
+        self._mediaservers = [
+            str(name).strip()
+            for name in (config.get("mediaservers") or [])
+            if str(name).strip()
+        ]
+        self._mediaserver_helper = MediaServerHelper()
+
+        if self._run_once:
+            self._onlyonce = False
+            self._save_config()
+
+    @staticmethod
+    def _positive_int(value: Any, default: int) -> int:
+        """把用户配置转换为正整数，非法值回退到稳定默认值。"""
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return default
+        return parsed if parsed > 0 else default
+
+    @staticmethod
+    def _normalize_cron(value: Any) -> Optional[str]:
+        """规范化可选五段 cron 文本，空值表示不注册周期任务。"""
+        normalized = str(value or "").strip()
+        return " ".join(normalized.split()) if normalized else None
+
+    def _save_config(self) -> bool:
+        """保存归一化配置，并让一次性开关只消费一次。"""
+        return self.update_config(
+            {
+                "enabled": self._enabled,
+                "onlyonce": self._onlyonce,
+                "cron": self._cron or "",
+                "res_dir": self._res_dir,
+                "days": self._days,
+                "cnt": self._cnt,
+                "mp_host": self._mp_host,
+                "show_time": self._show_time,
+                "black_library": self._black_library,
+                "emby_host": self._emby_host,
+                "emby_api_key": self._emby_api_key,
+                "mediaservers": self._mediaservers,
+                "type": self._type,
+            }
+        )
+
+    def get_state(self) -> bool:
+        """返回插件是否启用或仍有待执行的一次性任务。"""
+        return self._enabled or self._run_once
+
+    @staticmethod
+    def get_command() -> list[dict[str, Any]]:
+        """本插件不注册远程命令。"""
+        return []
+
+    def get_api(self) -> list[dict[str, Any]]:
+        """本插件不暴露宿主 HTTP API。"""
+        return []
+
+    def get_service(self) -> list[dict[str, Any]]:
+        """按 V3 公共服务合同注册一次性和周期报告任务。"""
+        services: list[dict[str, Any]] = []
+        if self._run_once:
+            services.append(
+                {
+                    "id": "EmbyReporter.Once",
+                    "name": "Emby观影报告（立即运行）",
+                    "trigger": "date",
+                    "func": self._run_once_report,
+                    "kwargs": {
+                        "run_date": datetime.now(
+                            pytz.timezone(str(settings.TZ))
+                        )
+                        + timedelta(seconds=3)
+                    },
+                }
+            )
+
+        if self._enabled and self._cron:
+            try:
+                services.append(
+                    {
+                        "id": "EmbyReporter",
+                        "name": "Emby观影报告",
+                        "trigger": CronTrigger.from_crontab(
+                            self._cron,
+                            timezone=pytz.timezone(str(settings.TZ)),
+                        ),
+                        "func": self.report,
+                        "kwargs": {},
+                    }
+                )
+            except (TypeError, ValueError) as error:
+                logger.error(f"定时任务配置错误：{error}")
+                self.systemmessage.put(f"执行周期配置错误：{error}")
+        return services
+
+    def get_form(self) -> tuple[list[dict], dict[str, Any]]:
+        """返回 V3 Vuetify 配置页和默认配置。"""
+        message_types = [
+            {"title": item.value, "value": item.name} for item in MessageType
+        ]
+        media_server_items = []
+        helper = self._mediaserver_helper or MediaServerHelper()
+        try:
+            media_server_items = [
+                {"title": config.name, "value": config.name}
+                for config in helper.get_configs().values()
+                if config.type == "emby"
+            ]
+        except (RuntimeError, TypeError, AttributeError):
+            # 配置组合根尚未装配时，配置页仍应能返回静态表单。
+            media_server_items = []
+
+        return [
+            {
+                "component": "VForm",
+                "content": [
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 6},
+                                "content": [
+                                    {
+                                        "component": "VSwitch",
+                                        "props": {"model": "enabled", "label": "启用插件"},
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 6},
+                                "content": [
+                                    {
+                                        "component": "VSwitch",
+                                        "props": {
+                                            "model": "onlyonce",
+                                            "label": "立即运行一次",
+                                        },
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 6},
+                                "content": [
+                                    {
+                                        "component": "VCronField",
+                                        "props": {
+                                            "model": "cron",
+                                            "label": "执行周期",
+                                            "placeholder": "5位cron表达式，留空自动",
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 6},
+                                "content": [
+                                    {
+                                        "component": "VTextField",
+                                        "props": {
+                                            "model": "res_dir",
+                                            "label": "素材路径",
+                                            "placeholder": "本地素材路径",
+                                        },
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 6},
+                                "content": [
+                                    {
+                                        "component": "VTextField",
+                                        "props": {
+                                            "model": "days",
+                                            "label": "报告天数",
+                                            "placeholder": "向前获取数据的天数",
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 6},
+                                "content": [
+                                    {
+                                        "component": "VTextField",
+                                        "props": {
+                                            "model": "cnt",
+                                            "label": "观影记录数量",
+                                            "placeholder": "获取观影数据数量，默认10",
+                                        },
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 6},
+                                "content": [
+                                    {
+                                        "component": "VTextField",
+                                        "props": {
+                                            "model": "mp_host",
+                                            "label": "MoviePilot域名",
+                                            "placeholder": "必填，末尾不带/",
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 6},
+                                "content": [
+                                    {
+                                        "component": "VSelect",
+                                        "props": {
+                                            "multiple": False,
+                                            "chips": True,
+                                            "model": "type",
+                                            "label": "推送方式",
+                                            "items": message_types,
+                                        },
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 6},
+                                "content": [
+                                    {
+                                        "component": "VSelect",
+                                        "props": {
+                                            "model": "show_time",
+                                            "label": "是否显示观看时长",
+                                            "items": [
+                                                {"title": "是", "value": True},
+                                                {"title": "否", "value": False},
+                                            ],
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 6},
+                                "content": [
+                                    {
+                                        "component": "VTextField",
+                                        "props": {
+                                            "model": "black_library",
+                                            "label": "黑名单媒体库名称",
+                                            "placeholder": "多个名称用英文逗号分隔",
+                                        },
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 6},
+                                "content": [
+                                    {
+                                        "component": "VTextField",
+                                        "props": {
+                                            "model": "emby_host",
+                                            "label": "自定义emby host",
+                                            "placeholder": "IP:PORT",
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 6},
+                                "content": [
+                                    {
+                                        "component": "VTextField",
+                                        "props": {
+                                            "model": "emby_api_key",
+                                            "label": "自定义emby apiKey",
+                                        },
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12},
+                                "content": [
+                                    {
+                                        "component": "VSelect",
+                                        "props": {
+                                            "multiple": True,
+                                            "chips": True,
+                                            "clearable": True,
+                                            "model": "mediaservers",
+                                            "label": "媒体服务器",
+                                            "items": media_server_items,
+                                        },
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    {
+                        "component": "VAlert",
+                        "props": {
+                            "type": "info",
+                            "variant": "tonal",
+                            "text": "如生成观影报告有空白记录，可酌情调大观影记录数量。",
+                        },
+                    },
+                    {
+                        "component": "VAlert",
+                        "props": {
+                            "type": "info",
+                            "variant": "tonal",
+                            "text": "未设置自定义emby配置时，读取已配置的Emby媒体服务器。",
+                        },
+                    },
+                ],
+            }
+        ], {
+            "enabled": False,
+            "onlyonce": False,
+            "cron": "5 1 * * *",
+            "res_dir": "",
+            "days": 7,
+            "cnt": 10,
+            "emby_host": "",
+            "emby_api_key": "",
+            "mp_host": "",
+            "black_library": "",
+            "show_time": True,
+            "type": "",
+            "mediaservers": [],
+        }
+
+    def get_page(self) -> list[dict]:
+        """本插件没有详情页。"""
+        return []
+
+    def stop_service(self) -> None:
+        """释放插件自有的执行上下文；公共任务由宿主调度器负责撤销。"""
+        self._connection = None
+
+    @staticmethod
+    def _normalize_host(value: Any) -> str:
+        """把 Emby 地址规范化为不带尾部斜杠的 HTTP 基地址。"""
+        host = str(value or "").strip()
+        if not host:
+            return ""
+        if not host.startswith(("http://", "https://")):
+            host = f"http://{host}"
+        return host.rstrip("/")
+
+    def _build_connection(self, name: str, service: Any) -> Optional[_EmbyConnection]:
+        """从 V3 媒体服务器服务投影提取 Emby 外部协议参数。"""
+        config = service.config.config if service.config else {}
+        config = config if isinstance(config, dict) else {}
+        host = self._normalize_host(config.get("host"))
+        api_key = str(config.get("apikey") or "").strip()
+        if not host or not api_key:
+            logger.warning(f"媒体服务器 {name} 配置不完整，跳过观影报告")
+            return None
+
+        user_id = None
+        if service.instance:
+            try:
+                resolved_user = service.instance.get_user()
+                user_id = str(resolved_user) if resolved_user is not None else None
+            except Exception as error:  # 外部媒体服务器实例的用户查询失败不应中断其他服务
+                logger.debug(f"获取媒体服务器 {name} 用户失败：{error}")
+        return _EmbyConnection(
+            name=str(name),
+            host=host,
+            api_key=api_key,
+            user_id=user_id,
+        )
+
+    def _connections(self) -> list[_EmbyConnection]:
+        """按配置返回启用的 Emby 服务，并优先使用完整的旧自定义连接配置。"""
+        custom_host = self._normalize_host(self._emby_host)
+        if custom_host and self._emby_api_key:
+            return [
+                _EmbyConnection(
+                    name="Emby",
+                    host=custom_host,
+                    api_key=self._emby_api_key,
+                )
+            ]
+
+        helper = self._mediaserver_helper or MediaServerHelper()
+        try:
+            services = helper.get_services(
+                name_filters=self._mediaservers,
+                type_filter="emby",
+            )
+        except (RuntimeError, TypeError, AttributeError) as error:
+            logger.error(f"获取Emby媒体服务器失败：{error}")
+            services = {}
+
+        connections = []
+        for name, service in (services or {}).items():
+            connection = self._build_connection(name, service)
+            if connection:
+                connections.append(connection)
+
+        return connections
+
+    def _run_once_report(self) -> None:
+        """消费一次性服务标记，再执行一轮观影报告。"""
+        with self._run_once_lock:
+            if not self._run_once:
+                return
+            self._run_once = False
+        self.report()
+
+    def report(self) -> None:
+        """读取各 Emby 服务的观影记录、生成海报并发送两张排行图片。"""
+        if not self._run_lock.acquire(blocking=False):
+            logger.warning("Emby观影报告任务正在运行，本次触发已跳过")
+            return
+
+        try:
+            self._report()
+        finally:
+            self._run_lock.release()
+
+    def _report(self) -> None:
+        """在 single-flight 门禁内执行一次观影报告。"""
+        if not self._mp_host or not self._type:
+            logger.warning("未配置MoviePilot域名或推送方式，跳过Emby观影报告")
+            return
+
+        connections = self._connections()
+        if not connections:
+            logger.error("未配置Emby媒体服务器")
+            return
+
+        report_time = datetime.now().strftime("%Y%m%d%H%M%S")
+        report_host = self._normalize_host(self._mp_host)
+        message_type = self._message_type()
+        for connection in connections:
+            self._connection = connection
+            try:
+                movie_ok, movies = self.get_report(
+                    types=self.PLAYBACK_REPORTING_TYPE_MOVIE,
+                    days=self._days,
+                    limit=self._cnt,
+                )
+                if not movie_ok:
+                    logger.error(f"{connection.name} 获取电影数据失败：{movies}")
+                    movies = []
+
+                tv_ok, tvshows = self.get_report(
+                    types=self.PLAYBACK_REPORTING_TYPE_TVSHOWS,
+                    days=self._days,
+                    limit=self._cnt,
+                )
+                if not tv_ok:
+                    logger.error(f"{connection.name} 获取电视剧数据失败：{tvshows}")
+                    tvshows = []
+
+                report_path = self.draw(
+                    res_path=self._res_dir,
+                    movies=movies if isinstance(movies, list) else [],
+                    tvshows=tvshows if isinstance(tvshows, list) else [],
+                    show_time=self._show_time,
+                    emby_name=connection.name,
+                )
+                if not report_path:
+                    logger.error(f"{connection.name} 生成观影报告失败")
+                    continue
+
+                safe_name = self._safe_name(connection.name)
+                self.__split_image_by_height(
+                    report_path,
+                    self._public_dir() / f"report_{safe_name}",
+                    self._REPORT_PART_HEIGHTS,
+                )
+                for part_number, title in (
+                    (2, f"Movies 近{self._days}日观影排行"),
+                    (3, f"TV Shows 近{self._days}日观影排行"),
+                ):
+                    relative_path = f"/report_{safe_name}_part_{part_number}.jpg"
+                    report_url = (
+                        f"{report_host}{relative_path}?_timestamp={report_time}"
+                    )
+                    self.post_message(
+                        title=title,
+                        mtype=message_type,
+                        image=report_url,
+                    )
+                    logger.info(f"{connection.name} 观影记录推送成功 {report_url}")
+            finally:
+                self._connection = None
+
+    def _message_type(self) -> MessageType:
+        """把旧配置值和 V3 消息类型名称归一为 MessageType。"""
+        configured = str(self._type or "").strip()
+        for message_type in MessageType:
+            if configured in {message_type.name, message_type.value}:
+                return message_type
+        return MessageType.MediaServer
+
+    @staticmethod
+    def _safe_name(value: Any) -> str:
+        """生成可用于静态报告文件名的媒体服务器名称。"""
+        cleaned = StringUtils.clear_file_name(str(value or "emby")).strip()
+        return cleaned or "emby"
+
+    @staticmethod
+    def _public_dir() -> Path:
+        """返回宿主静态前端目录，报告图片由该目录的 HTTP 静态服务提供。"""
+        configured = Path(str(settings.FRONTEND_PATH or "/public"))
+        if configured.is_absolute():
+            return configured
+        return Path(settings.ROOT_PATH) / configured
+
+    @staticmethod
+    def __split_image_by_height(
+        image_path: str | Path,
+        output_path_prefix: str | Path,
+        heights: tuple[int, ...] | list[int],
+    ) -> list[Path]:
+        """按指定高度切分报告，并返回实际生成的静态图片路径。"""
+        output_path_prefix = Path(output_path_prefix)
+        output_path_prefix.parent.mkdir(parents=True, exist_ok=True)
+        parts: list[Path] = []
+        with Image.open(image_path) as source:
+            image = source.convert("RGB") if source.mode == "RGBA" else source.copy()
+        try:
+            top = 0
+            for index, requested_height in enumerate(heights, start=1):
+                if top >= image.height:
+                    break
+                height = min(max(int(requested_height), 0), image.height - top)
+                if height <= 0:
+                    continue
+                part_path = output_path_prefix.parent / (
+                    f"{output_path_prefix.name}_part_{index}.jpg"
+                )
+                image.crop((0, top, image.width, top + height)).save(part_path)
+                parts.append(part_path)
+                top += height
+        finally:
+            image.close()
+        return parts
+
+    @staticmethod
+    def _load_font(path: Path, size: int) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
+        """加载自定义字体，素材不完整时使用 Pillow 内置字体继续生成报告。"""
+        try:
+            return ImageFont.truetype(str(path), size)
+        except (OSError, IOError):
+            return ImageFont.load_default()
+
+    @staticmethod
+    def _normalize_row(row: Any) -> Optional[tuple[str, str, str, str, int, int]]:
+        """校验 Playback Report 行并转换为绘图所需的稳定标量。"""
+        if not isinstance(row, (list, tuple)) or len(row) < 6:
+            return None
+        try:
+            user_id = str(row[0])
+            item_id = str(row[1])
+            item_type = str(row[2])
+            name = str(row[3])
+            count = int(row[4] or 0)
+            duration = int(float(row[5] or 0))
+        except (TypeError, ValueError):
+            return None
+        if not all((user_id, item_id, name)):
+            return None
+        return user_id, item_id, item_type, name, count, max(duration, 0)
+
+    def _is_blacklisted(self, info: Any) -> bool:
+        """按媒体服务器返回的库名、路径等字段过滤配置中的黑名单文本。"""
+        if not self._black_library or not isinstance(info, dict):
+            return False
+        black_names = [
+            name.strip().casefold()
+            for name in self._black_library.split(",")
+            if name.strip()
+        ]
+        candidates = [
+            str(info.get(key) or "").casefold()
+            for key in ("LibraryName", "CollectionName", "Path", "ParentId")
+        ]
+        return any(
+            black_name in candidate
+            for black_name in black_names
+            for candidate in candidates
+            if candidate
+        )
+
+    def _prepare_entry(
+        self,
+        row: Any,
+        *,
+        movie: bool,
+    ) -> Optional[tuple[str, int, bytes]]:
+        """读取排行行的封面和媒体详情，返回可直接绘制的条目。"""
+        normalized = self._normalize_row(row)
+        if not normalized:
+            return None
+        user_id, item_id, item_type, name, _count, duration = normalized
+        info: Optional[dict] = None
+        if not movie or self._black_library:
+            success, item_info = self.items(user_id, item_id)
+            if not success or not isinstance(item_info, dict):
+                return None
+            info = item_info
+            if self._is_blacklisted(info):
+                logger.info(f"{name} 已在媒体库黑名单中，已过滤")
+                return None
+
+        cover_id = item_id
+        if not movie:
+            cover_id = str((info or {}).get("SeriesId") or "")
+            if not cover_id:
+                return None
+        success, cover = self.primary(cover_id)
+        if not success or not cover:
+            return None
+        return name, duration, cover
+
+    @staticmethod
+    def _layout_entries(
+        movie_entries: list[tuple[str, int, bytes]],
+        tv_entries: list[tuple[str, int, bytes]],
+    ) -> list[tuple[tuple[str, int, bytes], int, int]]:
+        """固定电影和电视剧的独立行，避免电影不足时电视剧填入电影区域。"""
+        return [
+            (entry, column, 0)
+            for column, entry in enumerate(movie_entries)
+        ] + [
+            (entry, column, 331)
+            for column, entry in enumerate(tv_entries)
+        ]
+
+    def draw(
+        self,
+        res_path: str | Path,
+        movies: list[Any],
+        tvshows: list[Any],
+        show_time: bool = True,
+        emby_name: Optional[str] = None,
+    ) -> Optional[Path]:
+        """根据排行数据绘制报告海报并保存到宿主静态目录。"""
+        resource_dir = Path(res_path) if str(res_path or "").strip() else Path(__file__).parent / "res"
+        bg_dir = resource_dir / "bg"
+        mask_path = resource_dir / "cover-ranks-mask-2.png"
+        font_path = resource_dir / "PingFang Bold.ttf"
+        try:
+            backgrounds = [path for path in bg_dir.iterdir() if path.is_file()]
+        except OSError:
+            logger.error(f"观影报告素材目录不存在：{bg_dir}")
+            return None
+        if not backgrounds or not mask_path.is_file():
+            logger.error(f"观影报告素材不完整：{resource_dir}")
+            return None
+
+        movie_entries = [
+            entry
+            for row in movies
+            for entry in [self._prepare_entry(row, movie=True)]
+            if entry
+        ][:5]
+        tv_entries = [
+            entry
+            for row in tvshows
+            for entry in [self._prepare_entry(row, movie=False)]
+            if entry
+        ][:5]
+        layout_entries = self._layout_entries(movie_entries, tv_entries)
+        if not layout_entries:
+            return None
+
+        try:
+            with Image.open(random.choice(backgrounds)) as source:
+                background = source.convert("RGB").copy()
+            with Image.open(mask_path) as mask:
+                background.paste(mask, (0, 0), mask if mask.mode in {"RGBA", "L"} else None)
+            font = self._load_font(font_path, 18)
+            font_small = self._load_font(font_path, 14)
+            font_count = self._load_font(font_path, 8)
+            text_draw = ImageDraw.Draw(background)
+
+            for (name, duration, cover_data), column, offset_y in layout_entries:
+                try:
+                    with Image.open(BytesIO(cover_data)) as cover_source:
+                        cover = cover_source.convert("RGB").resize((108, 159))
+                    background.paste(cover, (73 + 145 * column, 379 + offset_y))
+                    cover.close()
+
+                    display_name = name
+                    display_font = font
+                    font_offset_y = 0
+                    try:
+                        if font.getlength(display_name) > 110:
+                            display_font = font_small
+                            font_offset_y = 4
+                            while len(display_name) > 1 and font_small.getlength(display_name) > 110:
+                                display_name = display_name[:-1]
+                            display_name += ".."
+                    except (AttributeError, UnicodeError):
+                        pass
+                    if show_time:
+                        duration_text = StringUtils.str_secends(duration)
+                        self.draw_text_psd_style(
+                            text_draw,
+                            (
+                                177 + 145 * column - font_count.getlength(duration_text),
+                                355 + offset_y,
+                            ),
+                            duration_text,
+                            font_count,
+                            126,
+                        )
+                    self.draw_text_psd_style(
+                        text_draw,
+                        (74 + 145 * column, 542 + font_offset_y + offset_y),
+                        display_name,
+                        display_font,
+                        126,
+                    )
+                except (OSError, TypeError, ValueError, UnicodeError) as error:
+                    logger.debug(f"绘制观影报告条目失败：{error}")
+
+            public_dir = self._public_dir()
+            public_dir.mkdir(parents=True, exist_ok=True)
+            output_path = public_dir / f"report_{self._safe_name(emby_name)}.jpg"
+            output_path.unlink(missing_ok=True)
+            background.save(output_path, format="JPEG")
+            background.close()
+            return output_path
+        except (OSError, ValueError, TypeError) as error:
+            logger.error(f"保存观影报告失败：{error}")
+            return None
+
+    @staticmethod
+    def draw_text_psd_style(
+        draw: ImageDraw.ImageDraw,
+        xy: tuple[float, float],
+        text: str,
+        font: ImageFont.FreeTypeFont | ImageFont.ImageFont,
+        tracking: float = 0,
+        leading: Optional[float] = None,
+        **kwargs: Any,
+    ) -> None:
+        """按 PSD tracking 语义逐字符绘制文本。"""
+        def stutter_chunk(values: str, size: int, overlap: int = 0) -> Any:
+            step = max(size - overlap, 1)
+            for index in range(0, len(values), step):
+                chunk = list(values[index : index + size])
+                while len(chunk) < size:
+                    chunk.append(" ")
+                yield chunk
+
+        x, y = xy
+        font_size = getattr(font, "size", 12)
+        lines = str(text).splitlines() or [""]
+        leading = leading if leading is not None else font_size * 1.2
+        for line in lines:
+            for first, second in stutter_chunk(line, 2, 1):
+                width = font.getlength(first + second) - font.getlength(second)
+                draw.text((x, y), first, font=font, **kwargs)
+                x += width + (tracking / 1000) * font_size
+            y += leading
+            x = xy[0]
+
+    def _image_request(
+        self,
+        path: str,
+        params: dict[str, Any],
+        *,
+        ret_url: bool = False,
+    ) -> tuple[bool, Any] | str:
+        """请求 Emby 图片并在读取内容后释放 HTTP 响应。"""
+        if not self._connection:
+            return False, "🤕Emby 服务器未连接!"
+        url = f"{self._connection.host}/{path.lstrip('/')}"
+        if ret_url:
+            query = "&".join(f"{key}={value}" for key, value in params.items())
+            return f"{url}?{query}" if query else url
+        response = None
+        try:
+            request_params = dict(params)
+            request_params["api_key"] = self._connection.api_key
+            response = RequestUtils().get_res(url=url, params=request_params)
+            if response is None or response.status_code not in (200, 204):
+                return False, "🤕Emby 服务器连接失败!"
+            return True, response.content
+        except Exception:
+            return False, "🤕Emby 服务器连接失败!"
+        finally:
+            if response is not None:
+                response.close()
+
+    def primary(
+        self,
+        item_id: str,
+        width: int = 720,
+        height: int = 1440,
+        quality: int = 90,
+        ret_url: bool = False,
+    ) -> tuple[bool, Any] | str:
+        """获取 Emby 条目的主海报。"""
+        return self._image_request(
+            f"emby/Items/{item_id}/Images/Primary",
+            {"maxHeight": height, "maxWidth": width, "quality": quality},
+            ret_url=ret_url,
+        )
+
+    def backdrop(
+        self,
+        item_id: str,
+        width: int = 1920,
+        quality: int = 70,
+        ret_url: bool = False,
+    ) -> tuple[bool, Any] | str:
+        """获取 Emby 条目的背景图。"""
+        return self._image_request(
+            f"emby/Items/{item_id}/Images/Backdrop/0",
+            {"maxWidth": width, "quality": quality},
+            ret_url=ret_url,
+        )
+
+    def logo(
+        self,
+        item_id: str,
+        quality: int = 70,
+        ret_url: bool = False,
+    ) -> tuple[bool, Any] | str:
+        """获取 Emby 条目的 Logo 图片。"""
+        return self._image_request(
+            f"emby/Items/{item_id}/Images/Logo",
+            {"quality": quality},
+            ret_url=ret_url,
+        )
+
+    def items(self, user_id: str, item_id: str) -> tuple[bool, Any]:
+        """读取 Emby 用户范围内的媒体条目详情。"""
+        if not self._connection:
+            return False, "🤕Emby 服务器未连接!"
+        response = None
+        try:
+            response = RequestUtils().get_res(
+                url=(
+                    f"{self._connection.host}/emby/Users/{user_id}/Items/{item_id}"
+                ),
+                params={"api_key": self._connection.api_key},
+            )
+            if response is None or response.status_code not in (200, 204):
+                return False, "🤕Emby 服务器连接失败!"
+            return True, response.json()
+        except Exception:
+            return False, "🤕Emby 服务器连接失败!"
+        finally:
+            if response is not None:
+                response.close()
+
+    def get_report(
+        self,
+        days: int,
+        types: Optional[str] = None,
+        user_id: Optional[str] = None,
+        limit: int = 10,
+    ) -> tuple[bool, Any]:
+        """通过 Playback Report 的原生查询接口读取电影或电视剧排行。"""
+        if not self._connection:
+            return False, "🤕Emby 服务器未连接!"
+        report_type = types or self.PLAYBACK_REPORTING_TYPE_MOVIE
+        if report_type not in {
+            self.PLAYBACK_REPORTING_TYPE_MOVIE,
+            self.PLAYBACK_REPORTING_TYPE_TVSHOWS,
+        }:
+            report_type = self.PLAYBACK_REPORTING_TYPE_MOVIE
+        item_type = "Movie" if report_type == self.PLAYBACK_REPORTING_TYPE_MOVIE else "Episode"
+        timezone = pytz.timezone(str(settings.TZ))
+        now = datetime.now(timezone)
+        start_time = (now - timedelta(days=self._positive_int(days, 7))).strftime(
+            "%Y-%m-%d 00:00:00"
+        )
+        end_time = now.strftime("%Y-%m-%d 23:59:59")
+        safe_limit = min(self._positive_int(limit, 10), 100)
+        sql = (
+            "SELECT UserId, ItemId, ItemType, "
+            f"{report_type} AS name, "
+            "COUNT(1) AS play_count, "
+            "SUM(PlayDuration - PauseDuration) AS total_duration "
+            "FROM PlaybackActivity "
+            f"WHERE ItemType = '{item_type}' "
+            f"AND DateCreated >= '{start_time}' AND DateCreated <= '{end_time}' "
+            "AND UserId not IN (select UserId from UserList) "
+        )
+        if user_id:
+            escaped_user_id = str(user_id).replace("'", "''")
+            sql += f"AND UserId = '{escaped_user_id}' "
+        sql += f"GROUP BY name ORDER BY total_duration DESC LIMIT {safe_limit}"
+
+        response = None
+        try:
+            response = RequestUtils().post_res(
+                url=(
+                    f"{self._connection.host}/emby/"
+                    "user_usage_stats/submit_custom_query"
+                ),
+                params={"api_key": self._connection.api_key},
+                data={"CustomQueryString": sql, "ReplaceUserId": False},
+            )
+            if response is None or response.status_code not in (200, 204):
+                return False, "🤕Emby 服务器连接失败!"
+            payload = response.json()
+            if not isinstance(payload, dict):
+                return False, "🤕Emby 返回数据格式错误!"
+            columns = payload.get("colums")
+            if columns is None:
+                columns = payload.get("columns")
+            if not columns:
+                return False, payload.get("message") or "🤕Emby 未返回观影数据!"
+            results = payload.get("results")
+            if not isinstance(results, list):
+                return False, "🤕Emby 返回数据格式错误!"
+            return True, results
+        except Exception:
+            return False, "🤕Emby 服务器连接失败!"
+        finally:
+            if response is not None:
+                response.close()

--- a/tests/v3/embyactorsync/test_plugin.py
+++ b/tests/v3/embyactorsync/test_plugin.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+import ast
+import json
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+BACKEND_ROOT = Path(os.environ["MOVIEPILOT_BACKEND_PATH"])
+sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.testing.bootstrap import prepare_v3_backend
+
+prepare_v3_backend(REPOSITORY_ROOT)
+
+from app.application.chain.context import (
+    ChainRuntimeContext,
+    configure_chain_runtime_context_provider,
+)
+from app.application.chain.data import configure_chain_data_ports
+from app.plugins import embyactorsync as embyactorsync_module
+from app.plugins.embyactorsync import EmbyActorSync
+
+PLUGIN_PATH = REPOSITORY_ROOT / "plugins.v3" / "embyactorsync" / "__init__.py"
+
+configure_chain_data_ports(
+    **{
+        name: lambda: Mock()
+        for name in (
+            "site",
+            "subscribe",
+            "download_history",
+            "transfer_history",
+            "transfer_pending",
+            "transfer_execution",
+            "media_server",
+            "download_failure",
+            "user",
+        )
+    }
+)
+
+
+@pytest.fixture(autouse=True)
+def _chain_runtime_context():
+    """为插件基类提供隔离 Chain 上下文。"""
+    configure_chain_runtime_context_provider(
+        lambda: ChainRuntimeContext(
+            module_manager=Mock(),
+            plugin_manager=Mock(),
+            event_manager=Mock(),
+            message_oper=Mock(),
+            message_helper=Mock(),
+            file_cache=Mock(),
+            async_file_cache=Mock(),
+            message_queue_factory=lambda _callback: Mock(),
+            module_dispatcher_factory=lambda **_kwargs: Mock(),
+        )
+    )
+    yield
+    configure_chain_runtime_context_provider(None)
+
+
+def _imports() -> set[str]:
+    """返回插件源码显式声明的导入模块集合。"""
+    tree = ast.parse(PLUGIN_PATH.read_text(encoding="utf-8"))
+    return {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module
+    }
+
+
+def test_v3_manifest_matches_source_and_disables_legacy_fallback() -> None:
+    """V3 索引、源码版本和旧代回退开关必须保持一致。"""
+    manifest = json.loads(
+        (REPOSITORY_ROOT / "package.v3.json").read_text(encoding="utf-8")
+    )["EmbyActorSync"]
+    package_manifest = json.loads(
+        (REPOSITORY_ROOT / "package.json").read_text(encoding="utf-8")
+    )["EmbyActorSync"]
+    v2_manifest = json.loads(
+        (REPOSITORY_ROOT / "package.v2.json").read_text(encoding="utf-8")
+    )["EmbyActorSync"]
+
+    assert manifest["version"] == EmbyActorSync.plugin_version == "2.0.0"
+    assert manifest["release"] is True
+    assert manifest["system_version"] == ">=3.0.0"
+    assert manifest["history"]["v2.0.0"]
+    assert package_manifest["v3"] is False
+    assert v2_manifest["v3"] is False
+
+
+def test_v3_source_uses_sdk_and_has_no_legacy_imports() -> None:
+    """V3 源码应只通过稳定 SDK 访问宿主能力。"""
+    source = PLUGIN_PATH.read_text(encoding="utf-8")
+    imports = _imports()
+
+    assert {
+        "app.sdk.config",
+        "app.sdk.events",
+        "app.sdk.logging",
+        "app.sdk.network",
+        "app.sdk.services",
+    }.issubset(imports)
+    forbidden_prefixes = (
+        "app.adapters",
+        "app.application",
+        "app.core",
+        "app.db",
+        "app.domain",
+        "app.foundation",
+        "app.helper",
+        "app.runtime",
+        "app.sdk._legacy",
+        "app.utils",
+    )
+    assert not any(module.startswith(forbidden_prefixes) for module in imports)
+    assert "RequestUtils().post(" not in source
+    assert "_EMBY_HOST" not in source
+
+
+class _Response:
+    """提供可观察 close 行为的最小 HTTP 响应替身。"""
+
+    def __init__(self, payload=None, status_code: int = 200, truthy: bool = True):
+        self.payload = payload
+        self.status_code = status_code
+        self.closed = False
+        self._truthy = truthy
+
+    def __bool__(self) -> bool:
+        return self._truthy
+
+    def json(self):
+        return self.payload
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_http_responses_are_closed_for_success_and_falsey_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Emby 读写请求无论结果真假都必须释放响应连接。"""
+    get_response = _Response({"Items": []}, truthy=False)
+    post_response = _Response(status_code=204, truthy=False)
+    request = Mock()
+    request.get_res.return_value = get_response
+    request.post_res.return_value = post_response
+    monkeypatch.setattr(embyactorsync_module, "RequestUtils", lambda **_kwargs: request)
+
+    plugin = EmbyActorSync()
+    context = embyactorsync_module._EmbyContext(
+        name="主 Emby",
+        host="https://emby.example",
+        user="user-id",
+        api_key="secret",
+    )
+
+    assert plugin._EmbyActorSync__get_items(context, "library") == []
+    assert plugin._EmbyActorSync__update_item_info(context, "episode", {}) is True
+    assert get_response.closed is True
+    assert post_response.closed is True
+
+
+def test_sync_copies_season_people_and_locks_cast(monkeypatch: pytest.MonkeyPatch) -> None:
+    """同步应保留季优先级，并在成功更新时锁定演员字段。"""
+    plugin = EmbyActorSync()
+    plugin._enabled = True
+    plugin._mediaservers = ["主 Emby"]
+
+    instance = Mock()
+    instance.get_user.return_value = "user-id"
+    instance.get_librarys.return_value = [
+        SimpleNamespace(id="library", name="剧集", type="电视剧"),
+        SimpleNamespace(id="movies", name="电影", type="电影"),
+    ]
+    plugin.mediaserver_helper = Mock()
+    plugin.mediaserver_helper.get_services.return_value = {
+        "主 Emby": SimpleNamespace(
+            instance=instance,
+            config=SimpleNamespace(
+                config={"host": "emby.example/", "apikey": "secret"}
+            ),
+        )
+    }
+
+    responses = [
+        _Response({"Items": [{"Id": "series", "Name": "示例剧 (2024)"}]}),
+        _Response({"Name": "示例剧", "People": [{"Name": "季演员"}]}),
+        _Response({"Items": [{"Id": "season"}]}),
+        _Response({"Name": "第一季", "People": [{"Name": "季演员"}]}),
+        _Response({"Items": [{"Id": "episode"}]}),
+        _Response({"Name": "第一集", "People": [], "LockedFields": []}),
+    ]
+    request = Mock()
+    request.get_res.side_effect = responses
+    update_response = _Response(status_code=204)
+    request.post_res.return_value = update_response
+    monkeypatch.setattr(embyactorsync_module, "RequestUtils", lambda **_kwargs: request)
+    monkeypatch.setattr(embyactorsync_module.time, "sleep", lambda _seconds: None)
+
+    plugin.sync(library_name="剧集", media_name="示例剧")
+
+    assert len(request.get_res.call_args_list) == 6
+    request.post_res.assert_called_once()
+    payload = request.post_res.call_args.kwargs["json"]
+    assert payload["People"] == [{"Name": "季演员"}]
+    assert payload["LockedFields"] == ["Cast"]
+    assert all(response.closed for response in responses)
+    assert update_response.closed is True
+
+
+def test_missing_people_does_not_clear_episode_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    """剧集和季都没有演员信息时不得向 Emby 写入空值。"""
+    plugin = EmbyActorSync()
+    context = embyactorsync_module._EmbyContext(
+        name="主 Emby",
+        host="https://emby.example",
+        user="user-id",
+        api_key="secret",
+    )
+    plugin._EmbyActorSync__get_item_info = Mock(
+        side_effect=[
+            {"Name": "示例剧", "People": []},
+            {"Name": "第一季", "People": []},
+        ]
+    )
+    plugin._EmbyActorSync__get_items = Mock(
+        side_effect=[
+            [{"Id": "season"}],
+            [{"Id": "episode"}],
+        ]
+    )
+    plugin._EmbyActorSync__update_item_info = Mock()
+
+    plugin._EmbyActorSync__sync_series(context, {"Id": "series", "Name": "示例剧"})
+
+    plugin._EmbyActorSync__update_item_info.assert_not_called()
+
+
+def test_concurrent_sync_is_skipped_and_lock_released() -> None:
+    """并发触发应跳过，任务完成后仍可再次执行。"""
+    plugin = EmbyActorSync()
+    plugin._EmbyActorSync__sync = Mock()
+    assert plugin._run_lock.acquire(blocking=False) is True
+    try:
+        plugin.sync()
+        plugin._EmbyActorSync__sync.assert_not_called()
+    finally:
+        plugin._run_lock.release()
+
+    plugin.sync()
+    plugin._EmbyActorSync__sync.assert_called_once_with(None, None, None)
+
+
+def test_init_without_one_time_service_and_stop_is_idempotent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """无一次性任务时不注册服务，重复停止也应安全。"""
+    helper = Mock()
+    helper.get_configs.return_value = {}
+    monkeypatch.setattr(embyactorsync_module, "MediaServerHelper", lambda: helper)
+    plugin = EmbyActorSync()
+
+    plugin.init_plugin({"enabled": False, "onlyonce": False, "mediaservers": []})
+
+    assert plugin.get_state() is False
+    assert plugin.get_api() == []
+    assert plugin.get_service() == []
+    assert plugin.get_page() == []
+    plugin.stop_service()
+    plugin.stop_service()
+
+
+def test_init_registers_host_managed_one_time_service(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """立即运行任务应通过宿主服务合同注册并消费配置开关。"""
+    monkeypatch.setattr(embyactorsync_module, "MediaServerHelper", Mock)
+    plugin = EmbyActorSync()
+    plugin.update_config = Mock(return_value=True)
+
+    plugin.init_plugin({"enabled": False, "onlyonce": True})
+
+    services = plugin.get_service()
+    assert len(services) == 1
+    assert services[0]["id"] == "EmbyActorSync.Once"
+    assert services[0]["trigger"] == "date"
+    assert services[0]["func"] == plugin._run_once_sync
+    assert plugin.get_state() is True
+    assert plugin._onlyonce is False
+    plugin.update_config.assert_called_once()

--- a/tests/v3/embyaudiobook/test_sdk_contract.py
+++ b/tests/v3/embyaudiobook/test_sdk_contract.py
@@ -1,0 +1,352 @@
+from __future__ import annotations
+
+import ast
+import json
+import os
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+BACKEND_ROOT = Path(os.environ["MOVIEPILOT_BACKEND_PATH"])
+sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.testing.bootstrap import prepare_v3_backend
+
+prepare_v3_backend(REPOSITORY_ROOT)
+
+from app.application.chain.context import (
+    ChainRuntimeContext,
+    configure_chain_runtime_context_provider,
+)
+from app.application.chain.data import configure_chain_data_ports
+from app.plugins import embyaudiobook as embyaudiobook_module
+from app.plugins.embyaudiobook import EmbyAudioBook
+from app.schemas.types import EventType
+from app.sdk.events import Event
+
+
+PLUGIN_PATH = REPOSITORY_ROOT / "plugins.v3" / "embyaudiobook" / "__init__.py"
+
+configure_chain_data_ports(
+    **{
+        name: lambda: Mock()
+        for name in (
+            "site",
+            "subscribe",
+            "download_history",
+            "transfer_history",
+            "transfer_pending",
+            "transfer_execution",
+            "media_server",
+            "download_failure",
+            "user",
+        )
+    }
+)
+
+
+@pytest.fixture(autouse=True)
+def _chain_runtime_context():
+    """为插件基类提供隔离 Chain 上下文，并在用例后恢复全局状态。"""
+    configure_chain_runtime_context_provider(
+        lambda: ChainRuntimeContext(
+            module_manager=Mock(),
+            plugin_manager=Mock(),
+            event_manager=Mock(),
+            message_oper=Mock(),
+            message_helper=Mock(),
+            file_cache=Mock(),
+            async_file_cache=Mock(),
+            message_queue_factory=lambda _callback: Mock(),
+            module_dispatcher_factory=lambda **_kwargs: Mock(),
+        )
+    )
+    yield
+    configure_chain_runtime_context_provider(None)
+
+
+def _imports() -> set[str]:
+    """返回插件源码中显式声明的 from-import 模块集合。"""
+    tree = ast.parse(PLUGIN_PATH.read_text(encoding="utf-8"))
+    return {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module
+    }
+
+
+def _emby_server(name: str = "主 Emby") -> SimpleNamespace:
+    """构造带有完整 V3 服务配置的 Emby 测试替身。"""
+    instance = SimpleNamespace(get_user=lambda: "user-1")
+    config = SimpleNamespace(config={"host": "https://emby.example/", "apikey": "secret"})
+    return SimpleNamespace(name=name, instance=instance, config=config)
+
+
+def test_v3_manifest_and_sdk_contract() -> None:
+    """V3 索引、旧代回退开关和公开 SDK 导入应保持一致。"""
+    manifest = json.loads(
+        (REPOSITORY_ROOT / "package.v3.json").read_text(encoding="utf-8")
+    )["EmbyAudioBook"]
+    legacy_manifest = json.loads(
+        (REPOSITORY_ROOT / "package.v2.json").read_text(encoding="utf-8")
+    )["EmbyAudioBook"]
+    legacy_v1_manifest = json.loads(
+        (REPOSITORY_ROOT / "package.json").read_text(encoding="utf-8")
+    )["EmbyAudioBook"]
+
+    assert manifest["version"] == EmbyAudioBook.plugin_version == "2.0.0"
+    assert manifest["release"] is True
+    assert manifest["system_version"] == ">=3.0.0"
+    assert list(manifest["history"]) == ["v2.0.0"]
+    assert legacy_manifest["v3"] is False
+    assert legacy_v1_manifest["v3"] is False
+
+    imports = _imports()
+    assert {
+        "app.sdk.config",
+        "app.sdk.events",
+        "app.sdk.logging",
+        "app.sdk.network",
+        "app.sdk.services",
+    }.issubset(imports)
+    forbidden_prefixes = (
+        "app.adapters",
+        "app.application",
+        "app.core",
+        "app.db",
+        "app.domain",
+        "app.foundation",
+        "app.helper",
+        "app.log",
+        "app.runtime",
+        "app.sdk._legacy",
+        "app.utils",
+    )
+    assert not any(module.startswith(forbidden_prefixes) for module in imports)
+    source = PLUGIN_PATH.read_text(encoding="utf-8")
+    assert "NotificationType" not in source
+    assert "def audiobook_artist" in source
+
+
+def test_commands_keep_distinct_routes_and_are_v3_events() -> None:
+    """整理和演播作者命令必须分别注册，避免旧实现的同名函数覆盖。"""
+    commands = EmbyAudioBook.get_command()
+
+    assert [(command["cmd"], command["data"]["action"]) for command in commands] == [
+        ("/ab", "audiobook"),
+        ("/aba", "audiobook_artist"),
+    ]
+    assert all(command["event"] is EventType.PluginAction for command in commands)
+
+
+def test_host_and_message_type_normalization() -> None:
+    """服务地址和旧配置中的消息类型值应转换为稳定的 V3 表示。"""
+    plugin = EmbyAudioBook()
+
+    assert plugin._normalize_host("emby.example/") == "http://emby.example/"
+    assert plugin._normalize_host("https://emby.example///") == "https://emby.example/"
+    assert plugin._normalize_host("") == ""
+
+    plugin._msgtype = "Manual"
+    assert plugin._message_type().name == "Manual"
+    plugin._msgtype = "手动处理"
+    assert plugin._message_type().name == "Manual"
+    plugin._msgtype = "not-exists"
+    assert plugin._message_type().name == "Manual"
+
+
+def test_http_response_manager_closes_falsey_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    """SDK 网络返回的假值响应也必须在读取后关闭。"""
+
+    class FalseyResponse:
+        status_code = 200
+
+        def __init__(self) -> None:
+            self.closed = False
+
+        def __bool__(self) -> bool:
+            return False
+
+        def json(self) -> dict:
+            return {"Items": [{"Id": "book-1"}]}
+
+        def close(self) -> None:
+            self.closed = True
+
+    response = FalseyResponse()
+
+    class Request:
+        @contextmanager
+        def response_manager(self, *_args, **_kwargs):
+            try:
+                yield response
+            finally:
+                response.close()
+
+    monkeypatch.setattr(embyaudiobook_module, "RequestUtils", lambda **_kwargs: Request())
+    plugin = EmbyAudioBook()
+    plugin._emby_host = "https://emby.example/"
+    plugin._emby_api_key = "secret"
+
+    assert plugin._EmbyAudioBook__request_json("emby/Artists") == {
+        "Items": [{"Id": "book-1"}]
+    }
+    assert response.closed is True
+
+
+def test_organize_items_updates_missing_metadata_and_extracts_episode_number(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """整理应继承来源剧集元数据，并从中文文件名提取整数集数。"""
+    source = {
+        "Id": "episode-1",
+        "Name": "filename",
+        "Album": "示例有声书",
+        "AlbumId": "album-1",
+        "AlbumPrimaryImageTag": "tag-1",
+        "Artists": ["作者"],
+        "ArtistItems": [{"Id": "artist-1", "Name": "作者"}],
+        "Composers": [{"Id": "artist-1", "Name": "作者"}],
+        "AlbumArtist": "作者",
+        "AlbumArtists": [{"Id": "artist-1", "Name": "作者"}],
+        "ParentIndexNumber": 1,
+    }
+    target = {"Id": "episode-2", "Name": "第12集", "AlbumId": None}
+    plugin = EmbyAudioBook()
+    plugin._EmbyAudioBook__get_item_info = Mock(
+        return_value={"Id": "episode-2", "Name": "filename", "Path": "/audio/第12集.mp3"}
+    )
+    plugin._EmbyAudioBook__update_item_info = Mock(return_value=True)
+    monkeypatch.setattr(embyaudiobook_module.time, "sleep", lambda _seconds: None)
+
+    assert plugin._EmbyAudioBook__organize_items([source, target], 1) is True
+    update_call = plugin._EmbyAudioBook__update_item_info.call_args
+    payload = update_call.args[1]
+    assert update_call.args[0] == "episode-2"
+    assert payload["AlbumId"] == "album-1"
+    assert payload["IndexNumber"] == 12
+    assert payload["Name"] == "第12集"
+    assert payload["LockData"] is True
+
+
+def test_audiobook_artist_command_updates_book_and_episodes() -> None:
+    """演播作者命令应同时更新专辑和剧集，并删除旧作者项目。"""
+    plugin = EmbyAudioBook()
+    plugin._enabled = True
+    plugin._library_id = "library-1"
+    plugin._mediaserver_helper = Mock()
+    plugin._mediaserver_helper.get_services.return_value = {"主 Emby": _emby_server()}
+    plugin._EmbyAudioBook__get_items = Mock(
+        side_effect=[
+            [{"Id": "book-1", "Name": "示例书"}],
+            [{"Id": "episode-1", "Name": "第1集"}],
+        ]
+    )
+    plugin._EmbyAudioBook__get_item_info = Mock(
+        side_effect=[
+            {
+                "Id": "book-1",
+                "ArtistItems": [{"Id": "old-artist", "Name": "旧作者"}],
+            },
+            {"Id": "episode-1", "Name": "第1集"},
+        ]
+    )
+    plugin._EmbyAudioBook__get_artists = Mock(
+        return_value=[{"Id": "new-artist", "Name": "新作者"}]
+    )
+    plugin._EmbyAudioBook__update_item_info = Mock(return_value=True)
+    plugin._EmbyAudioBook__delete_by_id = Mock(return_value=True)
+    plugin.post_message = Mock()
+
+    plugin.audiobook_artist(
+        Event(
+            EventType.PluginAction,
+            {
+                "action": "audiobook_artist",
+                "arg_str": "主 Emby 示例书 新作者",
+                "channel": "telegram",
+                "user": "user-1",
+            },
+        )
+    )
+
+    assert plugin._EmbyAudioBook__update_item_info.call_count == 2
+    plugin._EmbyAudioBook__delete_by_id.assert_called_once_with("old-artist")
+    plugin.post_message.assert_called_once()
+    assert "成功" in plugin.post_message.call_args.kwargs["title"]
+
+
+def test_init_without_enablement_does_not_register_service(monkeypatch: pytest.MonkeyPatch) -> None:
+    """无启用配置时插件仍应完成 V3 生命周期初始化且不注册任务。"""
+    monkeypatch.setattr(embyaudiobook_module, "MediaServerHelper", Mock)
+    plugin = EmbyAudioBook()
+
+    plugin.init_plugin({})
+
+    assert plugin.get_state() is False
+    assert plugin.get_api() == []
+    assert plugin.get_service() == []
+    assert plugin.get_page() == []
+
+
+def test_get_service_registers_host_managed_once_and_cron_jobs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """一次性和周期任务应由宿主调度器注册并使用稳定服务 ID。"""
+    monkeypatch.setattr(embyaudiobook_module, "MediaServerHelper", Mock)
+    plugin = EmbyAudioBook()
+    plugin.update_config = Mock(return_value=True)
+
+    plugin.init_plugin(
+        {
+            "enabled": True,
+            "onlyonce": True,
+            "cron": "5 1 * * *",
+        }
+    )
+
+    services = plugin.get_service()
+    assert [service["id"] for service in services] == [
+        "EmbyAudioBook.Once",
+        "EmbyAudioBook",
+    ]
+    assert services[0]["trigger"] == "date"
+    assert services[0]["func"] == plugin._run_once_check
+    assert services[1]["func"] == plugin.check
+    plugin.update_config.assert_called_once()
+    assert plugin._onlyonce is False
+
+
+def test_init_rebuilds_runtime_dependencies_inside_run_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """配置重载必须等待整理任务结束后再替换共享 Emby 上下文。"""
+
+    class TrackingLock:
+        entered = False
+
+        def __enter__(self):
+            self.entered = True
+            return self
+
+        def __exit__(self, *_args):
+            self.entered = False
+
+    plugin = EmbyAudioBook()
+    lock = TrackingLock()
+    plugin._run_lock = lock
+    helper_created_while_locked = []
+    monkeypatch.setattr(
+        embyaudiobook_module,
+        "MediaServerHelper",
+        lambda: helper_created_while_locked.append(lock.entered) or Mock(),
+    )
+
+    plugin.init_plugin({})
+
+    assert helper_created_while_locked == [True]

--- a/tests/v3/embycollectionsort/test_sdk_contract.py
+++ b/tests/v3/embycollectionsort/test_sdk_contract.py
@@ -1,0 +1,448 @@
+from __future__ import annotations
+
+import ast
+import json
+import os
+import sys
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+BACKEND_ROOT = Path(os.environ["MOVIEPILOT_BACKEND_PATH"])
+sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.testing.bootstrap import prepare_v3_backend
+
+prepare_v3_backend(REPOSITORY_ROOT)
+
+from app.application.chain.context import (
+    ChainRuntimeContext,
+    configure_chain_runtime_context_provider,
+)
+from app.application.chain.data import configure_chain_data_ports
+from app.plugins import embycollectionsort as embycollectionsort_module
+from app.plugins.embycollectionsort import EmbyCollectionSort
+from app.schemas.types import EventType
+
+
+PLUGIN_PATH = REPOSITORY_ROOT / "plugins.v3" / "embycollectionsort" / "__init__.py"
+
+configure_chain_data_ports(
+    **{
+        name: lambda: Mock()
+        for name in (
+            "site",
+            "subscribe",
+            "download_history",
+            "transfer_history",
+            "transfer_pending",
+            "transfer_execution",
+            "media_server",
+            "download_failure",
+            "user",
+        )
+    }
+)
+
+
+@pytest.fixture(autouse=True)
+def _chain_runtime_context():
+    """为插件基类提供隔离的 V3 Chain 上下文。"""
+    configure_chain_runtime_context_provider(
+        lambda: ChainRuntimeContext(
+            module_manager=Mock(),
+            plugin_manager=Mock(),
+            event_manager=Mock(),
+            message_oper=Mock(),
+            message_helper=Mock(),
+            file_cache=Mock(),
+            async_file_cache=Mock(),
+            message_queue_factory=lambda _callback: Mock(),
+            module_dispatcher_factory=lambda **_kwargs: Mock(),
+        )
+    )
+    yield
+    configure_chain_runtime_context_provider(None)
+
+
+def _imports() -> set[str]:
+    """返回插件源码中显式声明的 from-import 模块。"""
+    tree = ast.parse(PLUGIN_PATH.read_text(encoding="utf-8"))
+    return {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module
+    }
+
+
+def test_v3_manifest_matches_source_and_disables_legacy_fallback() -> None:
+    """V3 索引应与源码版本一致，并阻止旧代索引回退加载。"""
+    v3_manifest = json.loads(
+        (REPOSITORY_ROOT / "package.v3.json").read_text(encoding="utf-8")
+    )["EmbyCollectionSort"]
+    assert v3_manifest["version"] == EmbyCollectionSort.plugin_version == "2.0.0"
+    assert v3_manifest["release"] is True
+    assert v3_manifest["system_version"] == ">=3.0.0"
+    assert list(v3_manifest["history"]) == ["v2.0.0"]
+
+    for package_name in ("package.json", "package.v2.json"):
+        legacy_manifest = json.loads(
+            (REPOSITORY_ROOT / package_name).read_text(encoding="utf-8")
+        )["EmbyCollectionSort"]
+        assert legacy_manifest["v3"] is False
+
+
+def test_v3_source_uses_public_sdk_and_host_services() -> None:
+    """V3 源码不得回退到旧代宿主模块或插件自有调度器。"""
+    imports = _imports()
+    assert {
+        "app.plugins",
+        "app.schemas.types",
+        "app.sdk.config",
+        "app.sdk.events",
+        "app.sdk.logging",
+        "app.sdk.network",
+        "app.sdk.services",
+    }.issubset(imports)
+    forbidden_prefixes = (
+        "app.adapters",
+        "app.application",
+        "app.core",
+        "app.db",
+        "app.domain",
+        "app.foundation",
+        "app.helper",
+        "app.modules",
+        "app.runtime",
+        "app.sdk._legacy",
+        "app.utils",
+    )
+    assert not any(module.startswith(forbidden_prefixes) for module in imports)
+
+    source = PLUGIN_PATH.read_text(encoding="utf-8")
+    assert "BackgroundScheduler" not in source
+    assert "settings.EMBY_HOST" not in source
+    assert "settings.EMBY_API_KEY" not in source
+    assert "logger.warn(" not in source
+
+
+def test_datetime_parser_normalizes_emby_variants() -> None:
+    """Emby 时间应统一为无时区 UTC，且截断服务端可能返回的七位小数。"""
+    parse = EmbyCollectionSort._EmbyCollectionSort__parse_emby_datetime
+
+    assert parse("2024-01-02T03:04:05.1234567Z") == datetime(
+        2024, 1, 2, 3, 4, 5, 123456
+    )
+    assert parse("2024-01-02T11:04:05+08:00") == datetime(2024, 1, 2, 3, 4, 5)
+    assert parse("not-an-emby-date") is None
+
+
+def test_sorted_items_filters_invalid_dates_and_sorts_by_premiere() -> None:
+    """排序只处理有完整日期的条目，并按发布日期升序排列。"""
+    plugin = EmbyCollectionSort()
+    item_info = {
+        "item-a": {
+            "Id": "item-a",
+            "Name": "较新电影",
+            "PremiereDate": "2024-02-01T00:00:00Z",
+            "DateCreated": "2024-01-01T00:00:00Z",
+        },
+        "item-b": {
+            "Id": "item-b",
+            "Name": "较早电影",
+            "PremiereDate": "2024-01-01T00:00:00Z",
+            "DateCreated": "2024-01-02T00:00:00Z",
+        },
+        "item-invalid": {
+            "Id": "item-invalid",
+            "PremiereDate": "2024-03-01T00:00:00Z",
+            "DateCreated": "",
+        },
+    }
+    plugin._EmbyCollectionSort__get_item_info = Mock(
+        side_effect=lambda item_id: item_info[item_id]
+    )
+
+    result = plugin._EmbyCollectionSort__sorted_items(
+        [
+            {"Id": "item-a", "Name": "较新电影"},
+            {"Id": "item-b", "Name": "较早电影"},
+            {"Id": "item-invalid", "Name": "无效电影"},
+        ]
+    )
+
+    assert [item["Id"] for item in result] == ["item-b", "item-a"]
+
+
+def test_http_responses_are_closed_and_api_key_stays_in_params(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SDK 返回的响应无论成功与否都应关闭，API key 不应拼入 URL。"""
+
+    class Response:
+        def __init__(self, status_code: int, payload: dict | None = None) -> None:
+            self.status_code = status_code
+            self.payload = payload or {}
+            self.closed = False
+
+        def json(self) -> dict:
+            return self.payload
+
+        def close(self) -> None:
+            self.closed = True
+
+    get_response = Response(200, {"Items": []})
+    post_response = Response(204)
+    class Request:
+        def __init__(self) -> None:
+            self.get_call: tuple[tuple, dict] | None = None
+            self.post_call: tuple[tuple, dict] | None = None
+
+        def get_res(self, *args, **kwargs):
+            self.get_call = args, kwargs
+            return get_response
+
+        def post_res(self, *args, **kwargs):
+            self.post_call = args, kwargs
+            return post_response
+
+        @contextmanager
+        def response_manager(self, *args, **kwargs):
+            """兼容旧实现的上下文入口，同时记录其请求参数供迁移门禁断言。"""
+            if args and str(args[0]).upper() == "GET":
+                self.get_call = args, kwargs
+                response = get_response
+            else:
+                self.post_call = args, kwargs
+                response = post_response
+            try:
+                yield response
+            finally:
+                response.close()
+
+    request = Request()
+    monkeypatch.setattr(embycollectionsort_module, "RequestUtils", lambda **_kwargs: request)
+
+    plugin = EmbyCollectionSort()
+    plugin._EMBY_HOST = "https://emby.example"
+    plugin._EMBY_USER = "user-id"
+    plugin._EMBY_APIKEY = "secret"
+
+    assert plugin._EmbyCollectionSort__get_items("library-id") == []
+    assert get_response.closed is True
+    assert request.get_call is not None
+    get_args, get_kwargs = request.get_call
+    get_url = get_kwargs.get("url") or (get_args[1] if len(get_args) > 1 else "")
+    get_params = get_kwargs.get("params")
+    assert get_url == "https://emby.example/emby/Users/user-id/Items"
+    assert get_params == {"ParentId": "library-id", "api_key": "secret"}
+    assert "api_key" not in get_url
+
+    assert plugin._EmbyCollectionSort__update_item_info("item-id", {"Id": "item-id"})
+    assert post_response.closed is True
+    assert request.post_call is not None
+    post_args, post_kwargs = request.post_call
+    if post_kwargs.get("url"):
+        post_url = post_kwargs["url"]
+    elif len(post_args) >= 3:
+        post_url = post_args[2]
+    else:
+        post_url = post_args[1] if len(post_args) > 1 else ""
+    assert post_url == "https://emby.example/emby/Items/item-id"
+    assert post_kwargs.get("params") == {"api_key": "secret"}
+    assert "api_key" not in post_url
+
+
+def test_sort_collection_writes_descending_created_dates_without_mutating_input() -> None:
+    """合集排序应从现有最大入库时间倒序分配，并保持读取结果不可变。"""
+    plugin = EmbyCollectionSort()
+    plugin._sort_type = "升序"
+    item_info = {
+        "item-a": {
+            "Id": "item-a",
+            "Name": "较新电影",
+            "PremiereDate": "2024-02-01T00:00:00Z",
+            "DateCreated": "2024-01-01T00:00:00Z",
+        },
+        "item-b": {
+            "Id": "item-b",
+            "Name": "较早电影",
+            "PremiereDate": "2024-01-01T00:00:00Z",
+            "DateCreated": "2024-01-02T00:00:00Z",
+        },
+    }
+    plugin._EmbyCollectionSort__get_items = Mock(
+        return_value=[
+            {"Id": "item-a", "Name": "较新电影"},
+            {"Id": "item-b", "Name": "较早电影"},
+        ]
+    )
+    plugin._EmbyCollectionSort__get_item_info = Mock(
+        side_effect=lambda item_id: item_info[item_id]
+    )
+    plugin._EmbyCollectionSort__update_item_info = Mock(return_value=True)
+
+    plugin._EmbyCollectionSort__sort_collection(
+        {"Id": "collection-id", "Name": "示例合集"}, set()
+    )
+
+    updates = plugin._EmbyCollectionSort__update_item_info.call_args_list
+    assert [call.args[0] for call in updates] == ["item-b", "item-a"]
+    assert updates[0].args[1]["DateCreated"] == "2024-01-02T00:00:00.0000000Z"
+    assert updates[1].args[1]["DateCreated"] == "2024-01-01T23:59:59.0000000Z"
+    assert item_info["item-a"]["DateCreated"] == "2024-01-01T00:00:00Z"
+    assert item_info["item-b"]["DateCreated"] == "2024-01-02T00:00:00Z"
+
+
+def test_server_selection_normalizes_connection_and_stop_clears_projection() -> None:
+    """服务投影应从 V3 服务对象读取配置，并在任务结束后清理凭据。"""
+    plugin = EmbyCollectionSort()
+    service = SimpleNamespace(
+        config=SimpleNamespace(config={"host": "emby.example/", "apikey": " secret "}),
+        instance=SimpleNamespace(get_user=Mock(return_value="user-id")),
+    )
+
+    connection = plugin._EmbyCollectionSort__select_server(service)
+
+    assert connection is not None
+    assert connection.host == "http://emby.example"
+    assert connection.user_id == "user-id"
+    assert connection.api_key == "secret"
+    assert plugin._EMBY_HOST == connection.host
+    plugin.stop_service()
+    assert plugin._connection is None
+    assert plugin._EMBY_HOST is None
+    assert plugin._EMBY_USER is None
+    assert plugin._EMBY_APIKEY is None
+
+
+def test_collection_sort_isolates_each_media_server_context() -> None:
+    """多媒体服务器处理不得串用上一台服务的地址、用户或 API key。"""
+    plugin = EmbyCollectionSort()
+    plugin._collection_library_id = "library-id"
+    servers = {
+        "主 Emby": SimpleNamespace(
+            config=SimpleNamespace(config={"host": "emby-one", "apikey": "key-one"}),
+            instance=SimpleNamespace(get_user=Mock(return_value="user-one")),
+        ),
+        "备用 Emby": SimpleNamespace(
+            config=SimpleNamespace(config={"host": "emby-two", "apikey": "key-two"}),
+            instance=SimpleNamespace(get_user=Mock(return_value="user-two")),
+        ),
+    }
+    helper = Mock()
+    helper.get_services.return_value = servers
+    plugin._mediaserver_helper = helper
+    contexts: list[tuple[str | None, str | None, str | None]] = []
+
+    def get_items(_parent_id: str) -> list[dict]:
+        contexts.append((plugin._EMBY_HOST, plugin._EMBY_USER, plugin._EMBY_APIKEY))
+        return []
+
+    plugin._EmbyCollectionSort__get_items = Mock(side_effect=get_items)
+
+    assert plugin.collection_sort() is True
+    assert contexts == [
+        ("http://emby-one", "user-one", "key-one"),
+        ("http://emby-two", "user-two", "key-two"),
+    ]
+    assert plugin._connection is None
+
+
+def test_init_plugin_registers_host_services_without_private_scheduler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """配置初始化应只生成宿主服务描述，不创建插件私有调度器。"""
+
+    class Scheduler:
+        """防止旧实现的私有调度器在合同测试中启动后台线程。"""
+
+        running = False
+
+        def __init__(self, *_args, **_kwargs) -> None:
+            return None
+
+        def remove_all_jobs(self) -> None:
+            return None
+
+        def shutdown(self) -> None:
+            self.running = False
+
+        def add_job(self, *_args, **_kwargs) -> None:
+            return None
+
+        def get_jobs(self) -> list:
+            return []
+
+        def print_jobs(self) -> None:
+            return None
+
+        def start(self) -> None:
+            self.running = True
+
+    monkeypatch.setattr(
+        embycollectionsort_module,
+        "BackgroundScheduler",
+        Scheduler,
+        raising=False,
+    )
+    plugin = EmbyCollectionSort()
+    plugin.update_config = Mock()
+
+    plugin.init_plugin(
+        {
+            "enabled": True,
+            "onlyonce": True,
+            "cron": "*/5 * * * *",
+            "sort_type": "降序",
+            "collection_library_id": "library-id",
+            "mediaservers": ["主 Emby"],
+            "black_collection": "忽略",
+        }
+    )
+
+    services = plugin.get_service()
+    assert {service["id"] for service in services} == {
+        "EmbyCollectionSort.Once",
+        "EmbyCollectionSort",
+    }
+    once_service = next(
+        service
+        for service in services
+        if service["id"] == "EmbyCollectionSort.Once"
+    )
+    assert once_service["trigger"] == "date"
+    assert "run_date" not in once_service
+    assert isinstance(once_service["kwargs"]["run_date"], datetime)
+    assert {
+        service["id"] for service in plugin.get_service()
+    } == {
+        "EmbyCollectionSort.Once",
+        "EmbyCollectionSort",
+    }
+
+    plugin.collection_sort = Mock(return_value=True)
+    assert once_service["func"]() is True
+    plugin.collection_sort.assert_called_once_with()
+    assert {
+        service["id"] for service in plugin.get_service()
+    } == {"EmbyCollectionSort"}
+    assert plugin.get_state() is True
+    assert not hasattr(plugin, "_scheduler")
+    plugin.update_config.assert_called_once_with(
+        {
+            "onlyonce": False,
+            "cron": "*/5 * * * *",
+            "enabled": True,
+            "sort_type": "降序",
+            "collection_library_id": "library-id",
+            "mediaservers": ["主 Emby"],
+            "black_collection": "忽略",
+        }
+    )
+    plugin.stop_service()

--- a/tests/v3/embydanmu/test_embydanmu.py
+++ b/tests/v3/embydanmu/test_embydanmu.py
@@ -1,0 +1,484 @@
+from __future__ import annotations
+
+import ast
+import json
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+BACKEND_ROOT = Path(os.environ["MOVIEPILOT_BACKEND_PATH"])
+sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.testing.bootstrap import prepare_v3_backend
+
+prepare_v3_backend(REPOSITORY_ROOT)
+
+from app.application.chain.context import (
+    ChainRuntimeContext,
+    configure_chain_runtime_context_provider,
+)
+from app.application.chain.data import (
+    configure_chain_data_ports,
+)
+from app.plugins import embydanmu as embydanmu_module
+from app.plugins.embydanmu import EmbyDanmu
+from app.sdk.events import Event
+from app.schemas.types import EventType
+
+PLUGIN_PATH = REPOSITORY_ROOT / "plugins.v3" / "embydanmu" / "__init__.py"
+
+configure_chain_data_ports(
+    **{
+        name: lambda: Mock()
+        for name in (
+            "site",
+            "subscribe",
+            "download_history",
+            "transfer_history",
+            "transfer_pending",
+            "transfer_execution",
+            "media_server",
+            "download_failure",
+            "user",
+        )
+    }
+)
+
+
+@pytest.fixture(autouse=True)
+def _chain_runtime_context():
+    """为插件基类提供隔离 Chain 上下文，并在用例后恢复未配置状态。"""
+    configure_chain_runtime_context_provider(
+        lambda: ChainRuntimeContext(
+            module_manager=Mock(),
+            plugin_manager=Mock(),
+            event_manager=Mock(),
+            message_oper=Mock(),
+            message_helper=Mock(),
+            file_cache=Mock(),
+            async_file_cache=Mock(),
+            message_queue_factory=lambda _callback: Mock(),
+            module_dispatcher_factory=lambda **_kwargs: Mock(),
+        )
+    )
+    yield
+    configure_chain_runtime_context_provider(None)
+
+
+def _imports() -> set[str]:
+    """返回插件源码显式声明的 from-import 模块。"""
+    tree = ast.parse(PLUGIN_PATH.read_text(encoding="utf-8"))
+    return {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module
+    }
+
+
+def _service(
+    *,
+    host: str = "emby.example:8096",
+    api_key: str = "api-key",
+    user: str = "user-1",
+) -> SimpleNamespace:
+    """构造符合 V3 MediaServerHelper 返回结构的最小 Emby 服务。"""
+    return SimpleNamespace(
+        config=SimpleNamespace(config={"host": host, "apikey": api_key}),
+        instance=SimpleNamespace(get_user=Mock(return_value=user)),
+    )
+
+
+def test_v3_manifest_matches_source_and_disables_legacy_fallback() -> None:
+    """V3 索引应与源码版本一致，并阻止旧代实现回退加载。"""
+    manifest = json.loads(
+        (REPOSITORY_ROOT / "package.v3.json").read_text(encoding="utf-8")
+    )["EmbyDanmu"]
+    legacy_v1 = json.loads(
+        (REPOSITORY_ROOT / "package.json").read_text(encoding="utf-8")
+    )["EmbyDanmu"]
+    legacy_v2 = json.loads(
+        (REPOSITORY_ROOT / "package.v2.json").read_text(encoding="utf-8")
+    )["EmbyDanmu"]
+
+    assert manifest["version"] == EmbyDanmu.plugin_version == "3.0.0"
+    assert manifest["release"] is True
+    assert manifest["system_version"] == ">=3.0.0"
+    assert manifest["history"]["v3.0.0"]
+    assert legacy_v1["v3"] is False
+    assert legacy_v2["v3"] is False
+
+
+def test_v3_source_uses_sdk_and_has_no_legacy_imports() -> None:
+    """V3 源码应只依赖公开 SDK，不应回退到宿主旧代导入路径。"""
+    source = PLUGIN_PATH.read_text(encoding="utf-8")
+    imports = _imports()
+
+    assert {
+        "app.plugins",
+        "app.schemas.types",
+        "app.sdk.events",
+        "app.sdk.logging",
+        "app.sdk.network",
+        "app.sdk.services",
+    }.issubset(imports)
+    forbidden_prefixes = (
+        "app.adapters",
+        "app.application",
+        "app.core",
+        "app.db",
+        "app.domain",
+        "app.foundation",
+        "app.helper",
+        "app.runtime",
+        "app.sdk._legacy",
+        "app.utils",
+    )
+    assert not any(module.startswith(forbidden_prefixes) for module in imports)
+    assert "import requests" not in source
+    assert "MediaServerChain" not in source
+
+
+def test_plugin_initializes_without_scheduling(monkeypatch: pytest.MonkeyPatch) -> None:
+    """插件初始化应只重建配置状态，不启动后台服务或外部请求。"""
+    helper = Mock()
+    monkeypatch.setattr(embydanmu_module, "MediaServerHelper", lambda: helper)
+
+    plugin = EmbyDanmu()
+    plugin.init_plugin(
+        {
+            "enabled": True,
+            "disabled": True,
+            "mediaservers": ["主 Emby"],
+            "dirs": "/emby/media:/movie/media\ninvalid\n:/ignored",
+        }
+    )
+
+    assert plugin.get_state() is True
+    assert plugin.get_api() == []
+    assert plugin.get_service() == []
+    assert plugin.get_page() == []
+    assert plugin._paths == {"/emby/media": "/movie/media"}
+    assert plugin._mediaservers == ["主 Emby"]
+    assert plugin._library_task == {}
+    assert plugin.mediaserver_helper is helper
+
+
+def test_server_context_normalizes_host_and_requires_complete_credentials() -> None:
+    """服务发现结果应转换成统一连接上下文，缺任一凭据都不能执行请求。"""
+    plugin = EmbyDanmu()
+
+    assert plugin._EmbyDanmu__set_server_context(_service()) is True
+    assert plugin._emby_host == "http://emby.example:8096/"
+    assert plugin._emby_api_key == "api-key"
+    assert plugin._emby_user == "user-1"
+
+    assert plugin._EmbyDanmu__set_server_context(
+        _service(api_key="", user="user-1")
+    ) is False
+    assert plugin._EmbyDanmu__set_server_context(
+        _service(api_key="api-key", user="")
+    ) is False
+
+
+def test_http_helpers_close_falsey_responses(monkeypatch: pytest.MonkeyPatch) -> None:
+    """错误响应即使布尔值为假也必须释放连接，避免网络连接池泄漏。"""
+
+    class FalseyResponse:
+        status_code = 500
+
+        def __init__(self) -> None:
+            self.closed = False
+
+        def __bool__(self) -> bool:
+            return False
+
+        def close(self) -> None:
+            self.closed = True
+
+    response = FalseyResponse()
+    request = Mock()
+    request.get_res.return_value = response
+    monkeypatch.setattr(embydanmu_module, "RequestUtils", lambda **_kwargs: request)
+
+    plugin = EmbyDanmu()
+    plugin._emby_host = "https://emby.example/"
+    plugin._emby_api_key = "secret"
+
+    assert plugin._EmbyDanmu__get_json("emby/items") is None
+    assert response.closed is True
+
+
+def test_http_helpers_close_successful_text_and_post_responses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """成功的文本读取和 JSON 写入也必须在消费后关闭响应。"""
+    text_response = Mock(status_code=200, text="ok")
+    post_response = Mock(status_code=204)
+    request = Mock()
+    request.get_res.return_value = text_response
+    request.post_res.return_value = post_response
+    monkeypatch.setattr(embydanmu_module, "RequestUtils", lambda **_kwargs: request)
+
+    plugin = EmbyDanmu()
+    plugin._emby_host = "https://emby.example/"
+    plugin._emby_api_key = "secret"
+
+    assert plugin._EmbyDanmu__get_text("api/danmu/item", {"option": "Refresh"}) == "ok"
+    assert plugin._EmbyDanmu__post_json("emby/library", {"Id": "library"}) is True
+    text_response.close.assert_called_once_with()
+    post_response.close.assert_called_once_with()
+    request.get_res.assert_called_once_with(
+        url="https://emby.example/api/danmu/item",
+        params={"option": "Refresh", "api_key": "secret"},
+    )
+    request.post_res.assert_called_once_with(
+        url="https://emby.example/emby/library",
+        params={"api_key": "secret"},
+        json={"Id": "library"},
+    )
+
+
+def test_danmu_rejects_invalid_season_before_service_lookup() -> None:
+    """非法季数应立即通知，不得触发媒体服务器发现。"""
+    plugin = EmbyDanmu()
+    plugin._enabled = True
+    plugin.mediaserver_helper = Mock()
+    plugin.post_message = Mock()
+
+    plugin.danmu(
+        Event(
+            EventType.PluginAction,
+            {"action": "embydanmu", "arg_str": "电影库 示例电影 0"},
+        )
+    )
+
+    plugin.post_message.assert_called_once_with(
+        channel=None,
+        title="季数必须大于 0",
+        userid=None,
+    )
+    plugin.mediaserver_helper.get_services.assert_not_called()
+
+
+def test_danmu_dispatches_selected_server_and_media() -> None:
+    """远程命令应通过 V3 服务门面筛选 Emby，并传递媒体与季数。"""
+    plugin = EmbyDanmu()
+    plugin._enabled = True
+    helper = Mock()
+    helper.get_services.return_value = {"主 Emby": _service()}
+    plugin.mediaserver_helper = helper
+    plugin._EmbyDanmu__get_danmu_source = Mock(return_value=["弹幕源"])
+    plugin._EmbyDanmu__process_server = Mock()
+
+    plugin.danmu(
+        Event(
+            EventType.PluginAction,
+            {
+                "action": "embydanmu",
+                "arg_str": "电影库 示例电影 2",
+                "channel": "telegram",
+                "user": "42",
+            },
+        )
+    )
+
+    helper.get_services.assert_called_once_with(
+        name_filters=[],
+        type_filter="emby",
+    )
+    plugin._EmbyDanmu__process_server.assert_called_once_with(
+        server_name="主 Emby",
+        event_data={
+            "action": "embydanmu",
+            "arg_str": "电影库 示例电影 2",
+            "channel": "telegram",
+            "user": "42",
+        },
+        library_name="电影库",
+        item_name="示例电影",
+        season=2,
+    )
+
+
+def test_danmu_rejects_concurrent_commands_before_switching_server_context() -> None:
+    """长任务运行期间应拒绝新命令，避免共享 Emby 凭据被并发覆盖。"""
+    plugin = EmbyDanmu()
+    plugin._enabled = True
+    plugin.mediaserver_helper = Mock()
+    plugin.post_message = Mock()
+    assert plugin._run_lock.acquire(blocking=False) is True
+
+    try:
+        plugin.danmu(
+            Event(
+                EventType.PluginAction,
+                {
+                    "action": "embydanmu",
+                    "arg_str": "电影库 示例电影",
+                    "channel": "telegram",
+                    "user": "42",
+                },
+            )
+        )
+    finally:
+        plugin._run_lock.release()
+
+    plugin.mediaserver_helper.get_services.assert_not_called()
+    plugin.post_message.assert_called_once_with(
+        channel="telegram",
+        title="已有 Emby 弹幕下载任务正在执行，请稍后重试",
+        userid="42",
+    )
+
+
+def test_process_server_reenables_then_restores_danmu_and_clears_task() -> None:
+    """一次任务结束后，临时启用的 Danmu 开关应恢复且任务锁不能残留。"""
+    plugin = EmbyDanmu()
+    plugin._disabled = True
+    plugin._EmbyDanmu__get_librarys = Mock(
+        return_value=[
+            {
+                "Name": "电影库",
+                "Id": "library-1",
+                "CollectionType": "movies",
+                "LibraryOptions": {"DisabledSubtitleFetchers": ["Danmu", "Other"]},
+            }
+        ]
+    )
+    plugin._EmbyDanmu__get_items = Mock(return_value=[])
+    plugin._EmbyDanmu__update_library = Mock(return_value=True)
+    plugin._EmbyDanmu__notify = Mock()
+
+    plugin._EmbyDanmu__process_server(
+        server_name="主 Emby",
+        event_data={"channel": "telegram", "user": "42"},
+        library_name="电影库",
+        item_name=None,
+        season=None,
+    )
+
+    updates = plugin._EmbyDanmu__update_library.call_args_list
+    assert len(updates) == 2
+    assert updates[0].args[0] == "library-1"
+    assert updates[0].args[1]["DisabledSubtitleFetchers"] == ["Other"]
+    assert updates[1].args[1]["DisabledSubtitleFetchers"] == [
+        "Danmu",
+        "Other",
+    ]
+    assert plugin._library_task == {}
+    plugin._EmbyDanmu__notify.assert_called_once_with(
+        {"channel": "telegram", "user": "42"},
+        "主 Emby 获取媒体库：电影库的媒体列表失败",
+    )
+
+
+def test_process_movie_reports_existing_danmu_without_remote_call(tmp_path: Path) -> None:
+    """电影目录已有弹幕文件时应直接返回，避免重复通知 Emby 下载。"""
+    media_dir = tmp_path / "movie"
+    media_dir.mkdir()
+    (media_dir / "movie.xml").write_text("<d>", encoding="utf-8")
+
+    plugin = EmbyDanmu()
+    plugin._EmbyDanmu__get_item_info = Mock(
+        return_value={"Path": str(media_dir / "movie.mkv")}
+    )
+    plugin._EmbyDanmu__download_danmu = Mock()
+    plugin._EmbyDanmu__notify = Mock()
+
+    plugin._EmbyDanmu__process_movie(
+        server_name="主 Emby",
+        event_data={"channel": "telegram", "user": "42"},
+        library_name="电影库",
+        item={"Id": "movie-1", "Name": "示例电影"},
+        special_library=False,
+    )
+
+    plugin._EmbyDanmu__download_danmu.assert_not_called()
+    plugin._EmbyDanmu__notify.assert_called_once_with(
+        {"channel": "telegram", "user": "42"},
+        "主 Emby 电影库 示例电影 弹幕已下载完成",
+    )
+
+
+def test_process_movie_waits_after_successful_download(tmp_path: Path) -> None:
+    """通知 Emby 成功后应等待文件落盘并发送成功结果。"""
+    media_dir = tmp_path / "movie"
+    media_dir.mkdir()
+    plugin = EmbyDanmu()
+    plugin._EmbyDanmu__get_item_info = Mock(
+        return_value={
+            "Path": str(media_dir / "movie.mkv"),
+            "Name": "示例电影",
+            "ProductionYear": 2024,
+        }
+    )
+    plugin._EmbyDanmu__download_danmu = Mock(return_value=True)
+    plugin._EmbyDanmu__wait_for_movie = Mock(return_value=True)
+    plugin._EmbyDanmu__notify = Mock()
+
+    plugin._EmbyDanmu__process_movie(
+        server_name="主 Emby",
+        event_data={"channel": "telegram", "user": "42"},
+        library_name="电影库",
+        item={"Id": "movie-1", "Name": "示例电影"},
+        special_library=False,
+    )
+
+    plugin._EmbyDanmu__download_danmu.assert_called_once_with("movie-1")
+    plugin._EmbyDanmu__wait_for_movie.assert_called_once_with(
+        media_dir,
+        "*.xml",
+        {
+            "Path": str(media_dir / "movie.mkv"),
+            "Name": "示例电影",
+            "ProductionYear": 2024,
+        },
+    )
+    assert plugin._EmbyDanmu__notify.call_args_list[-1].args[1] == (
+        "主 Emby 电影库 示例电影 下载弹幕文件成功"
+    )
+
+
+def test_process_series_filters_requested_season() -> None:
+    """电视剧命令指定季数时只应处理对应季度。"""
+    plugin = EmbyDanmu()
+    plugin._EmbyDanmu__get_items = Mock(
+        return_value=[
+            {"Id": "season-1", "IndexNumber": 1},
+            {"Id": "season-2", "IndexNumber": 2},
+        ]
+    )
+    plugin._EmbyDanmu__process_season = Mock()
+
+    plugin._EmbyDanmu__process_series(
+        server_name="主 Emby",
+        event_data={},
+        library_name="剧集库",
+        series={"Id": "series-1", "Name": "示例剧集"},
+        season=2,
+    )
+
+    plugin._EmbyDanmu__get_items.assert_called_once_with("series-1")
+    plugin._EmbyDanmu__process_season.assert_called_once_with(
+        server_name="主 Emby",
+        event_data={},
+        library_name="剧集库",
+        series_name="示例剧集",
+        season_item={"Id": "season-2", "IndexNumber": 2},
+    )
+
+
+def test_get_path_uses_path_boundaries() -> None:
+    """目录映射必须区分 `/media` 与 `/media2`，避免替换错误路径。"""
+    plugin = EmbyDanmu()
+    plugin._paths = {"/media": "/mnt/media"}
+
+    assert plugin._EmbyDanmu__get_path("/media/movie/movie.mkv") == (
+        "/mnt/media/movie/movie.mkv"
+    )
+    assert plugin._EmbyDanmu__get_path("/media2/movie.mkv") == "/media2/movie.mkv"

--- a/tests/v3/embyextendtype/test_plugin.py
+++ b/tests/v3/embyextendtype/test_plugin.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import ast
+import json
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+BACKEND_ROOT = Path(os.environ["MOVIEPILOT_BACKEND_PATH"])
+sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.testing.bootstrap import prepare_v3_backend
+
+prepare_v3_backend(REPOSITORY_ROOT)
+
+from app.application.chain.context import (
+    ChainRuntimeContext,
+    configure_chain_runtime_context_provider,
+)
+from app.application.chain.data import configure_chain_data_ports
+from app.plugins import embyextendtype as embyextendtype_module
+from app.plugins.embyextendtype import EmbyExtendType
+from app.schemas.types import MessageType
+
+PLUGIN_PATH = REPOSITORY_ROOT / "plugins.v3" / "embyextendtype" / "__init__.py"
+
+configure_chain_data_ports(
+    **{
+        name: lambda: Mock()
+        for name in (
+            "site",
+            "subscribe",
+            "download_history",
+            "transfer_history",
+            "transfer_pending",
+            "media_server",
+            "download_failure",
+            "user",
+            "transfer_execution",
+        )
+    }
+)
+
+
+@pytest.fixture(autouse=True)
+def _chain_runtime_context():
+    """为插件基类提供隔离 Chain 上下文，并在用例后恢复全局提供器。"""
+    configure_chain_runtime_context_provider(
+        lambda: ChainRuntimeContext(
+            module_manager=Mock(),
+            plugin_manager=Mock(),
+            event_manager=Mock(),
+            message_oper=Mock(),
+            message_helper=Mock(),
+            file_cache=Mock(),
+            async_file_cache=Mock(),
+            message_queue_factory=lambda _callback: Mock(),
+            module_dispatcher_factory=lambda **_kwargs: Mock(),
+        )
+    )
+    yield
+    configure_chain_runtime_context_provider(None)
+
+
+def _imports() -> set[str]:
+    """返回插件源码中显式声明的 from-import 模块。"""
+    tree = ast.parse(PLUGIN_PATH.read_text(encoding="utf-8"))
+    return {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module
+    }
+
+
+def test_v3_manifest_and_strict_sdk_contract() -> None:
+    """V3 索引、旧代回退标记和稳定 SDK 导入应保持一致。"""
+    manifest = json.loads(
+        (REPOSITORY_ROOT / "package.v3.json").read_text(encoding="utf-8")
+    )["EmbyExtendType"]
+    legacy_v1 = json.loads(
+        (REPOSITORY_ROOT / "package.json").read_text(encoding="utf-8")
+    )["EmbyExtendType"]
+    legacy_v2 = json.loads(
+        (REPOSITORY_ROOT / "package.v2.json").read_text(encoding="utf-8")
+    )["EmbyExtendType"]
+
+    assert manifest["version"] == EmbyExtendType.plugin_version == "2.0.0"
+    assert manifest["release"] is True
+    assert manifest["system_version"] == ">=3.0.0"
+    assert list(manifest["history"]) == ["v2.0.0"]
+    assert legacy_v1["v3"] is False
+    assert legacy_v2["v3"] is False
+
+    imports = _imports()
+    assert {
+        "app.sdk.config",
+        "app.sdk.logging",
+        "app.sdk.network",
+        "app.sdk.services",
+    }.issubset(imports)
+    forbidden_prefixes = (
+        "app.adapters",
+        "app.application",
+        "app.core",
+        "app.db",
+        "app.domain",
+        "app.foundation",
+        "app.helper",
+        "app.modules",
+        "app.runtime",
+        "app.sdk._legacy",
+        "app.utils",
+    )
+    assert not any(module.startswith(forbidden_prefixes) for module in imports)
+    source = PLUGIN_PATH.read_text(encoding="utf-8")
+    assert "NotificationType" not in source
+    assert "app.log" not in source
+    assert "api_key=" not in source
+
+
+def test_plugin_initializes_without_scheduling_and_exposes_form(monkeypatch: pytest.MonkeyPatch) -> None:
+    """无启用配置时插件应完成初始化，表单只读取 SDK 媒体服务器配置。"""
+    helper = Mock()
+    helper.get_configs.return_value = {
+        "主 Emby": SimpleNamespace(name="主 Emby", type="emby"),
+        "Jellyfin": SimpleNamespace(name="Jellyfin", type="jellyfin"),
+    }
+    monkeypatch.setattr(embyextendtype_module, "MediaServerHelper", lambda: helper)
+
+    plugin = EmbyExtendType()
+    plugin.init_plugin({})
+
+    form, defaults = plugin.get_form()
+    assert plugin.get_state() is False
+    assert plugin.get_api() == []
+    assert plugin.get_command() == []
+    assert plugin.get_service() == []
+    assert plugin.get_page() == []
+    assert plugin._scheduler is None
+    assert defaults["msgtype"] == "Manual"
+    assert defaults["mediaservers"] == []
+    media_server_select = form[0]["content"][2]["content"][0]["content"][0]
+    assert media_server_select["props"]["items"] == [
+        {"title": "主 Emby", "value": "主 Emby"}
+    ]
+
+
+def test_check_extend_uses_selected_emby_service_and_closes_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """主检查链路应通过服务门面读取媒体库、按配置类型通知并关闭响应。"""
+
+    class FakeResponse:
+        status_code = 200
+
+        def __init__(self) -> None:
+            self.closed = False
+
+        def json(self) -> dict:
+            return {"Items": [{"Name": "喜剧"}]}
+
+        def close(self) -> None:
+            self.closed = True
+
+    response = FakeResponse()
+    request = Mock()
+    request.get_res.return_value = response
+    monkeypatch.setattr(embyextendtype_module, "RequestUtils", lambda: request)
+
+    emby = Mock()
+    emby.get_librarys.return_value = [SimpleNamespace(id="lib-1", name="电影")]
+    service = SimpleNamespace(
+        instance=emby,
+        config=SimpleNamespace(config={"host": "https://emby.example/", "apikey": "key"}),
+    )
+    helper = Mock()
+    helper.get_services.return_value = {"主 Emby": service}
+
+    plugin = EmbyExtendType()
+    plugin._mediaserver_helper = helper
+    plugin._extend = "动作, 喜剧,动作"
+    plugin._notify = True
+    plugin._msgtype = "Organize"
+    plugin.post_message = Mock()
+
+    plugin.check_extend()
+
+    helper.get_services.assert_called_once_with(
+        name_filters=[],
+        type_filter="emby",
+    )
+    emby.get_librarys.assert_called_once_with()
+    request.get_res.assert_called_once_with(
+        url="https://emby.example/emby/ExtendedVideoTypes",
+        params={
+            "ParentId": "lib-1",
+            "Recursive": "true",
+            "IncludeItemTypes": "Episode,Movie",
+            "Limit": 10,
+            "api_key": "key",
+        },
+    )
+    assert response.closed is True
+    plugin.post_message.assert_called_once_with(
+        title="Emby视频类型检查",
+        mtype=MessageType.Organize,
+        text="媒体库 电影 命中 喜剧 视频类型",
+    )
+
+
+def test_check_extend_fails_closed_for_missing_service_or_invalid_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """服务未连接、配置不完整或 Emby 响应无效时不得发送通知。"""
+
+    class FalseyResponse:
+        status_code = 500
+
+        def __init__(self) -> None:
+            self.closed = False
+
+        def __bool__(self) -> bool:
+            return False
+
+        def close(self) -> None:
+            self.closed = True
+
+        def json(self) -> dict:
+            return {"Items": [{"Name": "喜剧"}]}
+
+    response = FalseyResponse()
+    request = Mock()
+    request.get_res.return_value = response
+    monkeypatch.setattr(embyextendtype_module, "RequestUtils", lambda: request)
+
+    emby = Mock()
+    emby.get_librarys.return_value = [SimpleNamespace(id="lib-1", name="电影")]
+    helper = Mock()
+    helper.get_services.return_value = {
+        "断开 Emby": SimpleNamespace(instance=None, config=SimpleNamespace(config={})),
+        "配置错误": SimpleNamespace(
+            instance=emby,
+            config=SimpleNamespace(config={"host": "emby.example"}),
+        ),
+        "主 Emby": SimpleNamespace(
+            instance=emby,
+            config=SimpleNamespace(config={"host": "emby.example", "apikey": "key"}),
+        ),
+    }
+
+    plugin = EmbyExtendType()
+    plugin._mediaserver_helper = helper
+    plugin._extend = "喜剧"
+    plugin._notify = True
+    plugin.post_message = Mock()
+
+    plugin.check_extend()
+
+    assert response.closed is True
+    plugin.post_message.assert_not_called()
+
+
+def test_legacy_library_selection_and_invalid_message_type_are_safe() -> None:
+    """旧配置中的媒体库选择仍可使用，未知消息类型回退为手动处理。"""
+    plugin = EmbyExtendType()
+    plugin._librarys = ["儿童  library-2", "电影 library-1"]
+    libraries = [
+        SimpleNamespace(id="library-1", name="电影"),
+        SimpleNamespace(id="library-2", name="儿童"),
+        SimpleNamespace(id="library-3", name="剧集"),
+    ]
+
+    selected = plugin._select_libraries(libraries)
+
+    assert [library.id for library in selected] == ["library-1", "library-2"]
+    plugin._msgtype = "unknown"
+    assert plugin._message_type() is MessageType.Manual

--- a/tests/v3/embyreporter/test_plugin.py
+++ b/tests/v3/embyreporter/test_plugin.py
@@ -1,0 +1,420 @@
+from __future__ import annotations
+
+import ast
+import json
+import os
+import sys
+from datetime import datetime
+from io import BytesIO
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from PIL import Image
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+BACKEND_ROOT = Path(os.environ["MOVIEPILOT_BACKEND_PATH"])
+sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.testing.bootstrap import prepare_v3_backend
+
+prepare_v3_backend(REPOSITORY_ROOT)
+
+from app.application.chain.context import (
+    ChainRuntimeContext,
+    configure_chain_runtime_context_provider,
+)
+from app.application.chain.data import configure_chain_data_ports
+from app.plugins import embyreporter as embyreporter_module
+from app.plugins.embyreporter import EmbyReporter
+from app.schemas.types import MessageType
+
+PLUGIN_PATH = REPOSITORY_ROOT / "plugins.v3" / "embyreporter" / "__init__.py"
+
+configure_chain_data_ports(
+    **{
+        name: lambda: Mock()
+        for name in (
+            "site",
+            "subscribe",
+            "download_history",
+            "transfer_history",
+            "transfer_pending",
+            "transfer_execution",
+            "media_server",
+            "download_failure",
+            "user",
+        )
+    }
+)
+
+
+@pytest.fixture(autouse=True)
+def _chain_runtime_context():
+    """为插件基类提供隔离 Chain 上下文，并在用例后恢复全局提供器。"""
+    configure_chain_runtime_context_provider(
+        lambda: ChainRuntimeContext(
+            module_manager=Mock(),
+            plugin_manager=Mock(),
+            event_manager=Mock(),
+            message_oper=Mock(),
+            message_helper=Mock(),
+            file_cache=Mock(),
+            async_file_cache=Mock(),
+            message_queue_factory=lambda _callback: Mock(),
+            module_dispatcher_factory=lambda **_kwargs: Mock(),
+        )
+    )
+    yield
+    configure_chain_runtime_context_provider(None)
+
+
+def _imports() -> set[str]:
+    """返回插件源码中显式声明的 from-import 模块。"""
+    tree = ast.parse(PLUGIN_PATH.read_text(encoding="utf-8"))
+    return {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module
+    }
+
+
+def _find_props(form: object, model: str) -> dict:
+    """从 Vuetify 表单树中查找指定 model 的 props。"""
+    if isinstance(form, dict):
+        props = form.get("props")
+        if isinstance(props, dict) and props.get("model") == model:
+            return props
+        for value in form.values():
+            found = _find_props(value, model)
+            if found:
+                return found
+    elif isinstance(form, list):
+        for value in form:
+            found = _find_props(value, model)
+            if found:
+                return found
+    return {}
+
+
+def test_v3_manifest_and_strict_sdk_contract() -> None:
+    """V3 索引、旧代回退标记和稳定 SDK 导入应保持一致。"""
+    manifest = json.loads(
+        (REPOSITORY_ROOT / "package.v3.json").read_text(encoding="utf-8")
+    )["EmbyReporter"]
+    legacy_v1 = json.loads(
+        (REPOSITORY_ROOT / "package.json").read_text(encoding="utf-8")
+    )["EmbyReporter"]
+    legacy_v2 = json.loads(
+        (REPOSITORY_ROOT / "package.v2.json").read_text(encoding="utf-8")
+    )["EmbyReporter"]
+
+    assert manifest["version"] == EmbyReporter.plugin_version == "3.0.0"
+    assert manifest["release"] is True
+    assert manifest["system_version"] == ">=3.0.0"
+    assert manifest["history"]["v3.0.0"]
+    assert legacy_v1["v3"] is False
+    assert legacy_v2["v3"] is False
+
+    imports = _imports()
+    assert {
+        "app.sdk.config",
+        "app.sdk.logging",
+        "app.sdk.network",
+        "app.sdk.services",
+        "app.sdk.utilities",
+    }.issubset(imports)
+    forbidden_prefixes = (
+        "app.adapters",
+        "app.application",
+        "app.core",
+        "app.db",
+        "app.domain",
+        "app.foundation",
+        "app.helper",
+        "app.log",
+        "app.runtime",
+        "app.sdk._legacy",
+        "app.utils",
+    )
+    assert not any(module.startswith(forbidden_prefixes) for module in imports)
+    source = PLUGIN_PATH.read_text(encoding="utf-8")
+    assert "BackgroundScheduler" not in source
+    assert "NotificationType" not in source
+
+
+def test_init_exposes_host_services_for_periodic_and_one_shot_runs() -> None:
+    """周期和一次性任务都应通过宿主服务目录注册，而非自建调度器。"""
+    plugin = EmbyReporter()
+    plugin.update_config = Mock(return_value=True)
+
+    plugin.init_plugin({"enabled": False, "onlyonce": True})
+    assert plugin.get_state() is True
+    once_services = plugin.get_service()
+    assert len(once_services) == 1
+    assert once_services[0]["id"] == "EmbyReporter.Once"
+    assert once_services[0]["trigger"] == "date"
+    assert isinstance(once_services[0]["kwargs"]["run_date"], datetime)
+
+    plugin.report = Mock()
+    once_services[0]["func"]()
+    once_services[0]["func"]()
+    plugin.report.assert_called_once_with()
+    assert plugin.get_state() is False
+    assert plugin.get_service() == []
+
+    plugin.init_plugin({"enabled": True, "cron": "5 1 * * *", "type": "Manual"})
+    services = plugin.get_service()
+    assert len(services) == 1
+    assert services[0]["id"] == "EmbyReporter"
+    assert services[0]["func"] == plugin.report
+    assert services[0]["kwargs"] == {}
+
+
+def test_form_reads_only_emby_services(monkeypatch: pytest.MonkeyPatch) -> None:
+    """配置页的媒体服务器选项应来自 SDK 服务配置门面。"""
+    helper = Mock()
+    helper.get_configs.return_value = {
+        "主 Emby": SimpleNamespace(name="主 Emby", type="emby"),
+        "Jellyfin": SimpleNamespace(name="Jellyfin", type="jellyfin"),
+    }
+    monkeypatch.setattr(embyreporter_module, "MediaServerHelper", lambda: helper)
+
+    plugin = EmbyReporter()
+    plugin.init_plugin({})
+    form, defaults = plugin.get_form()
+
+    assert plugin.get_page() == []
+    assert plugin.get_api() == []
+    assert plugin.get_command() == []
+    assert defaults["mediaservers"] == []
+    assert _find_props(form, "mediaservers")["items"] == [
+        {"title": "主 Emby", "value": "主 Emby"}
+    ]
+
+
+def test_connections_prefer_complete_custom_legacy_configuration() -> None:
+    """完整的旧自定义 Emby 配置应覆盖服务发现结果。"""
+    helper = Mock()
+    plugin = EmbyReporter()
+    plugin._mediaserver_helper = helper
+    plugin._emby_host = "emby.example/"
+    plugin._emby_api_key = "custom-key"
+
+    assert plugin._connections() == [
+        embyreporter_module._EmbyConnection(
+            name="Emby",
+            host="http://emby.example",
+            api_key="custom-key",
+        )
+    ]
+    helper.get_services.assert_not_called()
+
+
+def test_connections_project_selected_service_and_normalize_host() -> None:
+    """没有自定义配置时应通过 SDK 服务发现并保留 Emby 用户 ID。"""
+    service = SimpleNamespace(
+        config=SimpleNamespace(config={"host": "https://emby.example/", "apikey": "key"}),
+        instance=SimpleNamespace(get_user=lambda: "user-1"),
+    )
+    helper = Mock()
+    helper.get_services.return_value = {"主 Emby": service}
+    plugin = EmbyReporter()
+    plugin._mediaserver_helper = helper
+    plugin._mediaservers = ["主 Emby"]
+
+    assert plugin._connections() == [
+        embyreporter_module._EmbyConnection(
+            name="主 Emby",
+            host="https://emby.example",
+            api_key="key",
+            user_id="user-1",
+        )
+    ]
+    helper.get_services.assert_called_once_with(
+        name_filters=["主 Emby"],
+        type_filter="emby",
+    )
+
+
+def test_http_responses_are_closed_even_when_falsey(monkeypatch: pytest.MonkeyPatch) -> None:
+    """SDK HTTP 返回的错误或假值响应也必须释放连接。"""
+
+    class FalseyResponse:
+        status_code = 500
+
+        def __init__(self) -> None:
+            self.closed = False
+
+        def __bool__(self) -> bool:
+            return False
+
+        def close(self) -> None:
+            self.closed = True
+
+    response = FalseyResponse()
+    request = Mock()
+    request.get_res.return_value = response
+    monkeypatch.setattr(embyreporter_module, "RequestUtils", lambda: request)
+
+    plugin = EmbyReporter()
+    plugin._connection = embyreporter_module._EmbyConnection(
+        name="Emby", host="https://emby.example", api_key="secret"
+    )
+
+    assert plugin.primary("item-1") == (False, "🤕Emby 服务器连接失败!")
+    assert response.closed is True
+
+
+def test_get_report_sanitizes_user_id_caps_limit_and_closes_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Playback Report 查询应限制结果数量、转义用户 ID 并释放响应。"""
+
+    class Response:
+        status_code = 200
+
+        def __init__(self) -> None:
+            self.closed = False
+
+        def json(self) -> dict:
+            return {"colums": ["name"], "results": [["u", "i", "Movie", "片名", 1, 60]]}
+
+        def close(self) -> None:
+            self.closed = True
+
+    response = Response()
+    request = Mock()
+    request.post_res.return_value = response
+    monkeypatch.setattr(embyreporter_module, "RequestUtils", lambda: request)
+
+    plugin = EmbyReporter()
+    plugin._connection = embyreporter_module._EmbyConnection(
+        name="Emby", host="https://emby.example", api_key="secret"
+    )
+
+    success, results = plugin.get_report(
+        days=7,
+        types=plugin.PLAYBACK_REPORTING_TYPE_TVSHOWS,
+        user_id="user'1",
+        limit=1000,
+    )
+
+    assert success is True
+    assert results
+    assert response.closed is True
+    request.post_res.assert_called_once()
+    query = request.post_res.call_args.kwargs["data"]["CustomQueryString"]
+    assert "ItemType = 'Episode'" in query
+    assert "UserId = 'user''1'" in query
+    assert "LIMIT 100" in query
+    assert request.post_res.call_args.kwargs["params"] == {"api_key": "secret"}
+
+
+def test_report_sends_two_images_per_server_and_uses_safe_public_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """报告执行应按媒体服务器隔离文件名，并发送电影和电视剧两张切片。"""
+    plugin = EmbyReporter()
+    plugin._mp_host = "https://moviepilot.example/"
+    plugin._type = MessageType.MediaServer.name
+    plugin._days = 7
+    plugin._show_time = True
+    plugin._connections = Mock(
+        return_value=[
+            embyreporter_module._EmbyConnection(
+                name="主/Emby", host="https://emby.example", api_key="secret"
+            )
+        ]
+    )
+    plugin.get_report = Mock(
+        side_effect=[(True, [["u", "m", "Movie", "电影", 1, 60]]), (True, [])]
+    )
+    report_path = tmp_path / "report.jpg"
+    report_path.write_bytes(b"placeholder")
+    plugin.draw = Mock(return_value=report_path)
+    split = Mock()
+    monkeypatch.setattr(
+        EmbyReporter,
+        "_public_dir",
+        staticmethod(lambda: tmp_path),
+    )
+    monkeypatch.setattr(
+        EmbyReporter,
+        "_EmbyReporter__split_image_by_height",
+        staticmethod(split),
+    )
+    plugin.post_message = Mock()
+
+    plugin.report()
+
+    split.assert_called_once_with(
+        report_path,
+        tmp_path / "report_主Emby",
+        plugin._REPORT_PART_HEIGHTS,
+    )
+    calls = plugin.post_message.call_args_list
+    assert len(calls) == 2
+    assert calls[0].kwargs["title"] == "Movies 近7日观影排行"
+    assert calls[1].kwargs["title"] == "TV Shows 近7日观影排行"
+    assert all(call.kwargs["mtype"] is MessageType.MediaServer for call in calls)
+    assert calls[0].kwargs["image"].startswith(
+        "https://moviepilot.example/report_主Emby_part_2.jpg?_timestamp="
+    )
+    assert calls[1].kwargs["image"].startswith(
+        "https://moviepilot.example/report_主Emby_part_3.jpg?_timestamp="
+    )
+    assert calls[0].kwargs["image"].split("?_timestamp=")[-1]
+    assert calls[0].kwargs["image"].split("?_timestamp=")[-1] == calls[1].kwargs[
+        "image"
+    ].split("?_timestamp=")[-1]
+
+
+def test_layout_keeps_tv_entries_on_the_second_row_when_movies_are_sparse() -> None:
+    """电影不足五条时，电视剧仍必须从电视剧行的第一列开始绘制。"""
+    layout = EmbyReporter._layout_entries(
+        [("电影", 60, b"movie")],
+        [("剧集", 120, b"tv")],
+    )
+
+    assert [(entry[0], column, offset_y) for entry, column, offset_y in layout] == [
+        ("电影", 0, 0),
+        ("剧集", 0, 331),
+    ]
+
+
+def test_draw_and_split_report_with_packaged_reference_assets(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """绘图链路应能使用仓库提供的报告素材并生成可切分的 JPEG。"""
+    cover = BytesIO()
+    Image.new("RGB", (108, 159), "#336699").save(cover, format="PNG")
+
+    plugin = EmbyReporter()
+    monkeypatch.setattr(
+        EmbyReporter,
+        "_public_dir",
+        staticmethod(lambda: tmp_path),
+    )
+    plugin.primary = Mock(return_value=(True, cover.getvalue()))
+    plugin.items = Mock(return_value=(True, {"SeriesId": "series-1"}))
+
+    report_path = plugin.draw(
+        REPOSITORY_ROOT / "data" / "EmbyReporter" / "res",
+        movies=[["user-1", "movie-1", "Movie", "电影", 1, 60]],
+        tvshows=[["user-1", "episode-1", "Episode", "剧集", 1, 120]],
+        emby_name="主/Emby",
+    )
+
+    assert report_path == tmp_path / "report_主Emby.jpg"
+    assert report_path.is_file()
+    parts = EmbyReporter._EmbyReporter__split_image_by_height(
+        report_path,
+        tmp_path / "report_主Emby",
+        EmbyReporter._REPORT_PART_HEIGHTS,
+    )
+    assert len(parts) == 3
+    assert all(part.is_file() for part in parts)


### PR DESCRIPTION
## 目标

完成第五批 MoviePilot V3 严格迁移，将六个 Emby 相关个人仓插件切换到独立 V3 实现。

## 主要变化

- 新增 `EmbyReporter`、`EmbyDanmu`、`EmbyExtendType`、`EmbyAudioBook`、`EmbyCollectionSort` 和 `EmbyActorSync` 的独立 V3 实现。
- `EmbyReporter` 与 `EmbyDanmu` 迁移到公开 SDK 网络能力和宿主调度服务，收口报告、弹幕任务与响应释放边界。
- `EmbyExtendType`、`EmbyAudioBook` 和 `EmbyCollectionSort` 迁移媒体服务器发现、通知、整理及多实例处理合同。
- `EmbyActorSync` 收紧演员同步生命周期、网络资源释放和定时任务注册行为。
- 同步插件版本、发布历史、代际路由和聚焦测试；`EmbyReporter`、`EmbyDanmu` 发布为 `3.0.0`，其余四个插件发布为 `2.0.0`。

## 关键边界

- V3 生产实现不使用 `app.sdk._legacy`，不直接访问宿主 Model、Session 或非公开应用层入口。
- Emby 外部请求、媒体服务器实例和定时任务按当前宿主服务合同管理；无法确认目标实例或响应状态时不推断成功。
- 测试按当前 Chain 数据端口与运行上下文合同构造替身，所有外部调用均使用 mock，不产生真实出站请求。

## 验证

- Batch 05 聚焦测试及 CI 合同测试：`61 passed`
- 插件版本门禁通过
- `package.json`、`package.v2.json`、`package.v3.json` JSON 解析通过
- 6 个新增 V3 插件目录编译通过
- replay 生产树一致性、非公开宿主导入扫描、代际路由断言和 `git diff --check` 通过
