### PR TITLE
feat: 完成第七批 MoviePilot V3 插件迁移

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "icon": "https://raw.githubusercontent.com/thsrite/MoviePilot-Plugins/main/icons/create.png",
     "author": "thsrite",
     "level": 1,
+    "v3": false,
     "v2": true,
     "history": {
       "v4.4.2": "fix bug",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "author": "thsrite",
     "level": 1,
     "v2": true,
+    "v3": false,
     "history": {
       "v1.1.4": "fix",
       "v1.1.3": "支持[目录实时监控]插件联动",

--- a/package.json
+++ b/package.json
@@ -418,6 +418,7 @@
     "author": "thsrite",
     "level": 1,
     "v2": true,
+    "v3": false,
     "history": {
       "v1.3": "自定义保留消息天数",
       "v1.2": "多个容器名,拼接",

--- a/package.json
+++ b/package.json
@@ -397,6 +397,7 @@
     "author": "thsrite",
     "level": 1,
     "v2": true,
+    "v3": false,
     "history": {
       "v1.7": "自定义通知关键词",
       "v1.6": "自定义保留消息天数",

--- a/package.v3.json
+++ b/package.v3.json
@@ -13,6 +13,20 @@
       "v5.0.0": "严格适配 MoviePilot V3，修复路径映射、索引和调度边界。"
     }
   },
+  "CloudStrmIncrement": {
+    "name": "云盘Strm生成（增量版）",
+    "description": "扫描增量目录，归档文件并生成Strm文件。",
+    "labels": "云盘",
+    "version": "2.0.0",
+    "icon": "https://raw.githubusercontent.com/thsrite/MoviePilot-Plugins/main/icons/create.png",
+    "author": "thsrite",
+    "level": 1,
+    "release": true,
+    "system_version": ">=3.0.0",
+    "history": {
+      "v2.0.0": "适配 V3 SDK、宿主调度和安全增量文件处理合同。"
+    }
+  },
   "StrmConvert": {
     "name": "Strm文件模式转换",
     "description": "Strm文件内容转为本地路径或者cd2/alist API路径。",

--- a/package.v3.json
+++ b/package.v3.json
@@ -474,5 +474,19 @@
     },
     "system_version": ">=3.0.0",
     "release": true
+  },
+  "CustomCommand": {
+    "name": "自定义命令",
+    "description": "自定义执行周期执行命令并推送结果。",
+    "labels": "自定义命令",
+    "version": "2.0.0",
+    "icon": "https://raw.githubusercontent.com/thsrite/MoviePilot-Plugins/main/icons/code.png",
+    "author": "thsrite",
+    "level": 1,
+    "release": true,
+    "system_version": ">=3.0.0",
+    "history": {
+      "v2.0.0": "适配 V3 SDK、宿主调度和可靠命令执行合同。"
+    }
   }
 }

--- a/package.v3.json
+++ b/package.v3.json
@@ -488,5 +488,19 @@
     "history": {
       "v2.0.0": "适配 V3 SDK、宿主调度和可靠命令执行合同。"
     }
+  },
+  "DockerManager": {
+    "name": "docker自定义任务",
+    "description": "管理宿主机docker，自定义容器定时任务。",
+    "labels": "自定义命令",
+    "version": "2.0.0",
+    "icon": "Docker_F.png",
+    "author": "thsrite",
+    "level": 1,
+    "release": true,
+    "system_version": ">=3.0.0",
+    "history": {
+      "v2.0.0": "适配 V3 SDK、宿主调度和 Docker client 生命周期。"
+    }
   }
 }

--- a/package.v3.json
+++ b/package.v3.json
@@ -1,4 +1,18 @@
 {
+  "CloudStrm": {
+    "name": "云盘Strm生成",
+    "description": "定时扫描云盘文件，生成Strm文件。",
+    "labels": "云盘",
+    "version": "5.0.0",
+    "icon": "https://raw.githubusercontent.com/thsrite/MoviePilot-Plugins/main/icons/create.png",
+    "author": "thsrite",
+    "level": 1,
+    "release": true,
+    "system_version": ">=3.0.0",
+    "history": {
+      "v5.0.0": "严格适配 MoviePilot V3，修复路径映射、索引和调度边界。"
+    }
+  },
   "StrmConvert": {
     "name": "Strm文件模式转换",
     "description": "Strm文件内容转为本地路径或者cd2/alist API路径。",

--- a/plugins.v3/cloudstrm/__init__.py
+++ b/plugins.v3/cloudstrm/__init__.py
@@ -1,0 +1,846 @@
+"""提供云盘文件扫描、STRM 生成和处理索引维护能力。"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+import threading
+import urllib.parse
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional, Tuple
+
+import pytz
+from apscheduler.triggers.cron import CronTrigger
+from apscheduler.triggers.date import DateTrigger
+
+from app.plugins import _PluginBase
+from app.schemas.types import EventType
+from app.sdk.config import settings
+from app.sdk.events import Event, eventmanager
+from app.sdk.logging import logger
+
+
+@dataclass(frozen=True)
+class MonitorConfig:
+    """一条源目录到输出目录的稳定路径映射。"""
+
+    source_dir: Path
+    target_dir: Path
+    library_dir: Optional[Path] = None
+    cloud_type: Optional[str] = None
+    cloud_path: Optional[Path] = None
+    cloud_url: Optional[str] = None
+
+
+# 配置字段与已发布键一一对应，路径映射和执行开关不能合并为隐式状态。
+# pylint: disable=too-many-instance-attributes
+class CloudStrm(_PluginBase):
+    """扫描云盘挂载目录并在媒体库目标目录生成 STRM 文件。"""
+
+    plugin_name = "云盘Strm生成"
+    plugin_desc = "定时扫描云盘文件，生成Strm文件。"
+    plugin_icon = (
+        "https://raw.githubusercontent.com/thsrite/"
+        "MoviePilot-Plugins/main/icons/create.png"
+    )
+    plugin_version = "5.0.0"
+    plugin_author = "thsrite"
+    author_url = "https://github.com/thsrite"
+    plugin_config_prefix = "cloudstrm_"
+    plugin_order = 26
+    auth_level = 1
+
+    _enabled = False
+    _cron = ""
+    _rebuild_cron = ""
+    _monitor_confs = ""
+    _onlyonce = False
+    _copy_files = False
+    _rebuild = False
+    _https = False
+    _monitors: list[MonitorConfig] = []
+    _cloud_files: set[str] = set()
+    _cloud_files_json: Path
+
+    def __init__(self) -> None:
+        """初始化实例级状态，避免热重载复用可变缓存或并发锁。"""
+        super().__init__()
+        self._run_lock = threading.Lock()
+        self._once_lock = threading.Lock()
+        self._run_once = False
+        self._monitors = []
+        self._cloud_files = set()
+        self._cloud_files_json = Path()
+
+    def init_plugin(self, config: dict = None) -> None:
+        """读取配置并把周期任务交给宿主服务投影。"""
+        config = config or {}
+        enabled = bool(config.get("enabled"))
+        cron = str(config.get("cron") or "").strip()
+        rebuild_cron = str(config.get("rebuild_cron") or "").strip()
+        monitor_confs = str(config.get("monitor_confs") or "")
+        onlyonce = bool(config.get("onlyonce"))
+        copy_files = bool(config.get("copy_files"))
+        rebuild = bool(config.get("rebuild"))
+        https = bool(config.get("https"))
+        monitors = self.__parse_monitor_confs(monitor_confs)
+        cloud_files_json = self.get_data_path() / "cloud_files.json"
+
+        # 配置切换必须等待在途文件写入结束，保证一次扫描只观察一套映射和开关。
+        with self._run_lock:
+            self._enabled = enabled
+            self._cron = cron
+            self._rebuild_cron = rebuild_cron
+            self._monitor_confs = monitor_confs
+            self._onlyonce = onlyonce
+            self._run_once = onlyonce
+            self._copy_files = copy_files
+            self._rebuild = rebuild
+            self._https = https
+            self._monitors = monitors
+            self._cloud_files = set()
+            self._cloud_files_json = cloud_files_json
+
+        if (enabled or onlyonce) and not monitors:
+            logger.warning("未获取到可用目录监控配置，请检查")
+
+    @staticmethod
+    def __normalise_path(value: str | Path) -> Path:
+        """把配置和事件路径规范化为绝对路径，后续映射只按组件比较。"""
+        return Path(os.path.abspath(os.path.expanduser(str(value).strip())))
+
+    @classmethod
+    def __parse_monitor_confs(  # pylint: disable=too-many-locals
+        cls, monitor_confs: str
+    ) -> list[MonitorConfig]:
+        """解析旧配置的本地媒体库、CD2 和 Alist 三种映射格式。"""
+        monitors: list[MonitorConfig] = []
+        for raw_line in monitor_confs.splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+
+            parts = [part.strip() for part in line.split("#")]
+            try:
+                if len(parts) == 3:
+                    source_dir, target_dir, library_dir = parts
+                    if not source_dir or not target_dir or not library_dir:
+                        raise ValueError("本地映射缺少路径")
+                    monitor = MonitorConfig(
+                        source_dir=cls.__normalise_path(source_dir),
+                        target_dir=cls.__normalise_path(target_dir),
+                        library_dir=cls.__normalise_path(library_dir),
+                    )
+                elif len(parts) == 5:
+                    source_dir, target_dir, cloud_type, cloud_path, cloud_url = parts
+                    cloud_type = cloud_type.casefold()
+                    if cloud_type not in {"cd2", "alist"}:
+                        raise ValueError(f"不支持的云盘类型 {cloud_type}")
+                    if not source_dir or not target_dir or not cloud_path or not cloud_url:
+                        raise ValueError("云盘映射缺少必要配置")
+                    monitor = MonitorConfig(
+                        source_dir=cls.__normalise_path(source_dir),
+                        target_dir=cls.__normalise_path(target_dir),
+                        cloud_type=cloud_type,
+                        cloud_path=cls.__normalise_path(cloud_path),
+                        cloud_url=cloud_url,
+                    )
+                else:
+                    raise ValueError("格式应包含 2 或 4 个 # 分隔符")
+            except ValueError as error:
+                logger.error(f"{line} 格式错误：{error}")
+                continue
+
+            source_root = monitor.source_dir.resolve(strict=False)
+            target_root = monitor.target_dir.resolve(strict=False)
+            if target_root == source_root or target_root.is_relative_to(source_root):
+                logger.error(f"{monitor.target_dir} 是监控目录 {monitor.source_dir} 的子目录，无法监控")
+                continue
+            monitors.append(monitor)
+        return monitors
+
+    @staticmethod
+    def __relative_path(root: Path, path: Path) -> Optional[Path]:
+        """按路径组件获取相对路径，拒绝同名前缀但非子目录的路径。"""
+        try:
+            return path.relative_to(root)
+        except ValueError:
+            return None
+
+    @classmethod
+    def __safe_target_path(cls, target_root: Path, relative_path: Path) -> Optional[Path]:
+        """确保目标父目录解析后仍位于目标根内，阻止符号链接逃逸。"""
+        if relative_path.is_absolute() or ".." in relative_path.parts:
+            return None
+        target_path = target_root.joinpath(relative_path)
+        try:
+            resolved_root = target_root.resolve(strict=False)
+            resolved_parent = target_path.parent.resolve(strict=False)
+            if not resolved_parent.is_relative_to(resolved_root):
+                return None
+        except OSError:
+            return None
+        return target_path
+
+    @staticmethod
+    def __skip_component(name: str) -> bool:
+        """识别隐藏、回收站和不应进入媒体库的附属目录。"""
+        return name.startswith(".") or name.casefold() in {
+            "@recycle",
+            "#recycle",
+            "@eadir",
+            "extrafanart",
+        }
+
+    @classmethod
+    def __skip_path(cls, path: Path, source_root: Path) -> bool:
+        """按源根的相对组件过滤隐藏文件和受保护目录。"""
+        relative_path = cls.__relative_path(source_root, path)
+        return relative_path is None or any(
+            cls.__skip_component(part) for part in relative_path.parts
+        )
+
+    def __iter_files(self, monitor: MonitorConfig) -> Iterator[Path]:
+        """以确定性顺序遍历源目录，并在遍历层面剪枝受保护目录。"""
+        source_root = monitor.source_dir
+        if not source_root.is_dir():
+            logger.error(f"监控目录不存在或不是目录：{source_root}")
+            return
+
+        for root, dirs, files in os.walk(str(source_root), topdown=True, followlinks=False):
+            root_path = Path(root)
+            dirs[:] = sorted(
+                name
+                for name in dirs
+                if not self.__skip_component(name)
+                and not (root_path / name).is_symlink()
+            )
+            for name in sorted(files):
+                path = root_path / name
+                if self.__skip_path(path, source_root):
+                    logger.info(f"{path} 是回收站或隐藏的文件，跳过处理")
+                    continue
+                if path.is_symlink() or not path.is_file():
+                    logger.info(f"{path} 不是普通文件，跳过处理")
+                    continue
+                if not self._copy_files and path.suffix.casefold() not in self.__media_extensions():
+                    continue
+                yield path
+
+    @staticmethod
+    def __media_extensions() -> set[str]:
+        """读取宿主公开媒体扩展名并统一大小写。"""
+        return {str(extension).casefold() for extension in settings.RMT_MEDIAEXT}
+
+    def __find_monitor(self, source_file: Path) -> Optional[MonitorConfig]:
+        """选择最长匹配的监控根，避免相邻或嵌套路径误配。"""
+        matches = [
+            monitor
+            for monitor in self._monitors
+            if self.__relative_path(monitor.source_dir, source_file) is not None
+        ]
+        return max(matches, key=lambda monitor: len(monitor.source_dir.parts), default=None)
+
+    @staticmethod
+    def __service_url(scheme: str, cloud_url: str) -> Optional[Tuple[str, str]]:
+        """规范化云盘服务地址，并返回基础 URL 与主机组件。"""
+        raw_url = cloud_url.strip()
+        parsed = urllib.parse.urlsplit(
+            raw_url if "://" in raw_url else f"{scheme}://{raw_url}"
+        )
+        if not parsed.netloc:
+            return None
+        base_url = f"{scheme}://{parsed.netloc}{parsed.path.rstrip('/')}"
+        return base_url, parsed.netloc
+
+    def __build_strm_content(  # pylint: disable=too-many-return-statements
+        self,
+        monitor: MonitorConfig,
+        source_file: Path,
+        dest_file: Path,
+    ) -> Optional[str]:
+        """根据映射模式生成媒体服务器可读取的本地路径或云盘 URL。"""
+        relative_path = self.__relative_path(monitor.source_dir, source_file)
+        if relative_path is None:
+            return None
+
+        scheme = "https" if self._https else "http"
+        if monitor.cloud_type:
+            if monitor.cloud_path is None or monitor.cloud_url is None:
+                return None
+            cloud_relative = self.__relative_path(monitor.cloud_path, source_file)
+            if cloud_relative is None:
+                logger.error(f"文件 {source_file} 不在云盘挂载根 {monitor.cloud_path} 内")
+                return None
+            service = self.__service_url(scheme, monitor.cloud_url)
+            if service is None:
+                logger.error(f"云盘服务地址无效：{monitor.cloud_url}")
+                return None
+            base_url, host = service
+            cloud_path = "/" + cloud_relative.as_posix().lstrip("/")
+            encoded_path = urllib.parse.quote(cloud_path, safe="")
+            if monitor.cloud_type == "cd2":
+                return f"{base_url}/static/{scheme}/{host}/False/{encoded_path}"
+            if monitor.cloud_type == "alist":
+                return f"{base_url}/d/{encoded_path}"
+            return None
+
+        if monitor.library_dir is None:
+            return None
+        del dest_file
+        return (monitor.library_dir / relative_path).as_posix()
+
+    @staticmethod
+    def __atomic_create_text(path: Path, content: str) -> bool:
+        """以同目录临时文件和排他硬链接完成原子且不覆盖的文本创建。"""
+        if path.exists() or path.is_symlink():
+            return True
+        fd: Optional[int] = None
+        temporary_name: Optional[str] = None
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            fd, temporary_name = tempfile.mkstemp(
+                prefix=f".{path.name}.", dir=path.parent
+            )
+            file_obj = os.fdopen(fd, "w", encoding="utf-8")
+            fd = None
+            with file_obj:
+                file_obj.write(content)
+                file_obj.flush()
+                os.fsync(file_obj.fileno())
+            os.chmod(temporary_name, 0o644)
+            try:
+                os.link(temporary_name, path)
+            except FileExistsError:
+                return True
+            return True
+        except OSError as error:
+            logger.error(f"创建文件失败 {path}：{error}")
+            return False
+        finally:
+            if fd is not None:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+            if temporary_name:
+                try:
+                    os.unlink(temporary_name)
+                except OSError:
+                    pass
+
+    @staticmethod
+    def __copy_without_overwrite(source: Path, target: Path) -> bool:
+        """复制非媒体文件并以排他链接提交，避免竞态覆盖既有目标。"""
+        if target.exists() or target.is_symlink():
+            return True
+        fd: Optional[int] = None
+        temporary_name: Optional[str] = None
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            fd, temporary_name = tempfile.mkstemp(
+                prefix=f".{target.name}.", dir=target.parent
+            )
+            os.close(fd)
+            fd = None
+            shutil.copy2(source, temporary_name)
+            try:
+                os.link(temporary_name, target)
+            except FileExistsError:
+                return True
+            return True
+        except OSError as error:
+            logger.error(f"复制文件失败 {source} -> {target}：{error}")
+            return False
+        finally:
+            if fd is not None:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+            if temporary_name:
+                try:
+                    os.unlink(temporary_name)
+                except OSError:
+                    pass
+
+    def __process_file(  # pylint: disable=too-many-return-statements
+        self, monitor: MonitorConfig, source_file: Path
+    ) -> bool:
+        """处理单个普通源文件，只有目标已存在或成功生成后才算完成。"""
+        if (
+            not source_file.exists()
+            or source_file.is_symlink()
+            or not source_file.is_file()
+            or self.__skip_path(source_file, monitor.source_dir)
+        ):
+            return False
+        relative_path = self.__relative_path(monitor.source_dir, source_file)
+        if relative_path is None:
+            return False
+        dest_file = self.__safe_target_path(monitor.target_dir, relative_path)
+        if dest_file is None:
+            logger.error(f"目标路径越界，跳过文件：{source_file}")
+            return False
+        if dest_file.exists() or dest_file.is_symlink():
+            logger.info(f"目标文件 {dest_file} 已存在，跳过处理")
+            return True
+
+        if source_file.suffix.casefold() in self.__media_extensions():
+            strm_path = dest_file.with_suffix(".strm")
+            content = self.__build_strm_content(monitor, source_file, dest_file)
+            if content is None:
+                logger.error(f"无法生成 {source_file} 的 STRM 内容")
+                return False
+            if self.__atomic_create_text(strm_path, content):
+                logger.info(f"创建strm文件 {strm_path}")
+                return True
+            return False
+
+        if not self._copy_files:
+            return False
+        return self.__copy_without_overwrite(source_file, dest_file)
+
+    def __load_index(self) -> set[str]:
+        """加载旧索引并规范化路径；损坏索引按空索引处理以便重建。"""
+        if not self._cloud_files_json.exists():
+            return set()
+        try:
+            content = json.loads(self._cloud_files_json.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            logger.warning(f"读取云盘文件索引失败，将重新扫描：{error}")
+            return set()
+        if not isinstance(content, list):
+            logger.warning("云盘文件索引格式无效，将重新扫描")
+            return set()
+        return {
+            str(self.__normalise_path(item))
+            for item in content
+            if isinstance(item, str) and item.strip()
+        }
+
+    def __write_index(self, files: set[str]) -> bool:
+        """在数据目录内原子替换索引，避免进程中断留下半份 JSON。"""
+        fd: Optional[int] = None
+        temporary_name: Optional[str] = None
+        try:
+            self._cloud_files_json.parent.mkdir(parents=True, exist_ok=True)
+            fd, temporary_name = tempfile.mkstemp(
+                prefix=f".{self._cloud_files_json.name}.",
+                dir=self._cloud_files_json.parent,
+            )
+            file_obj = os.fdopen(fd, "w", encoding="utf-8")
+            fd = None
+            with file_obj:
+                json.dump(sorted(files), file_obj, ensure_ascii=False)
+                file_obj.flush()
+                os.fsync(file_obj.fileno())
+            os.replace(temporary_name, self._cloud_files_json)
+            return True
+        except OSError as error:
+            logger.error(f"写入云盘文件索引失败：{error}")
+            return False
+        finally:
+            if fd is not None:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+            if temporary_name:
+                try:
+                    os.unlink(temporary_name)
+                except OSError:
+                    pass
+
+    def __run_scan(  # pylint: disable=too-many-branches
+        self,
+        force_rebuild: bool = False,
+        event_data: Optional[dict] = None,
+        *,
+        lock_held: bool = False,
+        once_consumed: bool = False,
+    ) -> bool:
+        """以 single-flight 门禁执行增量或完整扫描，并原子提交索引。"""
+        acquired = False
+        # 非阻塞获取定义重叠扫描的跳过语义，不能改用阻塞上下文。
+        # pylint: disable-next=consider-using-with
+        if not lock_held and not self._run_lock.acquire(blocking=False):
+            logger.warning("云盘strm生成任务正在运行，跳过重复触发")
+            return False
+        if not lock_held:
+            acquired = True
+        try:
+            if not once_consumed and not (self._enabled or self._run_once):
+                logger.error("插件未开启")
+                return False
+            if event_data:
+                self.post_message(
+                    channel=event_data.get("channel"),
+                    title="开始云盘strm生成 ...",
+                    userid=event_data.get("user"),
+                )
+            rebuild = force_rebuild or self._rebuild or not self._cloud_files_json.exists()
+            previous = set() if rebuild else self.__load_index()
+            processed = set() if rebuild else previous
+            success = True
+            changed = False
+            if not self._monitors:
+                success = False
+            for monitor in self._monitors:
+                if not monitor.source_dir.is_dir():
+                    success = False
+                    continue
+                for source_file in self.__iter_files(monitor):
+                    source_key = str(source_file)
+                    if not rebuild and source_key in processed:
+                        continue
+                    logger.info(f"扫描到新文件 {source_file}，正在开始处理")
+                    if self.__process_file(monitor, source_file):
+                        if source_key not in processed:
+                            processed.add(source_key)
+                            changed = True
+                    else:
+                        success = False
+
+            if rebuild or changed:
+                # 完整扫描全部失败时保留旧索引，避免失败结果覆盖可恢复的处理状态。
+                if success or processed:
+                    if not self.__write_index(processed):
+                        success = False
+                    else:
+                        self._cloud_files = processed
+            else:
+                self._cloud_files = processed
+
+            if success and self._rebuild:
+                self._rebuild = False
+                self.__update_config()
+            logger.info("云盘strm生成任务完成" if success else "云盘strm生成任务结束，存在失败文件")
+            if event_data:
+                self.post_message(
+                    channel=event_data.get("channel"),
+                    title="云盘strm生成任务完成！" if success else "云盘strm生成任务存在失败文件",
+                    userid=event_data.get("user"),
+                )
+            return success
+        finally:
+            if acquired:
+                self._run_lock.release()
+
+    def __consume_once(self) -> bool:
+        """配置持久化成功后才消费一次性扫描意图。"""
+        with self._once_lock:
+            if not self._run_once or not self._monitors:
+                return False
+            try:
+                persisted = self.__update_config(onlyonce=False)
+            except Exception as error:  # pylint: disable=broad-exception-caught
+                logger.error(f"保存一次性扫描状态失败：{error}")
+                return False
+            if persisted is False:
+                logger.error("保存一次性扫描状态失败：宿主拒绝更新配置")
+                return False
+            self._onlyonce = False
+            self._run_once = False
+            return True
+
+    def __run_once_scan(self) -> bool:
+        """等待扫描执行槽，在可靠消费一次性意图后完成扫描。"""
+        with self._run_lock:
+            if not self.__consume_once():
+                return False
+            return self.__run_scan(lock_held=True, once_consumed=True)
+
+    @eventmanager.register(EventType.PluginAction)
+    def cloudstrm_file(  # pylint: disable=too-many-return-statements
+        self, event: Event = None
+    ) -> bool:
+        """响应单文件联动事件，并复用与全量扫描相同的路径安全边界。"""
+        if not event:
+            return False
+        event_data = event.event_data or {}
+        if event_data.get("action") != "cloudstrm_file":
+            return False
+        file_path = event_data.get("file_path")
+        if not file_path:
+            return False
+        source_file = self.__normalise_path(file_path)
+        # 单文件联动与全量扫描共享非阻塞 single-flight 门禁。
+        # pylint: disable-next=consider-using-with
+        if not self._run_lock.acquire(blocking=False):
+            logger.warning("云盘strm生成任务正在运行，跳过重复触发")
+            return False
+        try:
+            if not (self._enabled or self._run_once):
+                return False
+            monitor = self.__find_monitor(source_file)
+            if monitor is None:
+                logger.error(f"未找到文件 {source_file} 对应的监控目录")
+                return False
+            if self.__skip_path(source_file, monitor.source_dir):
+                return False
+            if (
+                not self._copy_files
+                and source_file.suffix.casefold() not in self.__media_extensions()
+            ):
+                return False
+            if not self.__process_file(monitor, source_file):
+                return False
+            files = self.__load_index()
+            files.add(str(source_file))
+            self._cloud_files = files
+            return self.__write_index(files)
+        finally:
+            self._run_lock.release()
+
+    @eventmanager.register(EventType.PluginAction)
+    def scan(self, event: Event = None) -> bool:
+        """响应远程命令或宿主服务的全量/增量扫描。"""
+        event_data = None
+        if event:
+            event_data = event.event_data or {}
+            if event_data.get("action") != "cloud_strm":
+                return False
+        if not (self._enabled or self._run_once):
+            logger.error("插件未开启")
+            return False
+        return self.__run_scan(event_data=event_data)
+
+    def rebuild_index(self) -> bool:
+        """由宿主服务触发一次完整索引重建，不删除任何已有输出。"""
+        if not self._enabled:
+            return False
+        return self.__run_scan(force_rebuild=True)
+
+    def __update_config(self, *, onlyonce: Optional[bool] = None) -> Optional[bool]:
+        """保存一次性和重建开关被消费后的配置状态。"""
+        return self.update_config(
+            {
+                "enabled": self._enabled,
+                "onlyonce": self._onlyonce if onlyonce is None else onlyonce,
+                "rebuild": self._rebuild,
+                "copy_files": self._copy_files,
+                "https": self._https,
+                "cron": self._cron,
+                "rebuild_cron": self._rebuild_cron,
+                "monitor_confs": self._monitor_confs,
+            }
+        )
+
+    def get_state(self) -> bool:
+        """一次性任务待执行时保持插件可被宿主服务投影。"""
+        return bool(self._enabled or self._run_once)
+
+    @staticmethod
+    def get_command() -> List[Dict[str, Any]]:
+        """声明远程全量扫描命令。"""
+        return [
+            {
+                "cmd": "/cloud_strm",
+                "event": EventType.PluginAction,
+                "desc": "云盘strm文件生成",
+                "category": "",
+                "data": {"action": "cloud_strm"},
+            }
+        ]
+
+    def get_service(self) -> List[Dict[str, Any]]:
+        """声明宿主统一调度的周期、重建和一次性服务。"""
+        services: list[dict] = []
+        timezone = pytz.timezone(str(settings.TZ))
+        if self._run_once:
+            run_date = datetime.now(tz=timezone) + timedelta(seconds=3)
+            services.append(
+                {
+                    "id": "CloudStrmOnce",
+                    "name": "云盘strm全量执行",
+                    "trigger": DateTrigger(run_date=run_date),
+                    "func": self.__run_once_scan,
+                    "kwargs": {},
+                }
+            )
+        if not self._enabled:
+            return services
+        if self._cron:
+            try:
+                services.append(
+                    {
+                        "id": "CloudStrm",
+                        "name": "云盘strm文件生成服务",
+                        "trigger": CronTrigger.from_crontab(
+                            self._cron, timezone=timezone
+                        ),
+                        "func": self.scan,
+                        "kwargs": {},
+                    }
+                )
+            except (TypeError, ValueError) as error:
+                logger.error(f"执行周期配置错误：{error}")
+        if self._rebuild_cron:
+            try:
+                services.append(
+                    {
+                        "id": "CloudStrmRebuild",
+                        "name": "云盘strm重建索引服务",
+                        "trigger": CronTrigger.from_crontab(
+                            self._rebuild_cron, timezone=timezone
+                        ),
+                        "func": self.rebuild_index,
+                        "kwargs": {},
+                    }
+                )
+            except (TypeError, ValueError) as error:
+                logger.error(f"重建索引周期配置错误：{error}")
+        return services
+
+    def get_api(self) -> List[Dict[str, Any]]:
+        """当前插件不注册 HTTP API。"""
+        return []
+
+    def get_form(self) -> Tuple[List[dict], Dict[str, Any]]:
+        """返回插件配置页面及与旧版本一致的配置字段。"""
+        return [
+            {
+                "component": "VForm",
+                "content": [
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 4},
+                                "content": [
+                                    {
+                                        "component": "VSwitch",
+                                        "props": {"model": "enabled", "label": "启用插件"},
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 4},
+                                "content": [
+                                    {
+                                        "component": "VSwitch",
+                                        "props": {"model": "onlyonce", "label": "全量运行一次"},
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 4},
+                                "content": [
+                                    {
+                                        "component": "VSwitch",
+                                        "props": {"model": "rebuild", "label": "重建索引"},
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 6},
+                                "content": [
+                                    {
+                                        "component": "VTextField",
+                                        "props": {
+                                            "model": "cron",
+                                            "label": "生成周期",
+                                            "placeholder": "0 0 * * *",
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 6},
+                                "content": [
+                                    {
+                                        "component": "VTextField",
+                                        "props": {
+                                            "model": "rebuild_cron",
+                                            "label": "重建索引周期",
+                                            "placeholder": "0 1 * * *",
+                                        },
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        "component": "VTextarea",
+                        "props": {
+                            "model": "monitor_confs",
+                            "label": "监控目录",
+                            "rows": 5,
+                            "placeholder": "监控目录#目的目录#媒体服务器内源文件路径",
+                        },
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 4},
+                                "content": [
+                                    {
+                                        "component": "VSwitch",
+                                        "props": {"model": "copy_files", "label": "复制非媒体文件"},
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 4},
+                                "content": [
+                                    {
+                                        "component": "VSwitch",
+                                        "props": {"model": "https", "label": "启用https"},
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        "component": "VAlert",
+                        "props": {
+                            "type": "info",
+                            "variant": "tonal",
+                            "text": (
+                                "目录监控格式：1.监控目录#目的目录#媒体服务器内源文件路径；"
+                                "2.监控目录#目的目录#cd2#cd2挂载本地跟路径#cd2服务地址；"
+                                "3.监控目录#目的目录#alist#alist挂载本地跟路径#alist服务地址。"
+                            ),
+                        },
+                    },
+                ],
+            }
+        ], {
+            "enabled": False,
+            "cron": "",
+            "rebuild_cron": "",
+            "onlyonce": False,
+            "rebuild": False,
+            "copy_files": False,
+            "https": False,
+            "monitor_confs": "",
+        }
+
+    def get_page(self) -> List[dict]:
+        """当前插件不注册详情页面。"""
+        return []
+
+    def stop_service(self) -> None:
+        """等待在途文件写入结束，并阻止已注销的宿主回调继续执行。"""
+        with self._run_lock:
+            self._enabled = False
+            self._onlyonce = False
+            self._run_once = False

--- a/plugins.v3/cloudstrmincrement/__init__.py
+++ b/plugins.v3/cloudstrmincrement/__init__.py
@@ -1,0 +1,795 @@
+"""提供增量目录归档和云盘 STRM 生成能力。"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import tempfile
+import threading
+import urllib.parse
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional, Tuple
+
+import pytz
+from apscheduler.triggers.cron import CronTrigger
+from apscheduler.triggers.date import DateTrigger
+
+from app.plugins import _PluginBase
+from app.schemas.types import EventType
+from app.sdk.config import settings
+from app.sdk.events import Event, eventmanager
+from app.sdk.logging import logger
+
+
+DEFAULT_MEDIA_EXTENSIONS = (
+    ".mp4,.mkv,.ts,.iso,.rmvb,.avi,.mov,.mpeg,.mpg,.wmv,.3gp,.asf,.m4v,"
+    ".flv,.m2ts,.strm,.tp,.f4v"
+)
+
+
+@dataclass(frozen=True)
+class IncrementMonitor:
+    """一条增量目录、源目录和媒体库输出目录的稳定映射。"""
+
+    increment_dir: Path
+    source_dir: Path
+    target_dir: Path
+    library_dir: Optional[Path] = None
+    cloud_type: Optional[str] = None
+    cloud_path: Optional[Path] = None
+    cloud_url: Optional[str] = None
+
+
+# 配置字段分别控制复制、源删除和输出协议，不能合并为隐式模式。
+# pylint: disable=too-many-instance-attributes
+class CloudStrmIncrement(_PluginBase):
+    """把增量目录安全归档到源树，并为归档文件生成媒体库输出。"""
+
+    plugin_name = "云盘Strm生成（增量版）"
+    plugin_desc = "扫描增量目录并生成Strm文件。"
+    plugin_icon = (
+        "https://raw.githubusercontent.com/thsrite/"
+        "MoviePilot-Plugins/main/icons/create.png"
+    )
+    plugin_version = "2.0.0"
+    plugin_author = "thsrite"
+    author_url = "https://github.com/thsrite"
+    plugin_config_prefix = "cloudstrm_"
+    plugin_order = 26
+    auth_level = 1
+
+    def __init__(self) -> None:
+        """初始化实例级运行状态，避免热重载共享锁和可变配置。"""
+        super().__init__()
+        self._run_lock = threading.Lock()
+        self._once_lock = threading.Lock()
+        self._enabled = False
+        self._cron = ""
+        self._onlyonce = False
+        self._run_once = False
+        self._copy_files = False
+        self._https = False
+        self._del_source = True
+        self._monitor_confs = ""
+        self._no_del_dirs = ""
+        self._preserved_dir_names: set[str] = set()
+        self._rmt_mediaext = DEFAULT_MEDIA_EXTENSIONS
+        self._monitors: list[IncrementMonitor] = []
+
+    def init_plugin(self, config: dict = None) -> None:
+        """解析完整候选配置，并在在途任务收敛后一次性切换。"""
+        config = config or {}
+        enabled = bool(config.get("enabled"))
+        cron = str(config.get("cron") or "").strip()
+        onlyonce = bool(config.get("onlyonce"))
+        copy_files = bool(config.get("copy_files"))
+        https = bool(config.get("https"))
+        del_source = bool(config.get("del_source", True))
+        monitor_confs = str(config.get("monitor_confs") or "")
+        no_del_dirs = str(config.get("no_del_dirs") or "")
+        rmt_mediaext = str(config.get("rmt_mediaext") or DEFAULT_MEDIA_EXTENSIONS)
+        monitors = self.__parse_monitor_confs(monitor_confs)
+        preserved_names = {
+            item.strip().casefold()
+            for item in re.split(r"[,，\n]+", no_del_dirs)
+            if item.strip()
+        }
+
+        with self._run_lock:
+            self._enabled = enabled
+            self._cron = cron
+            self._onlyonce = onlyonce
+            self._run_once = onlyonce
+            self._copy_files = copy_files
+            self._https = https
+            self._del_source = del_source
+            self._monitor_confs = monitor_confs
+            self._no_del_dirs = no_del_dirs
+            self._preserved_dir_names = preserved_names
+            self._rmt_mediaext = rmt_mediaext
+            self._monitors = monitors
+
+        if (enabled or onlyonce) and not monitors:
+            logger.warning("未获取到可用增量目录配置，请检查")
+
+    @staticmethod
+    def __normalise_path(value: str | Path) -> Path:
+        """把配置和事件路径规范化为绝对路径。"""
+        return Path(os.path.abspath(os.path.expanduser(str(value).strip())))
+
+    @staticmethod
+    def __paths_overlap(first: Path, second: Path) -> bool:
+        """判断两个目录是否相同或存在任一方向的包含关系。"""
+        first_root = first.resolve(strict=False)
+        second_root = second.resolve(strict=False)
+        return (
+            first_root == second_root
+            or first_root.is_relative_to(second_root)
+            or second_root.is_relative_to(first_root)
+        )
+
+    @classmethod
+    def __parse_monitor_confs(  # pylint: disable=too-many-locals
+        cls, monitor_confs: str
+    ) -> list[IncrementMonitor]:
+        """解析本地媒体库、CD2 和 Alist 三种旧配置格式。"""
+        monitors: list[IncrementMonitor] = []
+        for raw_line in monitor_confs.splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = [part.strip() for part in line.split("#")]
+            try:
+                if len(parts) == 4:
+                    increment_dir, source_dir, target_dir, library_dir = parts
+                    if not all(parts):
+                        raise ValueError("本地映射缺少路径")
+                    monitor = IncrementMonitor(
+                        increment_dir=cls.__normalise_path(increment_dir),
+                        source_dir=cls.__normalise_path(source_dir),
+                        target_dir=cls.__normalise_path(target_dir),
+                        library_dir=cls.__normalise_path(library_dir),
+                    )
+                elif len(parts) == 6:
+                    increment_dir, source_dir, target_dir, cloud_type, cloud_path, cloud_url = parts
+                    cloud_type = cloud_type.casefold()
+                    if cloud_type not in {"cd2", "alist"}:
+                        raise ValueError(f"不支持的云盘类型 {cloud_type}")
+                    if not all((increment_dir, source_dir, target_dir, cloud_path, cloud_url)):
+                        raise ValueError("云盘映射缺少必要配置")
+                    monitor = IncrementMonitor(
+                        increment_dir=cls.__normalise_path(increment_dir),
+                        source_dir=cls.__normalise_path(source_dir),
+                        target_dir=cls.__normalise_path(target_dir),
+                        cloud_type=cloud_type,
+                        cloud_path=cls.__normalise_path(cloud_path),
+                        cloud_url=cloud_url,
+                    )
+                else:
+                    raise ValueError("格式应包含 3 或 5 个 # 分隔符")
+
+                roots = (monitor.increment_dir, monitor.source_dir, monitor.target_dir)
+                if any(
+                    cls.__paths_overlap(roots[left], roots[right])
+                    for left, right in ((0, 1), (0, 2), (1, 2))
+                ):
+                    raise ValueError("增量、源和目的目录不能相互包含")
+            except (OSError, ValueError) as error:
+                logger.error(f"{line} 格式错误：{error}")
+                continue
+            monitors.append(monitor)
+        return monitors
+
+    @staticmethod
+    def __relative_path(root: Path, path: Path) -> Optional[Path]:
+        """按路径组件获取相对路径，拒绝同名前缀路径。"""
+        try:
+            return path.relative_to(root)
+        except ValueError:
+            return None
+
+    @classmethod
+    def __safe_target_path(cls, root: Path, relative_path: Path) -> Optional[Path]:
+        """确保目标父目录解析后仍位于指定根目录内。"""
+        if relative_path.is_absolute() or ".." in relative_path.parts:
+            return None
+        target = root / relative_path
+        try:
+            resolved_root = root.resolve(strict=False)
+            if not target.parent.resolve(strict=False).is_relative_to(resolved_root):
+                return None
+        except OSError:
+            return None
+        return target
+
+    @staticmethod
+    def __skip_component(name: str) -> bool:
+        """识别隐藏、回收站和媒体附属目录。"""
+        return name.startswith(".") or name.casefold() in {
+            "@recycle",
+            "#recycle",
+            "@eadir",
+            "extrafanart",
+        }
+
+    @classmethod
+    def __skip_path(cls, path: Path, root: Path) -> bool:
+        """按增量根的相对组件过滤受保护路径。"""
+        relative = cls.__relative_path(root, path)
+        return relative is None or any(cls.__skip_component(part) for part in relative.parts)
+
+    def __media_extensions(self) -> set[str]:
+        """解析用户配置的媒体扩展名并统一大小写和前导点。"""
+        extensions = set()
+        for item in self._rmt_mediaext.split(","):
+            extension = item.strip().casefold()
+            if not extension:
+                continue
+            extensions.add(extension if extension.startswith(".") else f".{extension}")
+        return extensions
+
+    @classmethod
+    def __has_symlink_component(cls, root: Path, path: Path) -> bool:
+        """拒绝根目录以下任一软链接组件，避免词法子路径解析到根外。"""
+        relative = cls.__relative_path(root, path)
+        if relative is None:
+            return True
+        current = root
+        for part in relative.parts:
+            current /= part
+            if current.is_symlink():
+                return True
+        return False
+
+    @staticmethod
+    def __same_file_contents(first: Path, second: Path) -> bool:
+        """逐块比较两个普通文件，确认失败事务可安全从归档副本恢复。"""
+        try:
+            if (
+                first.is_symlink()
+                or second.is_symlink()
+                or not first.is_file()
+                or not second.is_file()
+                or first.stat().st_size != second.stat().st_size
+            ):
+                return False
+            with first.open("rb") as first_file, second.open("rb") as second_file:
+                while True:
+                    first_chunk = first_file.read(1024 * 1024)
+                    second_chunk = second_file.read(1024 * 1024)
+                    if first_chunk != second_chunk:
+                        return False
+                    if not first_chunk:
+                        return True
+        except OSError:
+            return False
+
+    def __iter_increment_files(self, monitor: IncrementMonitor) -> Iterator[Path]:
+        """以确定性顺序遍历增量目录并剪枝隐藏目录和软链接。"""
+        if not monitor.increment_dir.is_dir():
+            logger.error(f"增量目录不存在或不是目录：{monitor.increment_dir}")
+            return
+        media_extensions = self.__media_extensions()
+        for root, dirs, files in os.walk(
+            str(monitor.increment_dir), topdown=True, followlinks=False
+        ):
+            root_path = Path(root)
+            dirs[:] = sorted(
+                name
+                for name in dirs
+                if not self.__skip_component(name) and not (root_path / name).is_symlink()
+            )
+            for name in sorted(files):
+                path = root_path / name
+                if (
+                    self.__skip_path(path, monitor.increment_dir)
+                    or path.is_symlink()
+                    or not path.is_file()
+                ):
+                    continue
+                if not self._copy_files and path.suffix.casefold() not in media_extensions:
+                    continue
+                yield path
+
+    @staticmethod
+    def __service_url(scheme: str, cloud_url: str) -> Optional[Tuple[str, str]]:
+        """规范化云盘服务地址，并返回基础 URL 与主机组件。"""
+        raw_url = cloud_url.strip()
+        parsed = urllib.parse.urlsplit(
+            raw_url if "://" in raw_url else f"{scheme}://{raw_url}"
+        )
+        if not parsed.netloc:
+            return None
+        return f"{scheme}://{parsed.netloc}{parsed.path.rstrip('/')}", parsed.netloc
+
+    def __build_strm_content(  # pylint: disable=too-many-return-statements
+        self, monitor: IncrementMonitor, source_file: Path
+    ) -> Optional[str]:
+        """根据稳定映射生成媒体服务器路径或云盘 URL。"""
+        relative = self.__relative_path(monitor.source_dir, source_file)
+        if relative is None:
+            return None
+        if not monitor.cloud_type:
+            if monitor.library_dir is None:
+                return None
+            return (monitor.library_dir / relative).as_posix()
+
+        if monitor.cloud_path is None or monitor.cloud_url is None:
+            return None
+        cloud_relative = self.__relative_path(monitor.cloud_path, source_file)
+        if cloud_relative is None:
+            logger.error(f"文件 {source_file} 不在云盘挂载根 {monitor.cloud_path} 内")
+            return None
+        scheme = "https" if self._https else "http"
+        service = self.__service_url(scheme, monitor.cloud_url)
+        if service is None:
+            return None
+        base_url, host = service
+        encoded_path = urllib.parse.quote(
+            "/" + cloud_relative.as_posix().lstrip("/"), safe=""
+        )
+        if monitor.cloud_type == "cd2":
+            return f"{base_url}/static/{scheme}/{host}/False/{encoded_path}"
+        if monitor.cloud_type == "alist":
+            return f"{base_url}/d/{encoded_path}"
+        return None
+
+    @staticmethod
+    def __atomic_create_text(path: Path, content: str) -> bool:
+        """以同目录临时文件排他提交文本，不覆盖既有目标。"""
+        if path.is_symlink():
+            logger.error(f"目标是软链接，拒绝写入：{path}")
+            return False
+        if path.exists():
+            return path.is_file()
+        fd: Optional[int] = None
+        temporary_name: Optional[str] = None
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+            file_obj = os.fdopen(fd, "w", encoding="utf-8")
+            fd = None
+            with file_obj:
+                file_obj.write(content)
+                file_obj.flush()
+                os.fsync(file_obj.fileno())
+            os.chmod(temporary_name, 0o644)
+            try:
+                os.link(temporary_name, path)
+            except FileExistsError:
+                return path.is_file() and not path.is_symlink()
+            return True
+        except OSError as error:
+            logger.error(f"创建文件失败 {path}：{error}")
+            return False
+        finally:
+            if fd is not None:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+            if temporary_name:
+                try:
+                    os.unlink(temporary_name)
+                except OSError:
+                    pass
+
+    @staticmethod
+    def __copy_without_overwrite(  # pylint: disable=too-many-return-statements
+        source: Path, target: Path, *, existing_ok: bool
+    ) -> bool:
+        """使用同目录临时文件排他提交副本，避免检查后覆盖竞态。"""
+        if target.is_symlink():
+            logger.error(f"目标是软链接，拒绝复制：{target}")
+            return False
+        if target.exists():
+            return existing_ok and target.is_file()
+        fd: Optional[int] = None
+        temporary_name: Optional[str] = None
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            fd, temporary_name = tempfile.mkstemp(
+                prefix=f".{target.name}.", dir=target.parent
+            )
+            os.close(fd)
+            fd = None
+            shutil.copy2(source, temporary_name)
+            try:
+                os.link(temporary_name, target)
+            except FileExistsError:
+                return existing_ok and target.is_file() and not target.is_symlink()
+            return True
+        except OSError as error:
+            logger.error(f"复制文件失败 {source} -> {target}：{error}")
+            return False
+        finally:
+            if fd is not None:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+            if temporary_name:
+                try:
+                    os.unlink(temporary_name)
+                except OSError:
+                    pass
+
+    def __process_source_file(  # pylint: disable=too-many-return-statements
+        self, monitor: IncrementMonitor, source_file: Path
+    ) -> bool:
+        """为已归档源文件生成 STRM 或复制附属文件。"""
+        try:
+            resolved_root = monitor.source_dir.resolve(strict=False)
+            resolved_file = source_file.resolve(strict=True)
+        except OSError:
+            return False
+        if (
+            not source_file.exists()
+            or source_file.is_symlink()
+            or not source_file.is_file()
+        ):
+            return False
+        if (
+            self.__skip_path(source_file, monitor.source_dir)
+            or self.__has_symlink_component(monitor.source_dir, source_file)
+            or not resolved_file.is_relative_to(resolved_root)
+        ):
+            return False
+        relative = self.__relative_path(monitor.source_dir, source_file)
+        if relative is None:
+            return False
+        target_file = self.__safe_target_path(monitor.target_dir, relative)
+        if target_file is None:
+            logger.error(f"目标路径越界，跳过文件：{source_file}")
+            return False
+        if source_file.suffix.casefold() in self.__media_extensions():
+            content = self.__build_strm_content(monitor, source_file)
+            if content is None:
+                return False
+            return self.__atomic_create_text(target_file.with_suffix(".strm"), content)
+        if not self._copy_files:
+            return False
+        return self.__copy_without_overwrite(source_file, target_file, existing_ok=True)
+
+    def __cleanup_increment_parents(
+        self, monitor: IncrementMonitor, start_dir: Path
+    ) -> None:
+        """只清理增量根内的空目录，并在保留目录或异常处停止。"""
+        root = monitor.increment_dir.resolve(strict=False)
+        current = start_dir
+        while current != root:
+            try:
+                resolved = current.resolve(strict=False)
+                if not resolved.is_relative_to(root):
+                    return
+                if current.name.casefold() in self._preserved_dir_names:
+                    return
+                current.rmdir()
+            except OSError:
+                return
+            current = current.parent
+
+    def __process_increment_file(  # pylint: disable=too-many-return-statements
+        self, monitor: IncrementMonitor, increment_file: Path
+    ) -> bool:
+        """归档单个增量文件；输出成功后才允许删除增量源。"""
+        relative = self.__relative_path(monitor.increment_dir, increment_file)
+        if relative is None:
+            return False
+        source_file = self.__safe_target_path(monitor.source_dir, relative)
+        if source_file is None:
+            logger.error(f"源路径越界，跳过文件：{increment_file}")
+            return False
+
+        source_exists = source_file.exists() or source_file.is_symlink()
+        if source_exists:
+            if not self.__same_file_contents(increment_file, source_file):
+                logger.error(f"源文件 {source_file} 已存在且内容不同，拒绝覆盖")
+                return False
+            logger.warning(f"检测到可恢复的归档副本 {source_file}，继续重试输出")
+        if not self.__copy_without_overwrite(
+            increment_file, source_file, existing_ok=source_exists
+        ):
+            return False
+        if not self.__process_source_file(monitor, source_file):
+            return False
+        if not self._del_source:
+            return True
+        try:
+            increment_file.unlink()
+        except OSError as error:
+            logger.error(f"删除已归档增量文件失败 {increment_file}：{error}")
+            return False
+        self.__cleanup_increment_parents(monitor, increment_file.parent)
+        return True
+
+    def __run_scan(
+        self,
+        event_data: Optional[dict] = None,
+        *,
+        lock_held: bool = False,
+        once_consumed: bool = False,
+    ) -> bool:
+        """以 single-flight 门禁执行一次完整增量扫描。"""
+        acquired = False
+        # 非阻塞获取定义重复调度的跳过语义。
+        # pylint: disable-next=consider-using-with
+        if not lock_held and not self._run_lock.acquire(blocking=False):
+            logger.warning("云盘增量生成任务正在运行，跳过重复触发")
+            return False
+        if not lock_held:
+            acquired = True
+        try:
+            if not once_consumed and not (self._enabled or self._run_once):
+                logger.error("插件未开启")
+                return False
+            if event_data:
+                self.post_message(
+                    channel=event_data.get("channel"),
+                    title="开始云盘增量strm生成 ...",
+                    userid=event_data.get("user"),
+                )
+            success = bool(self._monitors)
+            for monitor in self._monitors:
+                if not monitor.increment_dir.is_dir():
+                    success = False
+                    continue
+                for increment_file in self.__iter_increment_files(monitor):
+                    if not self.__process_increment_file(monitor, increment_file):
+                        success = False
+            if event_data:
+                self.post_message(
+                    channel=event_data.get("channel"),
+                    title=(
+                        "云盘增量strm生成任务完成！"
+                        if success
+                        else "云盘增量strm生成任务存在失败文件"
+                    ),
+                    userid=event_data.get("user"),
+                )
+            return success
+        finally:
+            if acquired:
+                self._run_lock.release()
+
+    def __update_config(self, *, onlyonce: Optional[bool] = None) -> Optional[bool]:
+        """持久化稳定配置，并允许可靠消费一次性开关。"""
+        return self.update_config(
+            {
+                "enabled": self._enabled,
+                "cron": self._cron,
+                "onlyonce": self._onlyonce if onlyonce is None else onlyonce,
+                "copy_files": self._copy_files,
+                "https": self._https,
+                "del_source": self._del_source,
+                "monitor_confs": self._monitor_confs,
+                "no_del_dirs": self._no_del_dirs,
+                "rmt_mediaext": self._rmt_mediaext,
+            }
+        )
+
+    def __consume_once(self) -> bool:
+        """配置持久化成功后才消费一次性任务意图。"""
+        with self._once_lock:
+            if not self._run_once or not self._monitors:
+                return False
+            try:
+                persisted = self.__update_config(onlyonce=False)
+            except Exception as error:  # pylint: disable=broad-exception-caught
+                logger.error(f"保存一次性扫描状态失败：{error}")
+                return False
+            if persisted is False:
+                return False
+            self._onlyonce = False
+            self._run_once = False
+            return True
+
+    def __run_once_scan(self) -> bool:
+        """等待执行槽，可靠消费一次性意图后完成扫描。"""
+        with self._run_lock:
+            if not self.__consume_once():
+                return False
+            return self.__run_scan(lock_held=True, once_consumed=True)
+
+    @eventmanager.register(EventType.PluginAction)
+    def cloudstrm_file(self, event: Event = None) -> bool:
+        """处理实时监控插件传入的已归档源文件。"""
+        if not event:
+            return False
+        event_data = event.event_data or {}
+        if event_data.get("action") != "cloudstrm_file" or not event_data.get("file_path"):
+            return False
+        source_file = self.__normalise_path(event_data["file_path"])
+        # pylint: disable-next=consider-using-with
+        if not self._run_lock.acquire(blocking=False):
+            return False
+        try:
+            if not (self._enabled or self._run_once):
+                return False
+            matches = [
+                monitor
+                for monitor in self._monitors
+                if self.__relative_path(monitor.source_dir, source_file) is not None
+            ]
+            monitor = max(
+                matches, key=lambda item: len(item.source_dir.parts), default=None
+            )
+            if monitor is None or self.__skip_path(source_file, monitor.source_dir):
+                return False
+            return self.__process_source_file(monitor, source_file)
+        finally:
+            self._run_lock.release()
+
+    @eventmanager.register(EventType.PluginAction)
+    def scan(self, event: Event = None) -> bool:
+        """响应远程命令或宿主服务的增量扫描。"""
+        event_data = None
+        if event:
+            event_data = event.event_data or {}
+            if event_data.get("action") != "cloud_strm_increment":
+                return False
+        return self.__run_scan(event_data=event_data)
+
+    def get_state(self) -> bool:
+        """一次性任务待执行时保持宿主服务投影可见。"""
+        return bool(self._enabled or self._run_once)
+
+    @staticmethod
+    def get_command() -> List[Dict[str, Any]]:
+        """声明远程增量扫描命令。"""
+        return [
+            {
+                "cmd": "/cloud_strm_increment",
+                "event": EventType.PluginAction,
+                "desc": "云盘strm文件生成(增量版)",
+                "category": "",
+                "data": {"action": "cloud_strm_increment"},
+            }
+        ]
+
+    def get_service(self) -> List[Dict[str, Any]]:
+        """声明宿主统一调度的 cron 和一次性服务。"""
+        services: list[dict] = []
+        timezone = pytz.timezone(str(settings.TZ))
+        if self._run_once:
+            services.append(
+                {
+                    "id": "CloudStrmIncrementOnce",
+                    "name": "云盘增量strm文件生成一次性服务",
+                    "trigger": DateTrigger(
+                        run_date=datetime.now(tz=timezone) + timedelta(seconds=3),
+                        timezone=timezone,
+                    ),
+                    "func": self.__run_once_scan,
+                    "kwargs": {},
+                }
+            )
+        if self._enabled and self._cron:
+            try:
+                trigger = CronTrigger.from_crontab(self._cron, timezone=timezone)
+            except (TypeError, ValueError) as error:
+                logger.error(f"定时任务配置错误：{error}")
+            else:
+                services.append(
+                    {
+                        "id": "CloudStrmIncrement",
+                        "name": "云盘增量strm文件生成服务",
+                        "trigger": trigger,
+                        "func": self.scan,
+                        "kwargs": {},
+                    }
+                )
+        return services
+
+    def get_api(self) -> List[Dict[str, Any]]:
+        """当前插件不注册 HTTP API。"""
+        return []
+
+    def get_form(self) -> Tuple[List[dict], Dict[str, Any]]:
+        """返回增量扫描、源删除和目录映射配置表单。"""
+        switches = [
+            ("enabled", "启用插件"),
+            ("onlyonce", "立即运行一次"),
+            ("copy_files", "复制非媒体文件"),
+            ("del_source", "删除源文件"),
+            ("https", "启用https"),
+        ]
+        return [
+            {
+                "component": "VForm",
+                "content": [
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 4},
+                                "content": [
+                                    {
+                                        "component": "VSwitch",
+                                        "props": {"model": model, "label": label},
+                                    }
+                                ],
+                            }
+                            for model, label in switches
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 6},
+                                "content": [
+                                    {
+                                        "component": "VTextField",
+                                        "props": {
+                                            "model": "cron",
+                                            "label": "生成周期",
+                                            "placeholder": "0 0 * * *",
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 6},
+                                "content": [
+                                    {
+                                        "component": "VTextField",
+                                        "props": {
+                                            "model": "no_del_dirs",
+                                            "label": "保留路径",
+                                            "placeholder": "series,movies,downloads,others",
+                                        },
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        "component": "VTextarea",
+                        "props": {
+                            "model": "monitor_confs",
+                            "label": "监控目录",
+                            "rows": 5,
+                            "placeholder": (
+                                "增量目录#监控目录#目的目录#媒体服务器内源文件路径"
+                            ),
+                        },
+                    },
+                    {
+                        "component": "VTextarea",
+                        "props": {
+                            "model": "rmt_mediaext",
+                            "label": "视频格式",
+                            "rows": 2,
+                        },
+                    },
+                ],
+            }
+        ], {
+            "enabled": False,
+            "cron": "",
+            "onlyonce": False,
+            "copy_files": False,
+            "del_source": True,
+            "https": False,
+            "monitor_confs": "",
+            "no_del_dirs": "",
+            "rmt_mediaext": DEFAULT_MEDIA_EXTENSIONS,
+        }
+
+    def get_page(self) -> List[dict]:
+        """当前插件不注册详情页面。"""
+        return []
+
+    def stop_service(self) -> None:
+        """等待在途文件操作结束，并阻止过期宿主回调继续执行。"""
+        with self._run_lock:
+            self._enabled = False
+            self._onlyonce = False
+            self._run_once = False

--- a/plugins.v3/customcommand/__init__.py
+++ b/plugins.v3/customcommand/__init__.py
@@ -1,0 +1,729 @@
+"""提供由宿主调度器管理的自定义命令任务。"""
+
+from __future__ import annotations
+
+import os
+import random
+import re
+import signal
+import subprocess
+import threading
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any, Optional
+from zoneinfo import ZoneInfo
+
+from apscheduler.triggers.cron import CronTrigger
+
+from app.plugins import _PluginBase
+from app.schemas.types import MessageType
+from app.sdk.config import settings
+from app.sdk.logging import logger
+
+
+MAX_OUTPUT_SIZE = 64 * 1024
+PROCESS_STOP_TIMEOUT = 1.0
+OUTPUT_READ_SIZE = 4096
+
+
+class _BoundedOutput:
+    """保留命令输出的有限尾部，避免长时间运行任务耗尽内存。"""
+
+    def __init__(self, limit: int) -> None:
+        self._limit = limit
+        self._chunks: deque[str] = deque()
+        self._size = 0
+        self._truncated = False
+        self._lock = threading.Lock()
+
+    def append(self, chunk: str) -> None:
+        """追加一段输出，并在超限时丢弃最早内容。"""
+        if not chunk:
+            return
+        with self._lock:
+            if len(chunk) > self._limit:
+                self._chunks.clear()
+                self._chunks.append(chunk[-self._limit:])
+                self._size = self._limit
+                self._truncated = True
+                return
+            self._chunks.append(chunk)
+            self._size += len(chunk)
+            while self._size > self._limit:
+                removed = self._chunks.popleft()
+                overflow = self._size - self._limit
+                if len(removed) <= overflow:
+                    self._size -= len(removed)
+                else:
+                    self._chunks.appendleft(removed[overflow:])
+                    self._size -= overflow
+                self._truncated = True
+
+    def getvalue(self) -> str:
+        """返回不超过限制的输出尾部，并标识发生过截断。"""
+        with self._lock:
+            value = "".join(self._chunks)
+            if not self._truncated:
+                return value
+            marker = "[输出已截断]\n"
+            return marker + value[-(self._limit - len(marker)):]
+
+
+@dataclass(frozen=True)
+class CommandTask:
+    """保存一行配置解析出的宿主任务参数。"""
+
+    line_number: int
+    name: str
+    cron: str
+    command: str
+    random_delay: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    """保存命令执行状态以及供历史和通知使用的输出。"""
+
+    returncode: Optional[int]
+    stdout: str = ""
+    stderr: str = ""
+    error: Optional[str] = None
+    skipped: bool = False
+
+    @property
+    def success(self) -> bool:
+        """命令正常启动并以零返回码退出时才视为成功。"""
+        return not self.skipped and self.error is None and self.returncode == 0
+
+    @property
+    def message(self) -> str:
+        """保持旧版的 stdout 最后一行优先语义。"""
+        stdout_lines = [line.strip() for line in self.stdout.splitlines() if line.strip()]
+        if stdout_lines:
+            return stdout_lines[-1]
+        stderr_lines = [line.strip() for line in self.stderr.splitlines() if line.strip()]
+        if stderr_lines:
+            return stderr_lines[-1]
+        return self.error or ""
+
+
+# 插件配置字段保持与已发布配置键一一对应，避免隐式迁移或丢字段。
+# pylint: disable=too-many-instance-attributes
+class CustomCommand(_PluginBase):
+    """按配置的 cron 或一次性任务执行宿主 shell 命令。"""
+
+    plugin_name = "自定义命令"
+    plugin_desc = "自定义执行周期执行命令并推送结果。"
+    plugin_icon = "https://raw.githubusercontent.com/thsrite/MoviePilot-Plugins/main/icons/code.png"
+    plugin_version = "2.0.0"
+    plugin_author = "thsrite"
+    author_url = "https://github.com/thsrite"
+    plugin_config_prefix = "customcommand_"
+    plugin_order = 39
+    auth_level = 1
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._enabled = False
+        self._onlyonce = False
+        self._run_once = False
+        self._notify = False
+        self._clear = False
+        self._msgtype: Optional[str] = None
+        self._time_confs = ""
+        self._history_days = 30
+        self._notify_keywords = ""
+        self._run_lock = threading.Lock()
+        self._once_lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._process_lock = threading.RLock()
+        self._process: Optional[subprocess.Popen[str]] = None
+
+    def init_plugin(self, config: Optional[dict] = None) -> None:
+        """读取配置；服务注册和执行统一交由宿主调度器。"""
+        # 宿主配置更新会复用同一实例，切换配置前必须先收敛旧命令进程。
+        if self.stop_service() is False:
+            logger.error("旧命令进程未收敛，拒绝切换插件配置")
+            return
+        config = dict(config or {})
+        with self._run_lock:
+            self._enabled = bool(config.get("enabled"))
+            self._onlyonce = bool(config.get("onlyonce"))
+            self._run_once = self._onlyonce
+            self._notify = bool(config.get("notify"))
+            self._msgtype = config.get("msgtype")
+            self._clear = bool(config.get("clear"))
+            self._history_days = self._normalise_history_days(config.get("history_days"))
+            self._notify_keywords = str(config.get("notify_keywords") or "")
+            self._time_confs = str(config.get("time_confs") or "")
+            self._stop_event.clear()
+
+        if self._clear:
+            self.del_data("history")
+            self._clear = False
+            self.update_config(self._config_payload())
+
+    @staticmethod
+    def _normalise_history_days(value: Any) -> int:
+        """把非法保留天数收敛到兼容默认值。"""
+        try:
+            days = int(value or 30)
+        except (TypeError, ValueError):
+            return 30
+        return max(days, 1)
+
+    def _config_payload(self, *, onlyonce: Optional[bool] = None) -> dict[str, Any]:
+        """返回持久化所需的完整配置，避免消费开关时丢失其它字段。"""
+        return {
+            "enabled": self._enabled,
+            "onlyonce": self._onlyonce if onlyonce is None else onlyonce,
+            "notify": self._notify,
+            "msgtype": self._msgtype,
+            "time_confs": self._time_confs,
+            "history_days": self._history_days,
+            "notify_keywords": self._notify_keywords,
+            "clear": self._clear,
+        }
+
+    def _report_config_error(self, message: str) -> None:
+        """同时记录日志和宿主系统消息，便于用户定位被跳过的配置。"""
+        logger.error(message)
+        self.systemmessage.put(message)
+
+    def _tasks(self) -> list[CommandTask]:
+        """逐行解析任务；错误行隔离处理，不影响其它合法任务。"""
+        tasks: list[CommandTask] = []
+        for line_number, raw_line in enumerate(self._time_confs.splitlines(), start=1):
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split("#")
+            if len(parts) not in (3, 4) or not all(part.strip() for part in parts[:3]):
+                self._report_config_error(f"第 {line_number} 行命令配置错误，已跳过")
+                continue
+            tasks.append(
+                CommandTask(
+                    line_number=line_number,
+                    name=parts[0].strip(),
+                    cron=parts[1].strip(),
+                    command=parts[2].strip(),
+                    random_delay=parts[3].strip() if len(parts) == 4 else None,
+                )
+            )
+        return tasks
+
+    @staticmethod
+    def _delay_bounds(value: str) -> tuple[int, int]:
+        """解析闭区间随机延时，并拒绝负数或逆序范围。"""
+        parts = value.split("-", maxsplit=1)
+        if len(parts) != 2:
+            raise ValueError("随机延时必须使用 起始秒-结束秒 格式")
+        lower, upper = (int(item.strip()) for item in parts)
+        if lower < 0 or upper < lower:
+            raise ValueError("随机延时必须为非负且结束秒不小于起始秒")
+        return lower, upper
+
+    @staticmethod
+    def _popen_options() -> dict[str, Any]:
+        """创建独立进程组，使停止命令时不会遗留 shell 子进程。"""
+        if os.name == "nt":
+            return {
+                "creationflags": getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0),
+            }
+        return {"start_new_session": True}
+
+    @staticmethod
+    def _read_output(stream: Any, output: _BoundedOutput) -> None:
+        """持续消费管道并把日志和结果限制在固定内存上限内。"""
+        if stream is None:
+            return
+        try:
+            while True:
+                chunk = stream.read(OUTPUT_READ_SIZE)
+                if not chunk:
+                    break
+                output.append(chunk)
+                for line in chunk.splitlines():
+                    if line.strip():
+                        logger.info(line.strip())
+        except (OSError, ValueError) as error:
+            logger.debug("读取命令输出结束：%s", error)
+
+    def _execute_process(self, command: str) -> CommandResult:
+        """持续消费两个管道，避免阻塞并限制结果输出大小。"""
+        process: Optional[subprocess.Popen[str]] = None
+        stdout = _BoundedOutput(MAX_OUTPUT_SIZE)
+        stderr = _BoundedOutput(MAX_OUTPUT_SIZE)
+        readers: list[threading.Thread] = []
+        try:
+            with self._process_lock:
+                # 进程句柄由生命周期清理逻辑统一回收，不能通过上下文管理器提前关闭。
+                # pylint: disable-next=consider-using-with
+                process = subprocess.Popen(
+                    command,
+                    shell=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    **self._popen_options(),
+                )
+                self._process = process
+            for stream, output, name in (
+                (process.stdout, stdout, "custom-command-stdout"),
+                (process.stderr, stderr, "custom-command-stderr"),
+            ):
+                reader = threading.Thread(
+                    target=self._read_output,
+                    args=(stream, output),
+                    name=name,
+                    daemon=True,
+                )
+                readers.append(reader)
+                reader.start()
+            process.wait()
+            for reader in readers:
+                reader.join(timeout=PROCESS_STOP_TIMEOUT)
+        except Exception as error:  # pylint: disable=broad-exception-caught
+            logger.error("命令启动失败：%s", error)
+            return CommandResult(returncode=None, error=f"命令启动失败：{error}")
+        finally:
+            if process is not None:
+                self._clear_process(process)
+        if process is None:
+            return CommandResult(returncode=None, error="命令启动失败：未创建进程")
+        logger.info("命令执行%s，返回码=%s", "成功" if process.returncode == 0 else "失败", process.returncode)
+        return CommandResult(
+            returncode=process.returncode,
+            stdout=stdout.getvalue(),
+            stderr=stderr.getvalue(),
+        )
+
+    def _clear_process(self, process: subprocess.Popen[str]) -> None:
+        """仅清理仍指向该实例的句柄，避免旧任务覆盖新任务状态。"""
+        with self._process_lock:
+            if self._process is process:
+                self._process = None
+
+    def _save_history(self, task: CommandTask, result: CommandResult) -> None:
+        """追加执行历史并丢弃超出保留期或格式损坏的旧记录。"""
+        timezone = ZoneInfo(str(settings.TZ))
+        now = datetime.now(timezone)
+        history = self.get_data("history") or []
+        if not isinstance(history, list):
+            history = [history]
+        history.append({
+            "name": task.name,
+            "command": task.command,
+            "result": result.message,
+            "time": now.strftime("%Y-%m-%d %H:%M:%S"),
+        })
+        cutoff = now - timedelta(days=self._history_days)
+        retained = []
+        for record in history:
+            if not isinstance(record, dict):
+                continue
+            try:
+                recorded_at = datetime.strptime(
+                    str(record["time"]), "%Y-%m-%d %H:%M:%S"
+                ).replace(tzinfo=timezone)
+            except (KeyError, TypeError, ValueError):
+                continue
+            if recorded_at >= cutoff:
+                retained.append(record)
+        self.save_data(key="history", value=retained)
+
+    def _notify_result(self, task: CommandTask, result: CommandResult) -> None:
+        """按现有通知开关、消息类型和关键词规则投递执行结果。"""
+        if not self._notify or not self._msgtype:
+            return
+        message = result.message
+        if self._notify_keywords:
+            try:
+                matched = re.search(self._notify_keywords, message)
+            except re.error as error:
+                self._report_config_error(f"通知关键词正则表达式错误：{error}")
+                return
+            if not matched:
+                logger.info("通知关键词 %s 不匹配，跳过通知", self._notify_keywords)
+                return
+        message_type = MessageType.__members__.get(str(self._msgtype), MessageType.Manual)
+        self.post_message(
+            title=task.name,
+            mtype=message_type,
+            text=message,
+        )
+
+    def _run_task(self, task: CommandTask, *, apply_delay: bool) -> CommandResult:
+        """执行单个任务并完成历史与通知副作用。"""
+        if apply_delay and task.random_delay:
+            lower, upper = self._delay_bounds(task.random_delay)
+            delay = random.randint(lower, upper)
+            logger.info("任务 %s 随机延时 %s 秒", task.name, delay)
+            if self._stop_event.wait(delay):
+                return CommandResult(returncode=None, error="任务已停止")
+        if self._stop_event.is_set():
+            return CommandResult(returncode=None, error="任务已停止")
+        result = self._execute_process(task.command)
+        self._save_history(task, result)
+        self._notify_result(task, result)
+        return result
+
+    def _run_periodic_task(self, task: CommandTask) -> bool | tuple[bool, str]:
+        """周期任务采用非阻塞 single-flight，重叠触发直接跳过。"""
+        # 非阻塞获取决定了重叠任务的“跳过”语义，不能改用阻塞上下文。
+        # pylint: disable-next=consider-using-with
+        if not self._run_lock.acquire(blocking=False):
+            message = f"任务 {task.name} 触发时已有命令正在执行，本次已跳过"
+            logger.warning(message)
+            return False, message
+        try:
+            if not self._enabled or self._stop_event.is_set():
+                return False, "插件已停用"
+            result = self._run_task(task, apply_delay=True)
+            if result.success:
+                return True
+            return False, result.message or "命令执行失败"
+        except (TypeError, ValueError) as error:
+            message = f"任务 {task.name} 随机延时配置错误：{error}"
+            self._report_config_error(message)
+            return False, message
+        except Exception as error:  # pylint: disable=broad-exception-caught
+            message = f"任务 {task.name} 执行失败：{error}"
+            logger.error(message)
+            return False, message
+        finally:
+            self._run_lock.release()
+
+    def _consume_once(self) -> Optional[list[CommandTask]]:
+        """配置持久化成功后才消费一次性执行意图。"""
+        with self._once_lock:
+            if not self._run_once:
+                return None
+            tasks = self._tasks()
+            if not tasks:
+                return None
+            try:
+                persisted = self.update_config(self._config_payload(onlyonce=False))
+            except Exception as error:  # pylint: disable=broad-exception-caught
+                logger.error("保存一次性命令状态失败：%s", error)
+                return None
+            if persisted is False:
+                logger.error("保存一次性命令状态失败：宿主拒绝更新配置")
+                return None
+            self._onlyonce = False
+            self._run_once = False
+            return tasks
+
+    def _run_once_tasks(self) -> bool | tuple[bool, str]:
+        """等待执行槽并串行完成全部一次性任务，避免消费后丢任务。"""
+        with self._run_lock:
+            tasks = self._consume_once()
+            if tasks is None:
+                return False, "一次性任务无有效配置、已被消费或状态保存失败"
+            failed = []
+            for task in tasks:
+                try:
+                    result = self._run_task(task, apply_delay=False)
+                except Exception as error:  # pylint: disable=broad-exception-caught
+                    logger.error("一次性任务 %s 执行失败：%s", task.name, error)
+                    failed.append(task.name)
+                    continue
+                if not result.success:
+                    failed.append(task.name)
+            if failed:
+                return False, f"一次性任务执行失败：{', '.join(failed)}"
+            return True
+
+    def get_state(self) -> bool:
+        """启用状态或待执行的一次性状态均需向宿主投影服务。"""
+        return self._enabled or self._run_once
+
+    @staticmethod
+    def get_command() -> list[dict[str, Any]]:
+        """本插件不注册远程命令。"""
+        return []
+
+    def get_api(self) -> list[dict[str, Any]]:
+        """本插件不暴露 HTTP API。"""
+        return []
+
+    def get_service(self) -> list[dict[str, Any]]:
+        """把一次性和周期任务投影为宿主调度服务。"""
+        tasks = self._tasks()
+        services: list[dict[str, Any]] = []
+        timezone = ZoneInfo(str(settings.TZ))
+        if self._run_once and tasks:
+            services.append({
+                "id": "CustomCommand.Once",
+                "name": "自定义命令（立即运行）",
+                "trigger": "date",
+                "func": self._run_once_tasks,
+                "kwargs": {"run_date": datetime.now(timezone) + timedelta(seconds=3)},
+            })
+        if not self._enabled:
+            return services
+
+        for task in tasks:
+            try:
+                if task.random_delay:
+                    self._delay_bounds(task.random_delay)
+                trigger = CronTrigger.from_crontab(task.cron, timezone=timezone)
+            except (TypeError, ValueError) as error:
+                self._report_config_error(
+                    f"第 {task.line_number} 行定时任务配置错误：{error}"
+                )
+                continue
+            services.append({
+                "id": f"CustomCommand.{task.line_number}",
+                "name": task.name + (
+                    f"（随机延时 {task.random_delay} 秒）" if task.random_delay else ""
+                ),
+                "trigger": trigger,
+                "func": self._run_periodic_task,
+                "kwargs": {},
+                "func_kwargs": {"task": task},
+            })
+        return services
+
+    def get_form(self) -> tuple[list[dict], dict[str, Any]]:
+        """返回配置表单和默认值。"""
+        message_type_options = [
+            {"title": item.value, "value": item.name} for item in MessageType
+        ]
+        return [{
+            "component": "VForm",
+            "content": [
+                {
+                    "component": "VRow",
+                    "content": [
+                        self._switch("enabled", "启用插件"),
+                        self._switch("notify", "发送通知"),
+                        self._switch("onlyonce", "立即运行一次"),
+                        self._switch("clear", "清除历史记录"),
+                    ],
+                },
+                {
+                    "component": "VRow",
+                    "content": [
+                        {
+                            "component": "VCol",
+                            "props": {"cols": 12, "md": 4},
+                            "content": [{
+                                "component": "VSelect",
+                                "props": {
+                                    "model": "msgtype",
+                                    "label": "消息类型",
+                                    "items": message_type_options,
+                                    "multiple": False,
+                                    "chips": True,
+                                },
+                            }],
+                        },
+                        self._text_field("history_days", "保留历史天数"),
+                        self._text_field(
+                            "notify_keywords",
+                            "通知关键词",
+                            "支持正则表达式，未配置时所有通知均推送",
+                        ),
+                    ],
+                },
+                {
+                    "component": "VRow",
+                    "content": [{
+                        "component": "VCol",
+                        "props": {"cols": 12},
+                        "content": [{
+                            "component": "VTextarea",
+                            "props": {
+                                "model": "time_confs",
+                                "label": "执行命令",
+                                "rows": 2,
+                                "placeholder": (
+                                    "命令名#0 9 * * *#python main.py\n"
+                                    "命令名#0 9 * * *#python main.py#1-600"
+                                ),
+                            },
+                        }],
+                    }],
+                },
+                self._alert("命令名#cron表达式#命令"),
+                self._alert("命令名#cron表达式#命令#随机延时（单位秒）"),
+            ],
+        }], {
+            "enabled": False,
+            "notify": False,
+            "onlyonce": False,
+            "clear": False,
+            "time_confs": "",
+            "history_days": 30,
+            "notify_keywords": "",
+            "msgtype": "",
+        }
+
+    @staticmethod
+    def _switch(model: str, label: str) -> dict[str, Any]:
+        """构造四列开关字段。"""
+        return {
+            "component": "VCol",
+            "props": {"cols": 12, "md": 3},
+            "content": [{
+                "component": "VSwitch",
+                "props": {"model": model, "label": label},
+            }],
+        }
+
+    @staticmethod
+    def _text_field(
+        model: str,
+        label: str,
+        placeholder: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """构造三列文本字段。"""
+        props = {"model": model, "label": label}
+        if placeholder:
+            props["placeholder"] = placeholder
+        return {
+            "component": "VCol",
+            "props": {"cols": 12, "md": 4},
+            "content": [{"component": "VTextField", "props": props}],
+        }
+
+    @staticmethod
+    def _alert(text: str) -> dict[str, Any]:
+        """构造命令格式提示。"""
+        return {
+            "component": "VRow",
+            "content": [{
+                "component": "VCol",
+                "props": {"cols": 12},
+                "content": [{
+                    "component": "VAlert",
+                    "props": {"type": "info", "variant": "tonal", "text": text},
+                }],
+            }],
+        }
+
+    def get_page(self) -> list[dict]:
+        """返回按执行时间倒序排列的历史页面。"""
+        history = self.get_data("history") or []
+        if not history:
+            return [{
+                "component": "div",
+                "text": "暂无数据",
+                "props": {"class": "text-center"},
+            }]
+        if not isinstance(history, list):
+            history = [history]
+        history = sorted(
+            (item for item in history if isinstance(item, dict)),
+            key=lambda item: item.get("time") or "",
+            reverse=True,
+        )
+        rows = [{
+            "component": "tr",
+            "props": {"class": "text-sm"},
+            "content": [
+                self._cell(item.get("time"), "whitespace-nowrap break-keep text-high-emphasis"),
+                self._cell(item.get("name")),
+                self._cell(item.get("result")),
+            ],
+        } for item in history]
+        return [{
+            "component": "VRow",
+            "content": [{
+                "component": "VCol",
+                "props": {"cols": 12},
+                "content": [{
+                    "component": "VTable",
+                    "props": {"hover": True},
+                    "content": [
+                        {
+                            "component": "thead",
+                            "content": [{
+                                "component": "tr",
+                                "content": [
+                                    self._header("执行时间"),
+                                    self._header("命令名称"),
+                                    self._header("执行结果"),
+                                ],
+                            }],
+                        },
+                        {"component": "tbody", "content": rows},
+                    ],
+                }],
+            }],
+        }]
+
+    @staticmethod
+    def _cell(value: Any, css_class: Optional[str] = None) -> dict[str, Any]:
+        """构造历史表格单元格。"""
+        cell: dict[str, Any] = {"component": "td", "text": value or ""}
+        if css_class:
+            cell["props"] = {"class": css_class}
+        return cell
+
+    @staticmethod
+    def _header(text: str) -> dict[str, Any]:
+        """构造历史表头。"""
+        return {
+            "component": "th",
+            "props": {"class": "text-start ps-4"},
+            "text": text,
+        }
+
+    @staticmethod
+    def _terminate_process(process: subprocess.Popen[str], *, force: bool) -> None:
+        """向独立进程组发送终止信号，并兼容 Windows 进程组语义。"""
+        if os.name == "nt":
+            ctrl_break_event = getattr(signal, "CTRL_BREAK_EVENT", None)
+            if not force and ctrl_break_event is not None:
+                try:
+                    process.send_signal(ctrl_break_event)
+                    return
+                except (OSError, ProcessLookupError, ValueError):
+                    pass
+            try:
+                process.kill() if force else process.terminate()
+            except (OSError, ProcessLookupError, ValueError):
+                return
+            return
+        try:
+            os.killpg(process.pid, signal.SIGKILL if force else signal.SIGTERM)
+        except (OSError, ProcessLookupError):
+            # 自然退出与 stop_service 并发时，进程组可能已经不存在。
+            return
+
+    def stop_service(self) -> Optional[bool]:
+        """在进程锁内停止当前命令，并清理已退出的进程句柄。"""
+        self._stop_event.set()
+        converged = True
+        with self._process_lock:
+            process = self._process
+            if process is not None and process.poll() is not None:
+                self._clear_process(process)
+                process = None
+            if process is not None:
+                stopped = False
+                self._terminate_process(process, force=False)
+                try:
+                    process.wait(timeout=PROCESS_STOP_TIMEOUT)
+                    stopped = True
+                except subprocess.TimeoutExpired:
+                    self._terminate_process(process, force=True)
+                    try:
+                        process.wait(timeout=PROCESS_STOP_TIMEOUT)
+                        stopped = True
+                    except subprocess.TimeoutExpired:
+                        converged = False
+                        logger.error("命令进程停止超时，PID=%s", process.pid)
+                if stopped:
+                    self._clear_process(process)
+        if not converged:
+            return False
+        # 无进程窗口仍可能有已取得执行槽的任务；停止事件会使其在 Popen 前退出。
+        with self._run_lock:
+            pass
+        return None

--- a/plugins.v3/dockermanager/__init__.py
+++ b/plugins.v3/dockermanager/__init__.py
@@ -1,0 +1,624 @@
+"""提供由宿主调度器管理的 Docker 容器任务。"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any, Optional
+from zoneinfo import ZoneInfo
+
+import docker
+from apscheduler.triggers.cron import CronTrigger
+
+from app.plugins import _PluginBase
+from app.schemas.types import MessageType
+from app.sdk.config import settings
+from app.sdk.logging import logger
+
+
+@dataclass(frozen=True)
+class DockerTask:
+    """保存一行 Docker 任务配置。"""
+
+    line_number: int
+    container_names: tuple[str, ...]
+    cron: str
+    command: str
+
+    @property
+    def display_names(self) -> str:
+        """返回用于服务名称和日志的容器名列表。"""
+        return ",".join(self.container_names)
+
+
+@dataclass(frozen=True)
+class ContainerResult:
+    """保存单个容器的任务执行结果。"""
+
+    name: str
+    command: str
+    success: bool
+    error: Optional[str] = None
+    icon: Optional[str] = None
+
+    @property
+    def message(self) -> str:
+        """返回与历史及通知一致的可读结果。"""
+        status = "success" if self.success else "fail"
+        suffix = f"：{self.error}" if self.error else ""
+        return f"容器：{self.name} {self.command} {status}{suffix}"
+
+
+# 插件配置字段保持与已发布配置键一一对应，避免隐式迁移或丢字段。
+# pylint: disable=too-many-instance-attributes
+class DockerManager(_PluginBase):
+    """按 cron 或一次性配置控制指定 Docker 容器。"""
+
+    plugin_name = "docker自定义任务"
+    plugin_desc = "管理宿主机docker，自定义容器定时任务。"
+    plugin_icon = "Docker_F.png"
+    plugin_version = "2.0.0"
+    plugin_author = "thsrite"
+    author_url = "https://github.com/thsrite"
+    plugin_config_prefix = "dockermanager_"
+    plugin_order = 39
+    auth_level = 1
+
+    SUPPORTED_COMMANDS = frozenset({
+        "restart",
+        "start",
+        "stop",
+        "pause",
+        "unpause",
+        "update",
+    })
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._enabled = False
+        self._onlyonce = False
+        self._run_once = False
+        self._notify = False
+        self._clear = False
+        self._msgtype: Optional[str] = None
+        self._time_confs = ""
+        self._history_days = 30
+        self._docker_client: Any = None
+        self._run_lock = threading.Lock()
+        self._once_lock = threading.Lock()
+        self._client_lock = threading.Lock()
+
+    def init_plugin(self, config: Optional[dict] = None) -> None:
+        """释放旧 client 并读取配置；调度生命周期由宿主管理。"""
+        self.stop_service()
+        config = dict(config or {})
+        self._enabled = bool(config.get("enabled"))
+        self._onlyonce = bool(config.get("onlyonce"))
+        self._run_once = self._onlyonce
+        self._notify = bool(config.get("notify"))
+        self._msgtype = config.get("msgtype")
+        self._clear = bool(config.get("clear"))
+        self._time_confs = str(config.get("time_confs") or "")
+        self._history_days = self._normalise_history_days(config.get("history_days"))
+
+        if self._clear:
+            self.del_data("history")
+            self._clear = False
+            self.update_config(self._config_payload())
+
+    @staticmethod
+    def _normalise_history_days(value: Any) -> int:
+        """把非法历史保留天数收敛到兼容默认值。"""
+        try:
+            days = int(value or 30)
+        except (TypeError, ValueError):
+            return 30
+        return max(days, 1)
+
+    def _config_payload(self, *, onlyonce: Optional[bool] = None) -> dict[str, Any]:
+        """返回消费开关时需要持久化的完整配置。"""
+        return {
+            "enabled": self._enabled,
+            "onlyonce": self._onlyonce if onlyonce is None else onlyonce,
+            "notify": self._notify,
+            "msgtype": self._msgtype,
+            "time_confs": self._time_confs,
+            "history_days": self._history_days,
+            "clear": self._clear,
+        }
+
+    def _report_config_error(self, message: str) -> None:
+        """同时写入日志和宿主系统消息。"""
+        logger.error(message)
+        self.systemmessage.put(message)
+
+    def _tasks(self) -> list[DockerTask]:
+        """逐行解析任务，并隔离格式、容器名和命令错误。"""
+        tasks: list[DockerTask] = []
+        for line_number, raw_line in enumerate(self._time_confs.splitlines(), start=1):
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split("#")
+            if len(parts) != 3 or not all(part.strip() for part in parts):
+                self._report_config_error(f"第 {line_number} 行 Docker 任务配置错误，已跳过")
+                continue
+            names = tuple(dict.fromkeys(
+                name.strip() for name in parts[0].split(",") if name.strip()
+            ))
+            command = parts[2].strip().lower()
+            if not names:
+                self._report_config_error(f"第 {line_number} 行没有有效容器名，已跳过")
+                continue
+            if command not in self.SUPPORTED_COMMANDS:
+                self._report_config_error(
+                    f"第 {line_number} 行 Docker 命令 {command} 不受支持，已跳过"
+                )
+                continue
+            tasks.append(DockerTask(
+                line_number=line_number,
+                container_names=names,
+                cron=parts[1].strip(),
+                command=command,
+            ))
+        return tasks
+
+    def _get_client(self) -> Any:
+        """按宿主配置惰性创建并复用 Docker client。"""
+        with self._client_lock:
+            if self._docker_client is not None:
+                return self._docker_client
+            base_url = str(settings.DOCKER_CLIENT_API or "").strip()
+            if not base_url:
+                raise RuntimeError("宿主未配置 DOCKER_CLIENT_API")
+            self._docker_client = docker.DockerClient(base_url=base_url)
+            return self._docker_client
+
+    @staticmethod
+    def _container_attrs(container: Any) -> dict[str, Any]:
+        """把 Docker SDK 的动态 attrs 边界规整为字典。"""
+        attrs = getattr(container, "attrs", None)
+        return attrs if isinstance(attrs, dict) else {}
+
+    @classmethod
+    def _container_name(cls, container: Any) -> Optional[str]:
+        """优先沿用 HOST_CONTAINERNAME，缺失时回退到 Docker 标准名称。"""
+        attrs = cls._container_attrs(container)
+        config = attrs.get("Config")
+        config = config if isinstance(config, dict) else {}
+        envs = config.get("Env")
+        if isinstance(envs, list):
+            for item in envs:
+                if not isinstance(item, str):
+                    continue
+                key, separator, value = item.partition("=")
+                if separator and key == "HOST_CONTAINERNAME" and value:
+                    return value
+        name = getattr(container, "name", None)
+        if isinstance(name, str) and name.strip():
+            return name.strip()
+        raw_name = attrs.get("Name")
+        if isinstance(raw_name, str) and raw_name.strip("/"):
+            return raw_name.strip("/")
+        return None
+
+    @classmethod
+    def _container_icon(cls, container: Any) -> Optional[str]:
+        """读取可选 Unraid 图标，缺失或非 HTTP 地址时不用于通知。"""
+        attrs = cls._container_attrs(container)
+        config = attrs.get("Config")
+        config = config if isinstance(config, dict) else {}
+        labels = config.get("Labels")
+        labels = labels if isinstance(labels, dict) else {}
+        icon = labels.get("net.unraid.docker.icon")
+        if isinstance(icon, str) and icon.startswith(("http://", "https://")):
+            return icon
+        return None
+
+    @staticmethod
+    def _execute_container(
+        container: Any,
+        name: str,
+        command: str,
+        icon: Optional[str],
+    ) -> ContainerResult:
+        """执行经过白名单校验的容器方法，并把 SDK 异常转为结果。"""
+        try:
+            operation = getattr(container, command)
+            operation()
+        except Exception as error:  # pylint: disable=broad-exception-caught
+            logger.error("容器 %s 执行 %s 失败：%s", name, command, error)
+            return ContainerResult(
+                name=name,
+                command=command,
+                success=False,
+                error=str(error),
+                icon=icon,
+            )
+        logger.info("容器 %s 执行 %s 成功", name, command)
+        return ContainerResult(
+            name=name,
+            command=command,
+            success=True,
+            icon=icon,
+        )
+
+    def _save_history(self, results: list[ContainerResult]) -> None:
+        """批量追加容器结果并清理损坏或过期的旧记录。"""
+        timezone = ZoneInfo(str(settings.TZ))
+        now = datetime.now(timezone)
+        history = self.get_data("history") or []
+        if not isinstance(history, list):
+            history = [history]
+        for result in results:
+            history.append({
+                "name": result.name,
+                "command": result.command,
+                "result": "success" if result.success else "fail",
+                "time": now.strftime("%Y-%m-%d %H:%M:%S"),
+            })
+        cutoff = now - timedelta(days=self._history_days)
+        retained = []
+        for record in history:
+            if not isinstance(record, dict):
+                continue
+            try:
+                recorded_at = datetime.strptime(
+                    str(record["time"]), "%Y-%m-%d %H:%M:%S"
+                ).replace(tzinfo=timezone)
+            except (KeyError, TypeError, ValueError):
+                continue
+            if recorded_at >= cutoff:
+                retained.append(record)
+        self.save_data(key="history", value=retained)
+
+    def _notify_results(self, task: DockerTask, results: list[ContainerResult]) -> None:
+        """按原通知开关发送本次任务的聚合结果。"""
+        if not self._notify or not self._msgtype:
+            return
+        message_type = MessageType.__members__.get(str(self._msgtype), MessageType.Manual)
+        image = None
+        if len(task.container_names) == 1 and results:
+            image = results[0].icon
+        self.post_message(
+            title="docker任务通知",
+            mtype=message_type,
+            text="\n".join(result.message for result in results),
+            image=image,
+        )
+
+    def _run_task(self, task: DockerTask) -> list[ContainerResult]:
+        """执行一个任务中的全部容器，并显式报告未找到的目标。"""
+        try:
+            containers = self._get_client().containers.list(all=True)
+        except Exception as error:  # pylint: disable=broad-exception-caught
+            logger.error("获取 Docker 容器列表失败：%s", error)
+            results = [
+                ContainerResult(name=name, command=task.command, success=False, error=str(error))
+                for name in task.container_names
+            ]
+            self._save_history(results)
+            self._notify_results(task, results)
+            return results
+
+        by_name: dict[str, Any] = {}
+        for container in containers or []:
+            name = self._container_name(container)
+            if name and name not in by_name:
+                by_name[name] = container
+
+        results = []
+        for name in task.container_names:
+            container = by_name.get(name)
+            if container is None:
+                result = ContainerResult(
+                    name=name,
+                    command=task.command,
+                    success=False,
+                    error="未找到容器",
+                )
+                logger.error(result.message)
+            else:
+                result = self._execute_container(
+                    container,
+                    name,
+                    task.command,
+                    self._container_icon(container),
+                )
+            results.append(result)
+        self._save_history(results)
+        self._notify_results(task, results)
+        return results
+
+    def _run_periodic_task(self, task: DockerTask) -> bool | tuple[bool, str]:
+        """周期任务采用非阻塞 single-flight，重叠触发直接跳过。"""
+        # 非阻塞获取决定了重叠任务的“跳过”语义，不能改用阻塞上下文。
+        # pylint: disable-next=consider-using-with
+        if not self._run_lock.acquire(blocking=False):
+            message = f"Docker 任务 {task.display_names} 触发重叠，本次已跳过"
+            logger.warning(message)
+            return False, message
+        try:
+            results = self._run_task(task)
+            if results and all(result.success for result in results):
+                return True
+            return False, "Docker 任务存在失败容器"
+        except Exception as error:  # pylint: disable=broad-exception-caught
+            message = f"Docker 任务执行失败：{error}"
+            logger.error(message)
+            return False, message
+        finally:
+            self._run_lock.release()
+
+    def _consume_once(self) -> Optional[list[DockerTask]]:
+        """配置持久化成功后才消费一次性执行意图。"""
+        with self._once_lock:
+            if not self._run_once:
+                return None
+            tasks = self._tasks()
+            if not tasks:
+                return None
+            try:
+                persisted = self.update_config(self._config_payload(onlyonce=False))
+            except Exception as error:  # pylint: disable=broad-exception-caught
+                logger.error("保存一次性 Docker 任务状态失败：%s", error)
+                return None
+            if persisted is False:
+                logger.error("保存一次性 Docker 任务状态失败：宿主拒绝更新配置")
+                return None
+            self._onlyonce = False
+            self._run_once = False
+            return tasks
+
+    def _run_once_tasks(self) -> bool | tuple[bool, str]:
+        """等待执行槽并串行完成全部一次性 Docker 任务。"""
+        with self._run_lock:
+            tasks = self._consume_once()
+            if tasks is None:
+                return False, "一次性 Docker 任务无有效配置、已被消费或状态保存失败"
+            failed = []
+            for task in tasks:
+                try:
+                    results = self._run_task(task)
+                except Exception as error:  # pylint: disable=broad-exception-caught
+                    logger.error("一次性 Docker 任务 %s 失败：%s", task.display_names, error)
+                    failed.extend(task.container_names)
+                    continue
+                failed.extend(result.name for result in results if not result.success)
+            if failed:
+                return False, f"一次性 Docker 任务执行失败：{', '.join(failed)}"
+            return True
+
+    def get_state(self) -> bool:
+        """启用状态或待执行的一次性状态均需向宿主投影服务。"""
+        return self._enabled or self._run_once
+
+    @staticmethod
+    def get_command() -> list[dict[str, Any]]:
+        """本插件不注册远程命令。"""
+        return []
+
+    def get_api(self) -> list[dict[str, Any]]:
+        """本插件不暴露 HTTP API。"""
+        return []
+
+    def get_service(self) -> list[dict[str, Any]]:
+        """把一次性和周期 Docker 任务投影为宿主调度服务。"""
+        tasks = self._tasks()
+        timezone = ZoneInfo(str(settings.TZ))
+        services: list[dict[str, Any]] = []
+        if self._run_once and tasks:
+            services.append({
+                "id": "DockerManager.Once",
+                "name": "Docker 自定义任务（立即运行）",
+                "trigger": "date",
+                "func": self._run_once_tasks,
+                "kwargs": {"run_date": datetime.now(timezone) + timedelta(seconds=3)},
+            })
+        if not self._enabled:
+            return services
+        for task in tasks:
+            try:
+                trigger = CronTrigger.from_crontab(task.cron, timezone=timezone)
+            except (TypeError, ValueError) as error:
+                self._report_config_error(
+                    f"第 {task.line_number} 行 Docker 定时配置错误：{error}"
+                )
+                continue
+            services.append({
+                "id": f"DockerManager.{task.line_number}",
+                "name": f"{task.display_names} {task.command}",
+                "trigger": trigger,
+                "func": self._run_periodic_task,
+                "kwargs": {},
+                "func_kwargs": {"task": task},
+            })
+        return services
+
+    def get_form(self) -> tuple[list[dict], dict[str, Any]]:
+        """返回配置表单和默认值。"""
+        message_type_options = [
+            {"title": item.value, "value": item.name} for item in MessageType
+        ]
+        return [{
+            "component": "VForm",
+            "content": [
+                {
+                    "component": "VRow",
+                    "content": [
+                        self._switch("enabled", "启用插件"),
+                        self._switch("notify", "发送通知"),
+                        self._switch("onlyonce", "立即运行一次"),
+                        self._switch("clear", "清除历史记录"),
+                    ],
+                },
+                {
+                    "component": "VRow",
+                    "content": [
+                        {
+                            "component": "VCol",
+                            "props": {"cols": 12, "md": 6},
+                            "content": [{
+                                "component": "VSelect",
+                                "props": {
+                                    "model": "msgtype",
+                                    "label": "消息类型",
+                                    "items": message_type_options,
+                                    "multiple": False,
+                                    "chips": True,
+                                },
+                            }],
+                        },
+                        {
+                            "component": "VCol",
+                            "props": {"cols": 12, "md": 6},
+                            "content": [{
+                                "component": "VTextField",
+                                "props": {
+                                    "model": "history_days",
+                                    "label": "保留历史天数",
+                                },
+                            }],
+                        },
+                    ],
+                },
+                {
+                    "component": "VRow",
+                    "content": [{
+                        "component": "VCol",
+                        "props": {"cols": 12},
+                        "content": [{
+                            "component": "VTextarea",
+                            "props": {
+                                "model": "time_confs",
+                                "label": "执行命令",
+                                "rows": 2,
+                                "placeholder": (
+                                    "容器名#cron表达式#restart/start/stop/"
+                                    "pause/unpause/update"
+                                ),
+                            },
+                        }],
+                    }],
+                },
+                {
+                    "component": "VRow",
+                    "content": [{
+                        "component": "VCol",
+                        "props": {"cols": 12},
+                        "content": [{
+                            "component": "VAlert",
+                            "props": {
+                                "type": "info",
+                                "variant": "tonal",
+                                "text": (
+                                    "容器名(多个容器名,拼接)#cron表达式#"
+                                    "restart/start/stop/pause/unpause/update"
+                                ),
+                            },
+                        }],
+                    }],
+                },
+            ],
+        }], {
+            "enabled": False,
+            "notify": False,
+            "onlyonce": False,
+            "clear": False,
+            "time_confs": "",
+            "history_days": 30,
+            "msgtype": "",
+        }
+
+    @staticmethod
+    def _switch(model: str, label: str) -> dict[str, Any]:
+        """构造四列开关字段。"""
+        return {
+            "component": "VCol",
+            "props": {"cols": 12, "md": 3},
+            "content": [{
+                "component": "VSwitch",
+                "props": {"model": model, "label": label},
+            }],
+        }
+
+    def get_page(self) -> list[dict]:
+        """返回按执行时间倒序排列的历史页面。"""
+        history = self.get_data("history") or []
+        if not history:
+            return [{
+                "component": "div",
+                "text": "暂无数据",
+                "props": {"class": "text-center"},
+            }]
+        if not isinstance(history, list):
+            history = [history]
+        history = sorted(
+            (item for item in history if isinstance(item, dict)),
+            key=lambda item: item.get("time") or "",
+            reverse=True,
+        )
+        rows = [{
+            "component": "tr",
+            "props": {"class": "text-sm"},
+            "content": [
+                self._cell(item.get("time")),
+                self._cell(item.get("name")),
+                self._cell(item.get("command")),
+                self._cell(item.get("result")),
+            ],
+        } for item in history]
+        return [{
+            "component": "VRow",
+            "content": [{
+                "component": "VCol",
+                "props": {"cols": 12},
+                "content": [{
+                    "component": "VTable",
+                    "props": {"hover": True},
+                    "content": [
+                        {
+                            "component": "thead",
+                            "content": [{
+                                "component": "tr",
+                                "content": [
+                                    self._header("执行时间"),
+                                    self._header("容器名称"),
+                                    self._header("命令"),
+                                    self._header("执行结果"),
+                                ],
+                            }],
+                        },
+                        {"component": "tbody", "content": rows},
+                    ],
+                }],
+            }],
+        }]
+
+    @staticmethod
+    def _cell(value: Any) -> dict[str, Any]:
+        """构造历史表格单元格。"""
+        return {"component": "td", "text": value or ""}
+
+    @staticmethod
+    def _header(text: str) -> dict[str, Any]:
+        """构造历史表头。"""
+        return {
+            "component": "th",
+            "props": {"class": "text-start ps-4"},
+            "text": text,
+        }
+
+    def stop_service(self) -> None:
+        """等待正在执行的任务结束，再关闭并清空 Docker client。"""
+        with self._run_lock:
+            with self._client_lock:
+                client = self._docker_client
+                self._docker_client = None
+            if client is None:
+                return
+            try:
+                client.close()
+            except Exception as error:  # pylint: disable=broad-exception-caught
+                logger.error("关闭 Docker client 失败：%s", error)

--- a/tests/v3/cloudstrm/test_cloudstrm.py
+++ b/tests/v3/cloudstrm/test_cloudstrm.py
@@ -1,0 +1,441 @@
+from __future__ import annotations
+
+import ast
+import json
+import stat
+import threading
+import time
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from apscheduler.triggers.cron import CronTrigger
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+from app.plugins import cloudstrm as cloudstrm_module
+from app.plugins.cloudstrm import CloudStrm
+
+
+PLUGIN_PATH = REPOSITORY_ROOT / "plugins.v3" / "cloudstrm" / "__init__.py"
+
+
+def _plugin(tmp_path: Path, monitor_confs: str, **config) -> CloudStrm:
+    """创建使用隔离索引文件的插件实例。"""
+    plugin = CloudStrm()
+    plugin.update_config = Mock()
+    plugin.init_plugin(
+        {
+            "enabled": True,
+            "cron": "",
+            "rebuild_cron": "",
+            "onlyonce": False,
+            "rebuild": False,
+            "copy_files": False,
+            "https": False,
+            "monitor_confs": monitor_confs,
+            **config,
+        }
+    )
+    plugin._cloud_files_json = tmp_path / "cloud_files.json"
+    return plugin
+
+
+def _index(path: Path) -> list[str]:
+    """读取索引文件并返回排序后的源文件列表。"""
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_v3_manifest_and_import_contracts() -> None:
+    """V3 索引、版本和 SDK 导入边界必须一致。"""
+    manifest = json.loads(
+        (REPOSITORY_ROOT / "package.v3.json").read_text(encoding="utf-8")
+    )["CloudStrm"]
+    legacy_manifest = json.loads(
+        (REPOSITORY_ROOT / "package.json").read_text(encoding="utf-8")
+    )["CloudStrm"]
+
+    assert manifest["version"] == CloudStrm.plugin_version == "5.0.0"
+    assert manifest["system_version"] == ">=3.0.0"
+    assert manifest["release"] is True
+    assert manifest["history"]["v5.0.0"]
+    assert legacy_manifest["v3"] is False
+
+    source = PLUGIN_PATH.read_text(encoding="utf-8")
+    imports = {
+        node.module
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.ImportFrom) and node.module
+    }
+    assert {
+        "app.sdk.config",
+        "app.sdk.events",
+        "app.sdk.logging",
+    }.issubset(imports)
+    forbidden_prefixes = (
+        "app.adapters",
+        "app.application",
+        "app.core",
+        "app.db",
+        "app.domain",
+        "app.foundation",
+        "app.helper",
+        "app.runtime",
+        "app.sdk._legacy",
+        "app.utils",
+    )
+    assert not any(module.startswith(forbidden_prefixes) for module in imports)
+    assert "app.log" not in imports
+    assert "BackgroundScheduler" not in source
+
+
+def test_scan_maps_components_and_skips_hidden_directories(tmp_path: Path) -> None:
+    """扫描必须按路径组件映射，并过滤隐藏、回收站和 extrafanart 目录。"""
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    library = Path("/media/cloud")
+    (source / "Show").mkdir(parents=True)
+    (source / "Show" / "Movie.mp4").write_bytes(b"video")
+    (source / ".hidden.mp4").write_bytes(b"hidden")
+    (source / ".hidden" / "inside.mp4").parent.mkdir()
+    (source / ".hidden" / "inside.mp4").write_bytes(b"hidden")
+    (source / "@Recycle" / "deleted.mp4").parent.mkdir()
+    (source / "@Recycle" / "deleted.mp4").write_bytes(b"recycle")
+    (source / "#recycle" / "deleted.mp4").parent.mkdir()
+    (source / "#recycle" / "deleted.mp4").write_bytes(b"recycle")
+    (source / "@eaDir" / "metadata.mp4").parent.mkdir()
+    (source / "@eaDir" / "metadata.mp4").write_bytes(b"metadata")
+    (source / "extrafanart" / "fanart.mp4").parent.mkdir()
+    (source / "extrafanart" / "fanart.mp4").write_bytes(b"fanart")
+
+    plugin = _plugin(tmp_path, f"{source}#{target}#{library}")
+
+    assert plugin.scan() is True
+    assert (target / "Show" / "Movie.strm").read_text(encoding="utf-8") == (
+        "/media/cloud/Show/Movie.mp4"
+    )
+    assert not (target / ".hidden.strm").exists()
+    assert not (target / ".hidden").exists()
+    assert not (target / "@Recycle").exists()
+    assert not (target / "#recycle").exists()
+    assert not (target / "@eaDir").exists()
+    assert not (target / "extrafanart").exists()
+    assert _index(plugin._cloud_files_json) == [str(source / "Show" / "Movie.mp4")]
+
+
+def test_cloud_url_mapping_requires_component_boundary(tmp_path: Path) -> None:
+    """云盘 URL 只能从配置的挂载根按组件生成，不能使用字符串前缀替换。"""
+    source = tmp_path / "cloud"
+    target = tmp_path / "target"
+    cloud_path = source
+    source.mkdir()
+    (source / "Movie Name.mp4").write_bytes(b"video")
+    plugin = _plugin(
+        tmp_path,
+        f"{source}#{target}#alist#{cloud_path}#alist.example.test",
+    )
+
+    assert plugin.scan() is True
+    assert (target / "Movie Name.strm").read_text(encoding="utf-8") == (
+        "http://alist.example.test/d/%2FMovie%20Name.mp4"
+    )
+
+    mirrored = tmp_path / "cloudish" / "Movie Name.mp4"
+    assert plugin._CloudStrm__build_strm_content(
+        plugin._monitors[0], mirrored, target / "Movie Name.mp4"
+    ) is None
+
+
+def test_existing_targets_are_never_overwritten(tmp_path: Path) -> None:
+    """目标文件或 STRM 已存在时只跳过，不覆盖已有内容。"""
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    (source / "Movie.mp4").write_bytes(b"video")
+    (target).mkdir()
+    strm = target / "Movie.strm"
+    strm.write_text("keep", encoding="utf-8")
+
+    plugin = _plugin(tmp_path, f"{source}#{target}#/media")
+
+    assert plugin.scan() is True
+    assert strm.read_text(encoding="utf-8") == "keep"
+    assert _index(plugin._cloud_files_json) == [str(source / "Movie.mp4")]
+
+
+def test_failed_generation_does_not_poison_index(tmp_path: Path) -> None:
+    """URL 配置不匹配时不得把未生成成功的文件写入处理索引。"""
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    (source / "Movie.mp4").write_bytes(b"video")
+    plugin = _plugin(
+        tmp_path,
+        f"{source}#{target}#cd2#{tmp_path / 'different-root'}#cd2.example.test",
+    )
+
+    assert plugin.scan() is False
+    assert not target.exists()
+    assert not plugin._cloud_files_json.exists()
+
+
+def test_rebuild_replaces_index_without_deleting_outputs(tmp_path: Path) -> None:
+    """重建只替换源文件索引，不删除已有目标文件。"""
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    old_source = source / "Old.mp4"
+    old_source.write_bytes(b"old")
+    plugin = _plugin(tmp_path, f"{source}#{target}#/media")
+
+    assert plugin.scan() is True
+    old_output = target / "Old.strm"
+    assert old_output.exists()
+    old_source.unlink()
+    new_source = source / "New.mp4"
+    new_source.write_bytes(b"new")
+    plugin._rebuild = True
+
+    assert plugin.scan() is True
+    assert _index(plugin._cloud_files_json) == [str(new_source)]
+    assert old_output.exists()
+    assert plugin._rebuild is False
+
+
+def test_index_write_is_atomic_and_json_is_valid(tmp_path: Path) -> None:
+    """索引写入完成后应为有效 JSON，且不留下临时文件。"""
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    (source / "Movie.mp4").write_bytes(b"video")
+    plugin = _plugin(tmp_path, f"{source}#{target}#/media")
+
+    assert plugin.scan() is True
+    assert _index(plugin._cloud_files_json) == [str(source / "Movie.mp4")]
+    assert not list(plugin._cloud_files_json.parent.glob(f".{plugin._cloud_files_json.name}.*"))
+    assert stat.S_IMODE((target / "Movie.strm").stat().st_mode) == 0o644
+
+
+def test_temporary_file_setup_failures_return_false(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """临时文件创建失败必须收敛为失败结果，不能穿透宿主调度器。"""
+    source = tmp_path / "source.txt"
+    source.write_text("source", encoding="utf-8")
+    plugin = _plugin(tmp_path, "")
+    monkeypatch.setattr(
+        cloudstrm_module.tempfile,
+        "mkstemp",
+        Mock(side_effect=PermissionError("denied")),
+    )
+
+    assert plugin._CloudStrm__atomic_create_text(
+        tmp_path / "target" / "Movie.strm", "content"
+    ) is False
+    assert plugin._CloudStrm__copy_without_overwrite(
+        source, tmp_path / "copy" / "source.txt"
+    ) is False
+    assert plugin._CloudStrm__write_index({str(source)}) is False
+
+
+def test_host_services_cover_cron_rebuild_and_onlyonce(tmp_path: Path) -> None:
+    """周期、重建和一次性任务应由宿主服务投影统一注册。"""
+    source = tmp_path / "source"
+    source.mkdir()
+    plugin = _plugin(
+        tmp_path,
+        f"{source}#{tmp_path / 'target'}#/media",
+        cron="0 0 * * *",
+        rebuild_cron="0 1 * * *",
+        onlyonce=True,
+    )
+
+    services = plugin.get_service()
+    assert {service["id"] for service in services} == {
+        "CloudStrm",
+        "CloudStrmRebuild",
+        "CloudStrmOnce",
+    }
+    assert plugin.get_state() is True
+    assert all(
+        isinstance(service["trigger"], CronTrigger)
+        and str(service["trigger"].timezone) == "Asia/Shanghai"
+        for service in services
+        if service["id"] != "CloudStrmOnce"
+    )
+    once = next(service for service in services if service["id"] == "CloudStrmOnce")
+    plugin.update_config = Mock(return_value=True)
+    assert once["func"]() is True
+    assert plugin._onlyonce is False
+    assert plugin._run_once is False
+
+
+@pytest.mark.parametrize("persisted", [False, RuntimeError("storage unavailable")])
+def test_onlyonce_persistence_failure_keeps_pending_state(
+    tmp_path: Path,
+    persisted: object,
+) -> None:
+    """一次性状态回写失败时不得扫描或消费待执行意图。"""
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "Movie.mp4").write_bytes(b"video")
+    target = tmp_path / "target"
+    plugin = _plugin(
+        tmp_path,
+        f"{source}#{target}#/media",
+        enabled=False,
+        onlyonce=True,
+    )
+    if isinstance(persisted, Exception):
+        plugin.update_config = Mock(side_effect=persisted)
+    else:
+        plugin.update_config = Mock(return_value=persisted)
+
+    once = plugin.get_service()[0]
+    assert once["func"]() is False
+
+    assert plugin._onlyonce is True
+    assert plugin._run_once is True
+    assert not target.exists()
+    assert not plugin._cloud_files_json.exists()
+
+
+def test_onlyonce_waits_for_running_scan_before_consuming(tmp_path: Path) -> None:
+    """date job 必须等待扫描槽，避免重叠时丢失一次性任务。"""
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "Movie.mp4").write_bytes(b"video")
+    target = tmp_path / "target"
+    plugin = _plugin(
+        tmp_path,
+        f"{source}#{target}#/media",
+        enabled=False,
+        onlyonce=True,
+    )
+    plugin.update_config = Mock(return_value=True)
+    once = plugin.get_service()[0]
+    plugin._run_lock.acquire()
+    result: dict[str, bool] = {}
+    started = threading.Event()
+
+    def run_once() -> None:
+        started.set()
+        result["value"] = once["func"]()
+
+    worker = threading.Thread(target=run_once)
+    worker.start()
+    assert started.wait(timeout=1)
+    time.sleep(0.05)
+    plugin.update_config.assert_not_called()
+
+    plugin._run_lock.release()
+    worker.join(timeout=2)
+
+    assert not worker.is_alive()
+    assert result["value"] is True
+    assert plugin.update_config.call_args.args[0]["onlyonce"] is False
+    assert (target / "Movie.strm").exists()
+
+
+def test_scan_is_single_flight(tmp_path: Path) -> None:
+    """并发扫描不得重入同一索引和目标写入流程。"""
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "Movie.mp4").write_bytes(b"video")
+    plugin = _plugin(tmp_path, f"{source}#{tmp_path / 'target'}#/media")
+    assert plugin._run_lock.acquire(blocking=False)
+    try:
+        assert plugin.scan() is False
+    finally:
+        plugin._run_lock.release()
+
+
+def test_reload_waits_for_running_scan_before_switching_config(tmp_path: Path) -> None:
+    """热重载必须在旧扫描结束后一次性切换全部运行配置。"""
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "Movie.mp4").write_bytes(b"video")
+    old_target = tmp_path / "old-target"
+    new_target = tmp_path / "new-target"
+    plugin = _plugin(tmp_path, f"{source}#{old_target}#/old-media")
+    original_process = plugin._CloudStrm__process_file
+    entered = threading.Event()
+    release = threading.Event()
+    observed_https: list[bool] = []
+
+    def blocking_process(*args, **kwargs) -> bool:
+        entered.set()
+        assert release.wait(timeout=2)
+        observed_https.append(plugin._https)
+        return original_process(*args, **kwargs)
+
+    plugin._CloudStrm__process_file = blocking_process
+    scan_worker = threading.Thread(target=plugin.scan)
+    scan_worker.start()
+    assert entered.wait(timeout=1)
+
+    reload_worker = threading.Thread(
+        target=plugin.init_plugin,
+        args=(
+            {
+                "enabled": True,
+                "https": True,
+                "monitor_confs": f"{source}#{new_target}#/new-media",
+            },
+        ),
+    )
+    reload_worker.start()
+    time.sleep(0.05)
+
+    assert reload_worker.is_alive()
+    assert plugin._https is False
+    assert plugin._monitors[0].target_dir == old_target
+
+    release.set()
+    scan_worker.join(timeout=2)
+    reload_worker.join(timeout=2)
+
+    assert not scan_worker.is_alive()
+    assert not reload_worker.is_alive()
+    assert observed_https == [False]
+    assert plugin._https is True
+    assert plugin._monitors[0].target_dir == new_target
+
+
+def test_stop_waits_for_running_scan_and_blocks_later_writes(tmp_path: Path) -> None:
+    """停止返回时不得仍有扫描写入，过期宿主回调也必须失败关闭。"""
+    source = tmp_path / "source"
+    source.mkdir()
+    first_file = source / "First.mp4"
+    first_file.write_bytes(b"video")
+    target = tmp_path / "target"
+    plugin = _plugin(tmp_path, f"{source}#{target}#/media")
+    original_process = plugin._CloudStrm__process_file
+    entered = threading.Event()
+    release = threading.Event()
+
+    def blocking_process(*args, **kwargs) -> bool:
+        entered.set()
+        assert release.wait(timeout=2)
+        return original_process(*args, **kwargs)
+
+    plugin._CloudStrm__process_file = blocking_process
+    scan_worker = threading.Thread(target=plugin.scan)
+    scan_worker.start()
+    assert entered.wait(timeout=1)
+
+    stop_worker = threading.Thread(target=plugin.stop_service)
+    stop_worker.start()
+    time.sleep(0.05)
+    assert stop_worker.is_alive()
+
+    release.set()
+    scan_worker.join(timeout=2)
+    stop_worker.join(timeout=2)
+    assert not scan_worker.is_alive()
+    assert not stop_worker.is_alive()
+
+    second_file = source / "Second.mp4"
+    second_file.write_bytes(b"video")
+    assert plugin.scan() is False
+    assert not (target / "Second.strm").exists()

--- a/tests/v3/cloudstrmincrement/test_plugin.py
+++ b/tests/v3/cloudstrmincrement/test_plugin.py
@@ -1,0 +1,476 @@
+from __future__ import annotations
+
+import ast
+import json
+import threading
+import time
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from apscheduler.triggers.cron import CronTrigger
+from apscheduler.triggers.date import DateTrigger
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+from app.plugins.cloudstrmincrement import CloudStrmIncrement
+from app.runtime.events import Event
+from app.schemas.types import EventType
+
+
+PLUGIN_PATH = (
+    REPOSITORY_ROOT / "plugins.v3" / "cloudstrmincrement" / "__init__.py"
+)
+
+
+def _plugin(monitor_confs: str, **config) -> CloudStrmIncrement:
+    """创建使用指定目录映射的启用插件。"""
+    plugin = CloudStrmIncrement()
+    plugin.update_config = Mock(return_value=True)
+    plugin.init_plugin(
+        {
+            "enabled": True,
+            "cron": "",
+            "onlyonce": False,
+            "copy_files": False,
+            "del_source": True,
+            "https": False,
+            "monitor_confs": monitor_confs,
+            "no_del_dirs": "",
+            "rmt_mediaext": ".mp4,.mkv",
+            **config,
+        }
+    )
+    return plugin
+
+
+def test_v3_manifest_and_sdk_import_contracts() -> None:
+    """V3 版本、独立配置身份和公开 SDK 导入必须保持一致。"""
+    manifest = json.loads(
+        (REPOSITORY_ROOT / "package.v3.json").read_text(encoding="utf-8")
+    )["CloudStrmIncrement"]
+    legacy = json.loads(
+        (REPOSITORY_ROOT / "package.json").read_text(encoding="utf-8")
+    )["CloudStrmIncrement"]
+
+    assert manifest["version"] == CloudStrmIncrement.plugin_version == "2.0.0"
+    assert manifest["system_version"] == ">=3.0.0"
+    assert manifest["release"] is True
+    assert legacy["v3"] is False
+    assert CloudStrmIncrement.plugin_config_prefix == "cloudstrm_"
+
+    imports = {
+        node.module
+        for node in ast.walk(ast.parse(PLUGIN_PATH.read_text(encoding="utf-8")))
+        if isinstance(node, ast.ImportFrom) and node.module
+    }
+    assert {"app.sdk.config", "app.sdk.events", "app.sdk.logging"}.issubset(imports)
+    forbidden = (
+        "app.adapters",
+        "app.application",
+        "app.core",
+        "app.db",
+        "app.domain",
+        "app.foundation",
+        "app.helper",
+        "app.runtime",
+        "app.sdk._legacy",
+        "app.utils",
+    )
+    assert not any(module.startswith(forbidden) for module in imports)
+    assert "app.log" not in imports
+    assert "BackgroundScheduler" not in PLUGIN_PATH.read_text(encoding="utf-8")
+
+
+def test_scan_archives_media_then_deletes_increment_and_keeps_named_parent(
+    tmp_path: Path,
+) -> None:
+    """输出成功后才删除增量文件，并停止清理配置为保留的空目录。"""
+    increment = tmp_path / "increment"
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    increment_file = increment / "Keep" / "Show" / "Movie.mp4"
+    increment_file.parent.mkdir(parents=True)
+    increment_file.write_bytes(b"video")
+    plugin = _plugin(
+        f"{increment}#{source}#{target}#/media/cloud",
+        no_del_dirs="keep",
+    )
+
+    assert plugin.scan() is True
+
+    archived = source / "Keep" / "Show" / "Movie.mp4"
+    assert archived.read_bytes() == b"video"
+    assert (target / "Keep" / "Show" / "Movie.strm").read_text(
+        encoding="utf-8"
+    ) == "/media/cloud/Keep/Show/Movie.mp4"
+    assert not increment_file.exists()
+    assert not (increment / "Keep" / "Show").exists()
+    assert (increment / "Keep").is_dir()
+
+
+def test_existing_archive_is_not_overwritten_or_deleted(tmp_path: Path) -> None:
+    """源树已有同名文件时必须保留两侧数据并失败关闭。"""
+    increment = tmp_path / "increment"
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    increment.mkdir()
+    source.mkdir()
+    increment_file = increment / "Movie.mp4"
+    source_file = source / "Movie.mp4"
+    increment_file.write_bytes(b"new")
+    source_file.write_bytes(b"old")
+    plugin = _plugin(f"{increment}#{source}#{target}#/media")
+
+    assert plugin.scan() is False
+    assert increment_file.read_bytes() == b"new"
+    assert source_file.read_bytes() == b"old"
+    assert not (target / "Movie.strm").exists()
+
+
+def test_copy_files_preserves_increment_when_source_deletion_disabled(
+    tmp_path: Path,
+) -> None:
+    """非媒体文件可归档到两级目标，关闭源删除时保留增量副本。"""
+    increment = tmp_path / "increment"
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    increment_file = increment / "Show" / "poster.jpg"
+    increment_file.parent.mkdir(parents=True)
+    increment_file.write_bytes(b"image")
+    plugin = _plugin(
+        f"{increment}#{source}#{target}#/media",
+        copy_files=True,
+        del_source=False,
+    )
+
+    assert plugin.scan() is True
+    assert increment_file.read_bytes() == b"image"
+    assert (source / "Show" / "poster.jpg").read_bytes() == b"image"
+    assert (target / "Show" / "poster.jpg").read_bytes() == b"image"
+
+
+def test_copy_failure_never_deletes_increment_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """归档复制失败时不得删除增量源或创建媒体库输出。"""
+    increment = tmp_path / "increment"
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    increment.mkdir()
+    increment_file = increment / "Movie.mp4"
+    increment_file.write_bytes(b"video")
+    plugin = _plugin(f"{increment}#{source}#{target}#/media")
+    monkeypatch.setattr(
+        plugin,
+        "_CloudStrmIncrement__copy_without_overwrite",
+        Mock(return_value=False),
+    )
+
+    assert plugin.scan() is False
+    assert increment_file.exists()
+    assert not source.exists()
+    assert not target.exists()
+
+
+def test_output_failure_recovers_from_matching_archived_copy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """输出瞬时失败后应复用内容一致的归档副本完成下一次事务。"""
+    increment = tmp_path / "increment"
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    increment.mkdir()
+    increment_file = increment / "Movie.mp4"
+    increment_file.write_bytes(b"video")
+    plugin = _plugin(f"{increment}#{source}#{target}#/media")
+    original = plugin._CloudStrmIncrement__atomic_create_text
+    attempts = 0
+
+    def fail_once(path: Path, content: str) -> bool:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return False
+        return original(path, content)
+
+    monkeypatch.setattr(
+        plugin, "_CloudStrmIncrement__atomic_create_text", fail_once
+    )
+
+    assert plugin.scan() is False
+    assert increment_file.exists()
+    assert (source / "Movie.mp4").read_bytes() == b"video"
+    assert plugin.scan() is True
+    assert not increment_file.exists()
+    assert (target / "Movie.strm").read_text(encoding="utf-8") == "/media/Movie.mp4"
+
+
+def test_delete_failure_recovers_without_overwriting_archive(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """增量删除失败后应在下一次扫描重试删除并保留归档副本。"""
+    increment = tmp_path / "increment"
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    increment.mkdir()
+    increment_file = increment / "Movie.mp4"
+    increment_file.write_bytes(b"video")
+    plugin = _plugin(f"{increment}#{source}#{target}#/media")
+    original_unlink = Path.unlink
+    failed = False
+
+    def fail_increment_once(path: Path, *args, **kwargs) -> None:
+        nonlocal failed
+        if path == increment_file and not failed:
+            failed = True
+            raise OSError("busy")
+        original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", fail_increment_once)
+
+    assert plugin.scan() is False
+    assert increment_file.exists()
+    assert (source / "Movie.mp4").read_bytes() == b"video"
+    assert (target / "Movie.strm").exists()
+    assert plugin.scan() is True
+    assert not increment_file.exists()
+    assert (source / "Movie.mp4").read_bytes() == b"video"
+
+
+def test_hidden_and_symlinked_increment_paths_are_skipped(tmp_path: Path) -> None:
+    """隐藏、回收站及软链接路径不得进入归档和输出目录。"""
+    increment = tmp_path / "increment"
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    (increment / ".hidden").mkdir(parents=True)
+    (increment / ".hidden" / "Movie.mp4").write_bytes(b"hidden")
+    (increment / "@Recycle").mkdir()
+    (increment / "@Recycle" / "Deleted.mp4").write_bytes(b"deleted")
+    outside = tmp_path / "outside.mp4"
+    outside.write_bytes(b"outside")
+    (increment / "linked.mp4").symlink_to(outside)
+    plugin = _plugin(f"{increment}#{source}#{target}#/media")
+
+    assert plugin.scan() is True
+    assert not source.exists()
+    assert not target.exists()
+    assert outside.read_bytes() == b"outside"
+
+
+def test_cd2_url_uses_component_relative_cloud_path(tmp_path: Path) -> None:
+    """CD2 URL 必须按云盘根组件映射并使用配置的 HTTPS 协议。"""
+    increment = tmp_path / "increment"
+    cloud_root = tmp_path / "cloud"
+    source = cloud_root / "source"
+    target = tmp_path / "target"
+    increment_file = increment / "Show" / "Movie Name.mp4"
+    increment_file.parent.mkdir(parents=True)
+    increment_file.write_bytes(b"video")
+    plugin = _plugin(
+        f"{increment}#{source}#{target}#cd2#{cloud_root}#localhost:19798/base",
+        https=True,
+    )
+
+    assert plugin.scan() is True
+    content = (target / "Show" / "Movie Name.strm").read_text(encoding="utf-8")
+    assert content == (
+        "https://localhost:19798/base/static/https/localhost:19798/False/"
+        "%2Fsource%2FShow%2FMovie%20Name.mp4"
+    )
+
+
+def test_overlapping_roots_are_rejected(tmp_path: Path) -> None:
+    """相互包含的增量、源和目标目录不得形成递归复制配置。"""
+    increment = tmp_path / "data"
+    source = increment / "source"
+    target = tmp_path / "target"
+    plugin = _plugin(f"{increment}#{source}#{target}#/media")
+
+    assert plugin._monitors == []
+    assert plugin.scan() is False
+
+
+def test_realtime_event_processes_existing_source_file(tmp_path: Path) -> None:
+    """目录监控联动事件应处理源树文件，不重复执行增量复制。"""
+    increment = tmp_path / "increment"
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    source_file = source / "Movie.mp4"
+    source_file.write_bytes(b"video")
+    plugin = _plugin(f"{increment}#{source}#{target}#/media")
+    event = Event(
+        EventType.PluginAction,
+        {"action": "cloudstrm_file", "file_path": str(source_file)},
+    )
+
+    assert plugin.cloudstrm_file(event) is True
+    assert (target / "Movie.strm").read_text(encoding="utf-8") == "/media/Movie.mp4"
+
+
+def test_realtime_event_rejects_source_and_target_symlinks(tmp_path: Path) -> None:
+    """联动事件不得读取源软链接，也不能把目标软链接当作已完成输出。"""
+    increment = tmp_path / "increment"
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    target.mkdir()
+    outside_source = tmp_path / "outside.mp4"
+    outside_source.write_bytes(b"outside")
+    source_link = source / "Linked.mp4"
+    source_link.symlink_to(outside_source)
+    plugin = _plugin(f"{increment}#{source}#{target}#/media")
+
+    source_event = Event(
+        EventType.PluginAction,
+        {"action": "cloudstrm_file", "file_path": str(source_link)},
+    )
+    assert plugin.cloudstrm_file(source_event) is False
+
+    regular_source = source / "Movie.mp4"
+    regular_source.write_bytes(b"video")
+    outside_target = tmp_path / "outside.strm"
+    outside_target.write_text("sentinel", encoding="utf-8")
+    (target / "Movie.strm").symlink_to(outside_target)
+    target_event = Event(
+        EventType.PluginAction,
+        {"action": "cloudstrm_file", "file_path": str(regular_source)},
+    )
+    assert plugin.cloudstrm_file(target_event) is False
+    assert outside_target.read_text(encoding="utf-8") == "sentinel"
+
+    outside_dir = tmp_path / "outside-dir"
+    outside_dir.mkdir()
+    outside_file = outside_dir / "poster.jpg"
+    outside_file.write_bytes(b"private")
+    (source / "linked-dir").symlink_to(outside_dir, target_is_directory=True)
+    plugin.init_plugin(
+        {
+            "enabled": True,
+            "copy_files": True,
+            "monitor_confs": f"{increment}#{source}#{target}#/media",
+        }
+    )
+    middle_link_event = Event(
+        EventType.PluginAction,
+        {
+            "action": "cloudstrm_file",
+            "file_path": str(source / "linked-dir" / "poster.jpg"),
+        },
+    )
+    assert plugin.cloudstrm_file(middle_link_event) is False
+    assert not (target / "linked-dir" / "poster.jpg").exists()
+
+
+def test_host_services_use_timezone_and_reliable_onlyonce(tmp_path: Path) -> None:
+    """cron/date 服务使用宿主时区，once 持久化成功后才执行和消费。"""
+    increment = tmp_path / "increment"
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    increment.mkdir()
+    (increment / "Movie.mp4").write_bytes(b"video")
+    plugin = _plugin(
+        f"{increment}#{source}#{target}#/media",
+        enabled=False,
+        onlyonce=True,
+        cron="0 0 * * *",
+    )
+
+    services = plugin.get_service()
+    assert len(services) == 1
+    assert isinstance(services[0]["trigger"], DateTrigger)
+    assert str(services[0]["trigger"].run_date.tzinfo) == "Asia/Shanghai"
+    assert services[0]["func"]() is True
+    assert plugin._run_once is False
+    assert plugin._onlyonce is False
+    assert plugin.update_config.call_args.args[0]["onlyonce"] is False
+    assert (target / "Movie.strm").exists()
+
+    plugin.init_plugin(
+        {
+            "enabled": True,
+            "cron": "0 0 * * *",
+            "monitor_confs": f"{increment}#{source}#{target}#/media",
+        }
+    )
+    cron = plugin.get_service()[0]["trigger"]
+    assert isinstance(cron, CronTrigger)
+    assert str(cron.timezone) == "Asia/Shanghai"
+
+
+@pytest.mark.parametrize("persisted", [False, RuntimeError("storage unavailable")])
+def test_onlyonce_persistence_failure_keeps_pending_state(
+    tmp_path: Path,
+    persisted: object,
+) -> None:
+    """once 回写失败时不得扫描、消费或删除增量文件。"""
+    increment = tmp_path / "increment"
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    increment.mkdir()
+    increment_file = increment / "Movie.mp4"
+    increment_file.write_bytes(b"video")
+    plugin = _plugin(
+        f"{increment}#{source}#{target}#/media",
+        enabled=False,
+        onlyonce=True,
+    )
+    plugin.update_config = (
+        Mock(side_effect=persisted)
+        if isinstance(persisted, Exception)
+        else Mock(return_value=persisted)
+    )
+
+    assert plugin.get_service()[0]["func"]() is False
+    assert plugin._run_once is True
+    assert plugin._onlyonce is True
+    assert increment_file.exists()
+    assert not source.exists()
+
+
+def test_stop_waits_for_running_scan_and_blocks_stale_callback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """停止返回时文件操作已收敛，过期回调不能继续处理新文件。"""
+    increment = tmp_path / "increment"
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    increment.mkdir()
+    first = increment / "First.mp4"
+    first.write_bytes(b"video")
+    plugin = _plugin(f"{increment}#{source}#{target}#/media")
+    original = plugin._CloudStrmIncrement__process_increment_file
+    entered = threading.Event()
+    release = threading.Event()
+
+    def blocking_process(*args, **kwargs) -> bool:
+        entered.set()
+        assert release.wait(timeout=2)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(
+        plugin, "_CloudStrmIncrement__process_increment_file", blocking_process
+    )
+    scan_worker = threading.Thread(target=plugin.scan)
+    scan_worker.start()
+    assert entered.wait(timeout=1)
+    stop_worker = threading.Thread(target=plugin.stop_service)
+    stop_worker.start()
+    time.sleep(0.05)
+    assert stop_worker.is_alive()
+
+    release.set()
+    scan_worker.join(timeout=2)
+    stop_worker.join(timeout=2)
+    assert not scan_worker.is_alive()
+    assert not stop_worker.is_alive()
+
+    second = increment / "Second.mp4"
+    second.write_bytes(b"video")
+    assert plugin.scan() is False
+    assert second.exists()
+    assert not (target / "Second.strm").exists()

--- a/tests/v3/customcommand/test_plugin.py
+++ b/tests/v3/customcommand/test_plugin.py
@@ -1,0 +1,542 @@
+from __future__ import annotations
+
+import ast
+import io
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, call
+
+from apscheduler.triggers.cron import CronTrigger
+import pytest
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+from app.plugins import customcommand as customcommand_module
+from app.plugins.customcommand import CommandResult, CommandTask, CustomCommand
+from app.runtime.extensions.plugin.projection import PluginProjection
+from app.schemas.types import MessageType
+
+PLUGIN_PATH = REPOSITORY_ROOT / "plugins.v3" / "customcommand" / "__init__.py"
+
+
+@pytest.fixture
+def plugin() -> CustomCommand:
+    """构造不访问真实配置与数据目录的插件实例。"""
+    instance = CustomCommand()
+    instance.systemmessage = Mock()
+    instance.get_data = Mock(return_value=[])
+    instance.save_data = Mock()
+    return instance
+
+
+def test_manifest_and_strict_v3_import_contract() -> None:
+    """版本、代际路由和稳定 SDK 导入必须保持一致。"""
+    manifest = json.loads(
+        (REPOSITORY_ROOT / "package.v3.json").read_text(encoding="utf-8")
+    )["CustomCommand"]
+    legacy = json.loads(
+        (REPOSITORY_ROOT / "package.json").read_text(encoding="utf-8")
+    )["CustomCommand"]
+
+    assert manifest["version"] == CustomCommand.plugin_version == "2.0.0"
+    assert manifest["release"] is True
+    assert manifest["system_version"] == ">=3.0.0"
+    assert list(manifest["history"]) == ["v2.0.0"]
+    assert legacy["v3"] is False
+
+    tree = ast.parse(PLUGIN_PATH.read_text(encoding="utf-8"))
+    imports = {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module
+    }
+    assert {"app.sdk.config", "app.sdk.logging"}.issubset(imports)
+    forbidden = (
+        "app.adapters",
+        "app.application",
+        "app.core",
+        "app.db",
+        "app.domain",
+        "app.foundation",
+        "app.helper",
+        "app.log",
+        "app.runtime",
+        "app.sdk._legacy",
+        "app.utils",
+    )
+    assert not any(module.startswith(forbidden) for module in imports)
+    assert "BackgroundScheduler" not in PLUGIN_PATH.read_text(encoding="utf-8")
+
+
+def test_services_isolate_invalid_lines_and_use_host_scheduler(
+    plugin: CustomCommand,
+) -> None:
+    """错误行不得阻断合法 cron，随机延时在注册阶段完成校验。"""
+    plugin.init_plugin({
+        "enabled": True,
+        "time_confs": (
+            "备份#0 1 * * *#echo ok#1-3\n"
+            "错误行\n"
+            "坏cron#not cron#echo bad\n"
+            "坏延时#0 2 * * *#echo bad#3-1\n"
+            "# 注释"
+        ),
+    })
+
+    services = plugin.get_service()
+
+    assert len(services) == 1
+    service = services[0]
+    assert service["id"] == "CustomCommand.1"
+    assert service["name"] == "备份（随机延时 1-3 秒）"
+    assert isinstance(service["trigger"], CronTrigger)
+    assert str(service["trigger"].timezone) == "Asia/Shanghai"
+    assert service["func"] == plugin._run_periodic_task
+    assert service["kwargs"] == {}
+    assert service["func_kwargs"]["task"].command == "echo ok"
+    assert plugin.systemmessage.put.call_count == 3
+
+
+def test_onlyonce_projects_date_service_and_preserves_periodic_services(
+    plugin: CustomCommand,
+) -> None:
+    """一次性状态必须可被宿主投影，同时不隐藏已启用的周期任务。"""
+    plugin.init_plugin({
+        "enabled": True,
+        "onlyonce": True,
+        "time_confs": "任务#0 1 * * *#echo ok",
+    })
+
+    services = PluginProjection({"CustomCommand": plugin}).services()
+
+    assert [service["id"] for service in services] == [
+        "CustomCommand.Once",
+        "CustomCommand.1",
+    ]
+    assert services[0]["trigger"] == "date"
+    assert isinstance(services[0]["kwargs"]["run_date"], datetime)
+    assert plugin._run_once is True
+    assert plugin._onlyonce is True
+
+
+def test_onlyonce_waits_for_slot_then_consumes_full_config(
+    plugin: CustomCommand,
+) -> None:
+    """一次性任务必须先取得执行槽，持久化成功后再执行全部任务。"""
+    plugin.init_plugin({
+        "enabled": True,
+        "onlyonce": True,
+        "notify": True,
+        "msgtype": "Manual",
+        "history_days": 5,
+        "notify_keywords": "ok",
+        "time_confs": "一#0 1 * * *#echo one\n二#0 2 * * *#echo two#1-9",
+    })
+    plugin.update_config = Mock(return_value=True)
+    plugin._run_task = Mock(
+        return_value=CommandResult(returncode=0, stdout="ok\n")
+    )
+    plugin._run_lock.acquire()
+    result: dict[str, object] = {}
+    started = threading.Event()
+
+    def invoke() -> None:
+        started.set()
+        result["value"] = plugin._run_once_tasks()
+
+    worker = threading.Thread(target=invoke)
+    worker.start()
+    assert started.wait(timeout=1)
+    time.sleep(0.05)
+    plugin.update_config.assert_not_called()
+
+    plugin._run_lock.release()
+    worker.join(timeout=2)
+
+    assert not worker.is_alive()
+    assert result["value"] is True
+    plugin.update_config.assert_called_once_with({
+        "enabled": True,
+        "onlyonce": False,
+        "notify": True,
+        "msgtype": "Manual",
+        "time_confs": "一#0 1 * * *#echo one\n二#0 2 * * *#echo two#1-9",
+        "history_days": 5,
+        "notify_keywords": "ok",
+        "clear": False,
+    })
+    assert [call.args[0].name for call in plugin._run_task.call_args_list] == ["一", "二"]
+    assert all(call.kwargs == {"apply_delay": False} for call in plugin._run_task.call_args_list)
+    assert plugin._run_once is False
+    assert plugin._onlyonce is False
+
+
+@pytest.mark.parametrize("persisted", [False, RuntimeError("storage unavailable")])
+def test_onlyonce_persistence_failure_keeps_pending_state(
+    plugin: CustomCommand,
+    persisted: object,
+) -> None:
+    """配置回写失败时不得执行或消费一次性任务。"""
+    plugin.init_plugin({
+        "onlyonce": True,
+        "time_confs": "任务#0 1 * * *#echo ok",
+    })
+    if isinstance(persisted, Exception):
+        plugin.update_config = Mock(side_effect=persisted)
+    else:
+        plugin.update_config = Mock(return_value=persisted)
+    plugin._run_task = Mock()
+
+    result = plugin._run_once_tasks()
+
+    assert result[0] is False
+    assert plugin._run_once is True
+    assert plugin._onlyonce is True
+    plugin._run_task.assert_not_called()
+
+
+def test_process_streams_output_and_keeps_stdout_last_line(
+    monkeypatch: pytest.MonkeyPatch,
+    plugin: CustomCommand,
+) -> None:
+    """两个输出管道应持续消费，历史显示保持 stdout 最后一行优先。"""
+    process = SimpleNamespace(
+        returncode=3,
+        stdout=io.StringIO("first\nlast\n"),
+        stderr=io.StringIO("error\n"),
+        wait=Mock(return_value=None),
+    )
+    popen = Mock(return_value=process)
+    monkeypatch.setattr(customcommand_module.subprocess, "Popen", popen)
+
+    result = plugin._execute_process("demo")
+
+    assert result.success is False
+    assert result.message == "last"
+    assert popen.call_args.args == ("demo",)
+    assert popen.call_args.kwargs == {
+        "shell": True,
+        "stdout": customcommand_module.subprocess.PIPE,
+        "stderr": customcommand_module.subprocess.PIPE,
+        "text": True,
+        "encoding": "utf-8",
+        "errors": "replace",
+        **(
+            {"creationflags": getattr(customcommand_module.subprocess, "CREATE_NEW_PROCESS_GROUP", 0)}
+            if os.name == "nt"
+            else {"start_new_session": True}
+        ),
+    }
+    process.wait.assert_called_once_with()
+
+
+def test_output_is_truncated_without_unbounded_result(
+    monkeypatch: pytest.MonkeyPatch,
+    plugin: CustomCommand,
+) -> None:
+    """超长 stdout/stderr 只保留有限尾部并标注截断。"""
+    process = SimpleNamespace(
+        returncode=0,
+        stdout=io.StringIO("head\n" + "x" * (customcommand_module.MAX_OUTPUT_SIZE + 100) + "\nlast\n"),
+        stderr=io.StringIO("error\n" + "y" * (customcommand_module.MAX_OUTPUT_SIZE + 100)),
+        wait=Mock(return_value=None),
+    )
+    monkeypatch.setattr(customcommand_module.subprocess, "Popen", Mock(return_value=process))
+
+    result = plugin._execute_process("demo")
+
+    assert len(result.stdout) <= customcommand_module.MAX_OUTPUT_SIZE
+    assert len(result.stderr) <= customcommand_module.MAX_OUTPUT_SIZE
+    assert result.stdout.startswith("[输出已截断]\n")
+    assert result.stderr.startswith("[输出已截断]\n")
+    assert result.stdout.endswith("last\n")
+
+
+def test_stop_service_terminates_long_command_and_clears_handle(
+    plugin: CustomCommand,
+) -> None:
+    """长命令应可由 stop_service 收敛，且执行结束后不残留句柄。"""
+    command = subprocess.list2cmdline([
+        sys.executable,
+        "-c",
+        "import time; time.sleep(60)",
+    ])
+    result: dict[str, CommandResult] = {}
+
+    worker = threading.Thread(
+        target=lambda: result.update(value=plugin._execute_process(command)),
+    )
+    worker.start()
+    try:
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline:
+            with plugin._process_lock:
+                if plugin._process is not None:
+                    break
+            time.sleep(0.01)
+        with plugin._process_lock:
+            assert plugin._process is not None
+
+        plugin.stop_service()
+        worker.join(timeout=5)
+
+        assert not worker.is_alive()
+        assert plugin._process is None
+        assert result["value"].returncode != 0
+    finally:
+        plugin.stop_service()
+        worker.join(timeout=5)
+
+
+def test_natural_exit_does_not_terminate_or_clear_replacement_process(
+    plugin: CustomCommand,
+) -> None:
+    """自然退出的旧进程不应误杀或清除后来登记的新进程。"""
+    old_process = SimpleNamespace(
+        pid=111,
+        poll=Mock(return_value=0),
+        terminate=Mock(),
+        kill=Mock(),
+    )
+    new_process = SimpleNamespace(pid=222)
+    with plugin._process_lock:
+        plugin._process = old_process
+
+    plugin.stop_service()
+    with plugin._process_lock:
+        plugin._process = new_process
+    plugin._clear_process(old_process)
+
+    old_process.terminate.assert_not_called()
+    old_process.kill.assert_not_called()
+    assert plugin._process is new_process
+
+
+def test_stop_service_escalates_after_timeout_and_clears_handle(
+    monkeypatch: pytest.MonkeyPatch,
+    plugin: CustomCommand,
+) -> None:
+    """首次终止未收敛时应升级信号，并在有限等待后清理句柄。"""
+    process = SimpleNamespace(
+        pid=123,
+        poll=Mock(return_value=None),
+        wait=Mock(
+            side_effect=[
+                subprocess.TimeoutExpired("demo", customcommand_module.PROCESS_STOP_TIMEOUT),
+                None,
+            ]
+        ),
+    )
+    killpg = Mock()
+    monkeypatch.setattr(customcommand_module.os, "killpg", killpg)
+    with plugin._process_lock:
+        plugin._process = process
+
+    plugin.stop_service()
+
+    assert killpg.call_args_list == [
+        call(123, customcommand_module.signal.SIGTERM),
+        call(123, customcommand_module.signal.SIGKILL),
+    ]
+    assert process.wait.call_args_list == [
+        call(timeout=customcommand_module.PROCESS_STOP_TIMEOUT),
+        call(timeout=customcommand_module.PROCESS_STOP_TIMEOUT),
+    ]
+    assert plugin._process is None
+
+
+def test_stop_service_keeps_handle_when_force_kill_does_not_converge(
+    monkeypatch: pytest.MonkeyPatch,
+    plugin: CustomCommand,
+) -> None:
+    """两轮停止都超时时保留句柄，使后续生命周期仍能重试收敛。"""
+    timeout = subprocess.TimeoutExpired(
+        "demo", customcommand_module.PROCESS_STOP_TIMEOUT
+    )
+    process = SimpleNamespace(
+        pid=321,
+        poll=Mock(return_value=None),
+        wait=Mock(side_effect=[timeout, timeout]),
+    )
+    monkeypatch.setattr(customcommand_module.os, "killpg", Mock())
+    with plugin._process_lock:
+        plugin._process = process
+
+    assert plugin.stop_service() is False
+
+    assert plugin._process is process
+
+
+def test_disable_cancels_task_during_delay_before_process_start(
+    monkeypatch: pytest.MonkeyPatch,
+    plugin: CustomCommand,
+) -> None:
+    """任务取得执行槽但尚未创建进程时，禁用必须中断延时并阻止启动。"""
+    plugin.init_plugin({"enabled": True})
+    execute = Mock()
+    monkeypatch.setattr(plugin, "_execute_process", execute)
+    monkeypatch.setattr(customcommand_module.random, "randint", Mock(return_value=60))
+    task = CommandTask(
+        name="delayed",
+        cron="0 0 * * *",
+        command="echo late",
+        random_delay="60-60",
+        line_number=1,
+    )
+    result: dict[str, object] = {}
+    worker = threading.Thread(
+        target=lambda: result.update(value=plugin._run_periodic_task(task))
+    )
+    worker.start()
+    deadline = time.monotonic() + 1
+    while time.monotonic() < deadline and plugin._run_lock.acquire(blocking=False):
+        plugin._run_lock.release()
+        time.sleep(0.01)
+
+    plugin.init_plugin({"enabled": False})
+    worker.join(timeout=2)
+
+    assert not worker.is_alive()
+    execute.assert_not_called()
+    assert result["value"] == (False, "任务已停止")
+
+
+def test_init_plugin_stops_running_process_before_disabling(
+    monkeypatch: pytest.MonkeyPatch,
+    plugin: CustomCommand,
+) -> None:
+    """同实例禁用必须走真实停止路径收敛旧进程并清理句柄。"""
+    process = SimpleNamespace(
+        pid=456,
+        poll=Mock(return_value=None),
+        wait=Mock(return_value=None),
+    )
+    terminate = Mock()
+    monkeypatch.setattr(plugin, "_terminate_process", terminate)
+    with plugin._process_lock:
+        plugin._process = process
+
+    plugin.init_plugin({"enabled": False, "time_confs": "任务#0 1 * * *#echo ok"})
+
+    terminate.assert_called_once_with(process, force=False)
+    process.wait.assert_called_once_with(timeout=customcommand_module.PROCESS_STOP_TIMEOUT)
+    assert plugin._process is None
+    assert plugin.get_state() is False
+
+
+def test_init_plugin_rejects_config_switch_when_process_does_not_stop(
+    monkeypatch: pytest.MonkeyPatch,
+    plugin: CustomCommand,
+) -> None:
+    """旧进程未收敛时不得清除停止态或应用下一套命令配置。"""
+    plugin._enabled = True
+    plugin._time_confs = "old#0 0 * * *#echo old"
+    timeout = subprocess.TimeoutExpired(
+        "demo", customcommand_module.PROCESS_STOP_TIMEOUT
+    )
+    process = SimpleNamespace(
+        pid=654,
+        poll=Mock(return_value=None),
+        wait=Mock(side_effect=[timeout, timeout]),
+    )
+    monkeypatch.setattr(customcommand_module.os, "killpg", Mock())
+    with plugin._process_lock:
+        plugin._process = process
+
+    plugin.init_plugin(
+        {"enabled": True, "time_confs": "new#0 1 * * *#echo new"}
+    )
+
+    assert plugin._process is process
+    assert plugin._stop_event.is_set()
+    assert plugin._time_confs == "old#0 0 * * *#echo old"
+
+
+def test_run_task_saves_history_and_filters_notification(
+    monkeypatch: pytest.MonkeyPatch,
+    plugin: CustomCommand,
+) -> None:
+    """执行结果应写入历史，并按关键词和消息类型发送通知。"""
+    plugin.init_plugin({
+        "notify": True,
+        "msgtype": "Plugin",
+        "notify_keywords": "completed",
+        "history_days": 30,
+    })
+    plugin.post_message = Mock()
+    monkeypatch.setattr(
+        plugin,
+        "_execute_process",
+        Mock(return_value=CommandResult(returncode=0, stdout="completed\n")),
+    )
+    task = customcommand_module.CommandTask(1, "备份", "0 1 * * *", "echo ok")
+
+    result = plugin._run_task(task, apply_delay=False)
+
+    assert result.success is True
+    saved = plugin.save_data.call_args.kwargs["value"]
+    assert saved[-1]["name"] == "备份"
+    assert saved[-1]["command"] == "echo ok"
+    assert saved[-1]["result"] == "completed"
+    plugin.post_message.assert_called_once_with(
+        title="备份",
+        mtype=MessageType.Plugin,
+        text="completed",
+    )
+
+
+def test_periodic_single_flight_skips_overlap(plugin: CustomCommand) -> None:
+    """周期任务重叠时不得启动第二个命令。"""
+    task = customcommand_module.CommandTask(1, "备份", "0 1 * * *", "echo ok")
+    plugin._run_task = Mock()
+    assert plugin._run_lock.acquire(blocking=False) is True
+    try:
+        result = plugin._run_periodic_task(task)
+    finally:
+        plugin._run_lock.release()
+
+    assert result[0] is False
+    assert "已跳过" in result[1]
+    plugin._run_task.assert_not_called()
+
+
+def test_once_isolates_task_side_effect_failure(plugin: CustomCommand) -> None:
+    """单个任务的历史或通知异常不得阻断其它已消费的一次性任务。"""
+    plugin.init_plugin({
+        "onlyonce": True,
+        "time_confs": "一#0 1 * * *#echo one\n二#0 2 * * *#echo two",
+    })
+    plugin.update_config = Mock(return_value=True)
+    plugin._run_task = Mock(
+        side_effect=[RuntimeError("history unavailable"), CommandResult(returncode=0)]
+    )
+
+    result = plugin._run_once_tasks()
+
+    assert result == (False, "一次性任务执行失败：一")
+    assert plugin._run_task.call_count == 2
+    assert plugin._run_lock.acquire(blocking=False) is True
+    plugin._run_lock.release()
+
+
+def test_clear_history_and_static_surfaces(plugin: CustomCommand) -> None:
+    """清理开关应立即消费，静态接口和页面保持稳定结构。"""
+    plugin.del_data = Mock()
+    plugin.update_config = Mock(return_value=True)
+    plugin.init_plugin({"clear": True, "history_days": "invalid"})
+
+    plugin.del_data.assert_called_once_with("history")
+    assert plugin.update_config.call_args.args[0]["clear"] is False
+    assert plugin.update_config.call_args.args[0]["history_days"] == 30
+    assert plugin.get_command() == []
+    assert plugin.get_api() == []
+    assert plugin.get_service() == []
+    assert plugin.get_page()[0]["text"] == "暂无数据"
+    assert plugin.get_form()[1]["history_days"] == 30
+    assert plugin.stop_service() is None

--- a/tests/v3/dockermanager/test_plugin.py
+++ b/tests/v3/dockermanager/test_plugin.py
@@ -1,0 +1,365 @@
+from __future__ import annotations
+
+import ast
+import json
+import threading
+import time
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from apscheduler.triggers.cron import CronTrigger
+import pytest
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+from app.plugins import dockermanager as dockermanager_module
+from app.plugins.dockermanager import ContainerResult, DockerManager, DockerTask
+from app.runtime.extensions.plugin.projection import PluginProjection
+from app.schemas.types import MessageType
+
+PLUGIN_PATH = REPOSITORY_ROOT / "plugins.v3" / "dockermanager" / "__init__.py"
+
+
+@pytest.fixture
+def plugin() -> DockerManager:
+    """构造不访问真实配置、数据和 Docker daemon 的插件实例。"""
+    instance = DockerManager()
+    instance.systemmessage = Mock()
+    instance.get_data = Mock(return_value=[])
+    instance.save_data = Mock()
+    return instance
+
+
+def _container(
+    name: str | None,
+    *,
+    host_name: str | None = None,
+    icon: str | None = None,
+) -> SimpleNamespace:
+    """构造满足 Docker SDK 动态边界的容器替身。"""
+    env = [f"HOST_CONTAINERNAME={host_name}"] if host_name else None
+    labels = {"net.unraid.docker.icon": icon} if icon else None
+    attrs = {"Config": {"Env": env, "Labels": labels}}
+    return SimpleNamespace(
+        name=name,
+        attrs=attrs,
+        restart=Mock(),
+        start=Mock(),
+        stop=Mock(),
+        pause=Mock(),
+        unpause=Mock(),
+        update=Mock(),
+    )
+
+
+def test_manifest_and_strict_v3_contract() -> None:
+    """版本、代际路由、SDK 导入和宿主 Docker 配置必须保持一致。"""
+    manifest = json.loads(
+        (REPOSITORY_ROOT / "package.v3.json").read_text(encoding="utf-8")
+    )["DockerManager"]
+    legacy = json.loads(
+        (REPOSITORY_ROOT / "package.json").read_text(encoding="utf-8")
+    )["DockerManager"]
+
+    assert manifest["version"] == DockerManager.plugin_version == "2.0.0"
+    assert manifest["release"] is True
+    assert manifest["system_version"] == ">=3.0.0"
+    assert list(manifest["history"]) == ["v2.0.0"]
+    assert legacy["v3"] is False
+
+    tree = ast.parse(PLUGIN_PATH.read_text(encoding="utf-8"))
+    imports = {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module
+    }
+    assert {"app.sdk.config", "app.sdk.logging"}.issubset(imports)
+    forbidden = (
+        "app.adapters",
+        "app.application",
+        "app.core",
+        "app.db",
+        "app.domain",
+        "app.foundation",
+        "app.helper",
+        "app.log",
+        "app.runtime",
+        "app.sdk._legacy",
+        "app.utils",
+    )
+    assert not any(module.startswith(forbidden) for module in imports)
+    source = PLUGIN_PATH.read_text(encoding="utf-8")
+    assert "BackgroundScheduler" not in source
+    assert "tcp://127.0.0.1:38379" not in source
+    assert "settings.DOCKER_CLIENT_API" in source
+
+
+def test_services_isolate_invalid_lines_and_project_once(
+    plugin: DockerManager,
+) -> None:
+    """错误行与命令应隔离，once 和合法 cron 同时交由宿主管理。"""
+    plugin.init_plugin({
+        "enabled": True,
+        "onlyonce": True,
+        "time_confs": (
+            "app,db,app#0 1 * * *#restart\n"
+            "错误行\n"
+            "bad#0 2 * * *#remove\n"
+            "cron#not cron#start"
+        ),
+    })
+
+    services = PluginProjection({"DockerManager": plugin}).services()
+
+    assert [service["id"] for service in services] == [
+        "DockerManager.Once",
+        "DockerManager.1",
+    ]
+    assert services[0]["trigger"] == "date"
+    assert isinstance(services[0]["kwargs"]["run_date"], datetime)
+    periodic = services[1]
+    assert isinstance(periodic["trigger"], CronTrigger)
+    assert str(periodic["trigger"].timezone) == "Asia/Shanghai"
+    assert periodic["func_kwargs"]["task"].container_names == ("app", "db")
+    assert plugin.systemmessage.put.call_count == 3
+
+
+def test_client_uses_host_setting_and_is_reused(
+    monkeypatch: pytest.MonkeyPatch,
+    plugin: DockerManager,
+) -> None:
+    """Docker client 必须使用宿主地址，并在插件生命周期内复用。"""
+    client = Mock()
+    factory = Mock(return_value=client)
+    monkeypatch.setattr(dockermanager_module.docker, "DockerClient", factory)
+    monkeypatch.setattr(
+        dockermanager_module,
+        "settings",
+        SimpleNamespace(TZ="Asia/Shanghai", DOCKER_CLIENT_API="unix:///docker.sock"),
+    )
+
+    assert plugin._get_client() is client
+    assert plugin._get_client() is client
+
+    factory.assert_called_once_with(base_url="unix:///docker.sock")
+
+
+def test_container_identity_handles_missing_dynamic_fields() -> None:
+    """HOST_CONTAINERNAME 缺失时应回退标准名称，空 attrs 不得抛异常。"""
+    unraid = _container("docker-name", host_name="unraid-name")
+    standard = _container("docker-name")
+    raw = SimpleNamespace(attrs={"Name": "/raw-name"})
+    empty = SimpleNamespace(attrs=None)
+
+    assert DockerManager._container_name(unraid) == "unraid-name"
+    assert DockerManager._container_name(standard) == "docker-name"
+    assert DockerManager._container_name(raw) == "raw-name"
+    assert DockerManager._container_name(empty) is None
+    assert DockerManager._container_icon(empty) is None
+
+
+def test_task_executes_matches_reports_missing_and_notifies(
+    plugin: DockerManager,
+) -> None:
+    """已匹配与缺失容器都应形成历史和聚合通知结果。"""
+    app = _container(
+        "docker-app",
+        host_name="app",
+        icon="https://example.com/app.png",
+    )
+    client = Mock()
+    client.containers.list.return_value = [app, _container("other")]
+    plugin._docker_client = client
+    plugin.post_message = Mock()
+    plugin.init_plugin({
+        "notify": True,
+        "msgtype": "Plugin",
+        "history_days": 7,
+    })
+    # init_plugin 会释放旧 client；执行阶段显式注入隔离替身。
+    plugin._docker_client = client
+    task = DockerTask(1, ("app", "missing"), "0 1 * * *", "restart")
+
+    results = plugin._run_task(task)
+
+    assert [result.success for result in results] == [True, False]
+    assert results[1].error == "未找到容器"
+    app.restart.assert_called_once_with()
+    saved = plugin.save_data.call_args.kwargs["value"]
+    assert [(item["name"], item["result"]) for item in saved] == [
+        ("app", "success"),
+        ("missing", "fail"),
+    ]
+    plugin.post_message.assert_called_once_with(
+        title="docker任务通知",
+        mtype=MessageType.Plugin,
+        text=(
+            "容器：app restart success\n"
+            "容器：missing restart fail：未找到容器"
+        ),
+        image=None,
+    )
+
+
+def test_single_container_notification_uses_optional_http_icon(
+    plugin: DockerManager,
+) -> None:
+    """单容器任务可使用 HTTP 图标，多容器或本地图标不透传。"""
+    plugin.init_plugin({"notify": True, "msgtype": "Manual"})
+    plugin.post_message = Mock()
+    task = DockerTask(1, ("app",), "0 1 * * *", "start")
+    result = ContainerResult(
+        name="app",
+        command="start",
+        success=True,
+        icon="https://example.com/app.png",
+    )
+
+    plugin._notify_results(task, [result])
+
+    assert plugin.post_message.call_args.kwargs["image"] == "https://example.com/app.png"
+
+
+def test_container_failure_isolated_from_other_targets(plugin: DockerManager) -> None:
+    """单个 Docker SDK 操作失败不得阻断同任务中的其它容器。"""
+    broken = _container("broken")
+    broken.stop.side_effect = RuntimeError("denied")
+    healthy = _container("healthy")
+    client = Mock()
+    client.containers.list.return_value = [broken, healthy]
+    plugin._docker_client = client
+    task = DockerTask(1, ("broken", "healthy"), "0 1 * * *", "stop")
+
+    results = plugin._run_task(task)
+
+    assert [result.success for result in results] == [False, True]
+    assert results[0].error == "denied"
+    healthy.stop.assert_called_once_with()
+
+
+def test_periodic_single_flight_skips_overlap(plugin: DockerManager) -> None:
+    """周期任务重叠时不得访问 Docker client。"""
+    task = DockerTask(1, ("app",), "0 1 * * *", "restart")
+    plugin._run_task = Mock()
+    assert plugin._run_lock.acquire(blocking=False) is True
+    try:
+        result = plugin._run_periodic_task(task)
+    finally:
+        plugin._run_lock.release()
+
+    assert result[0] is False
+    assert "已跳过" in result[1]
+    plugin._run_task.assert_not_called()
+
+
+def test_once_waits_then_consumes_full_config(plugin: DockerManager) -> None:
+    """一次性任务应等待执行槽，并在完整配置回写成功后执行。"""
+    plugin.init_plugin({
+        "enabled": True,
+        "onlyonce": True,
+        "notify": True,
+        "msgtype": "Manual",
+        "history_days": 5,
+        "time_confs": "app#0 1 * * *#restart",
+    })
+    plugin.update_config = Mock(return_value=True)
+    plugin._run_task = Mock(
+        return_value=[ContainerResult("app", "restart", True)]
+    )
+    plugin._run_lock.acquire()
+    result: dict[str, object] = {}
+    started = threading.Event()
+
+    def invoke() -> None:
+        started.set()
+        result["value"] = plugin._run_once_tasks()
+
+    worker = threading.Thread(target=invoke)
+    worker.start()
+    assert started.wait(timeout=1)
+    time.sleep(0.05)
+    plugin.update_config.assert_not_called()
+
+    plugin._run_lock.release()
+    worker.join(timeout=2)
+
+    assert not worker.is_alive()
+    assert result["value"] is True
+    plugin.update_config.assert_called_once_with({
+        "enabled": True,
+        "onlyonce": False,
+        "notify": True,
+        "msgtype": "Manual",
+        "time_confs": "app#0 1 * * *#restart",
+        "history_days": 5,
+        "clear": False,
+    })
+    assert plugin._run_once is False
+    assert plugin._onlyonce is False
+
+
+@pytest.mark.parametrize("persisted", [False, RuntimeError("storage unavailable")])
+def test_once_persistence_failure_keeps_pending_state(
+    plugin: DockerManager,
+    persisted: object,
+) -> None:
+    """配置回写失败时不得访问 Docker 或消费一次性任务。"""
+    plugin.init_plugin({
+        "onlyonce": True,
+        "time_confs": "app#0 1 * * *#restart",
+    })
+    if isinstance(persisted, Exception):
+        plugin.update_config = Mock(side_effect=persisted)
+    else:
+        plugin.update_config = Mock(return_value=persisted)
+    plugin._run_task = Mock()
+
+    result = plugin._run_once_tasks()
+
+    assert result[0] is False
+    assert plugin._run_once is True
+    assert plugin._onlyonce is True
+    plugin._run_task.assert_not_called()
+
+
+def test_stop_service_waits_for_run_and_closes_client(plugin: DockerManager) -> None:
+    """停止插件必须等待任务释放执行槽，再关闭并清空 client。"""
+    client = Mock()
+    plugin._docker_client = client
+    plugin._run_lock.acquire()
+    completed = threading.Event()
+
+    def stop() -> None:
+        plugin.stop_service()
+        completed.set()
+
+    worker = threading.Thread(target=stop)
+    worker.start()
+    time.sleep(0.05)
+    assert not completed.is_set()
+    client.close.assert_not_called()
+
+    plugin._run_lock.release()
+    worker.join(timeout=2)
+
+    assert completed.is_set()
+    client.close.assert_called_once_with()
+    assert plugin._docker_client is None
+
+
+def test_clear_history_and_static_surfaces(plugin: DockerManager) -> None:
+    """清理开关立即消费，静态接口和页面保持明确结构。"""
+    plugin.del_data = Mock()
+    plugin.update_config = Mock(return_value=True)
+    plugin.init_plugin({"clear": True, "history_days": "invalid"})
+
+    plugin.del_data.assert_called_once_with("history")
+    assert plugin.update_config.call_args.args[0]["clear"] is False
+    assert plugin.update_config.call_args.args[0]["history_days"] == 30
+    assert plugin.get_command() == []
+    assert plugin.get_api() == []
+    assert plugin.get_service() == []
+    assert plugin.get_page()[0]["text"] == "暂无数据"
+    assert plugin.get_form()[1]["history_days"] == 30
+    assert plugin.stop_service() is None


### PR DESCRIPTION
## 目标

完成第七批 MoviePilot V3 严格迁移，将命令、Docker 管理和云盘 STRM 全量/增量处理插件切换到独立 V3 实现。

## 主要变化

- 新增 `CustomCommand`、`DockerManager`、`CloudStrm` 和 `CloudStrmIncrement` 的独立 V3 实现。
- `CustomCommand` 与 `DockerManager` 迁移到公开 SDK 配置、日志和宿主调度合同，收口命令结果、超时及 Docker client 生命周期。
- `CloudStrm` 与 `CloudStrmIncrement` 迁移全量/增量扫描、索引、路径映射、归档和删除边界，并由宿主统一管理定时及一次性任务。
- 同步插件版本、发布历史和代际路由；版本分别为 `2.0.0`、`2.0.0`、`5.0.0`、`2.0.0`。
- 四个新增测试目录直接复用仓级共享 bootstrap 与 Chain fixture，不再维护逐文件运行时垫片。

## 关键边界

- V3 生产实现不使用 `app.sdk._legacy`，不直接访问宿主 Model、Session 或非公开应用层入口。
- Docker 操作使用明确的 client 生命周期与失败结果；容器状态无法确认时不推断操作成功。
- 云盘扫描、索引写入、源文件删除和路径映射均保持失败关闭，未确认的路径或不完整状态不会触发破坏性处理。

## 验证

- 整仓 pytest：`370 passed`
- V3 全量测试：`364 passed`
- Batch 07 聚焦测试：`63 passed`
- CI 合同测试：`4 passed`；根合同测试：`2 passed`
- 插件版本门禁、三份 package JSON 解析和 4 个 V3 插件目录编译通过
- replay 与 candidate 生产树一致性、非公开宿主导入扫描、代际发布路由、`package.v2.json` 不变和 `git diff --check` 通过
