### PR TITLE
chore(v3): 收口旧代插件回退范围

### DIFF
--- a/package.json
+++ b/package.json
@@ -576,6 +576,7 @@
     "description": "HomePage自定义API。",
     "labels": "工具",
     "version": "1.2",
+    "v3": false,
     "icon": "https://raw.githubusercontent.com/thsrite/MoviePilot-Plugins/main/icons/homepage.png",
     "author": "thsrite",
     "level": 1,

--- a/package.json
+++ b/package.json
@@ -513,6 +513,7 @@
     "description": "定时刷新Emby媒体库元数据，演职人员中文。",
     "labels": "Emby",
     "version": "1.7.5",
+    "v3": false,
     "icon": "https://raw.githubusercontent.com/thsrite/MoviePilot-Plugins/main/icons/emby-icon.png",
     "author": "thsrite",
     "level": 1,

--- a/package.json
+++ b/package.json
@@ -290,6 +290,7 @@
     "description": "监控视频短剧创建，刮削。",
     "labels": "刮削",
     "version": "3.2.1",
+    "v3": false,
     "icon": "Amule_B.png",
     "author": "thsrite",
     "level": 1,

--- a/package.json
+++ b/package.json
@@ -191,6 +191,7 @@
     "description": "同步MoviePilot站点Cookie到本地CookieCloud。",
     "labels": "站点",
     "version": "1.3",
+    "v3": false,
     "icon": "https://raw.githubusercontent.com/thsrite/MoviePilot-Plugins/main/icons/cookiecloud.png",
     "author": "thsrite",
     "level": 1,

--- a/package.json
+++ b/package.json
@@ -306,6 +306,7 @@
     "description": "监控云盘目录文件变化，自动转移链接。",
     "labels": "云盘",
     "version": "2.4.7",
+    "v3": false,
     "icon": "Linkease_A.png",
     "author": "thsrite",
     "level": 1,

--- a/package.json
+++ b/package.json
@@ -487,6 +487,7 @@
     "description": "电视剧下载后自动添加官组等信息到订阅；添加订阅后根据二级分类名称自定义订阅规则。",
     "labels": "订阅",
     "version": "2.7",
+    "v3": false,
     "icon": "teamwork.png",
     "author": "thsrite",
     "level": 2,

--- a/package.json
+++ b/package.json
@@ -538,6 +538,7 @@
     "description": "自动给媒体库媒体添加标签。",
     "labels": "Emby",
     "version": "1.2",
+    "v3": false,
     "icon": "https://raw.githubusercontent.com/thsrite/MoviePilot-Plugins/main/icons/tag.png",
     "author": "thsrite",
     "level": 1,

--- a/package.json
+++ b/package.json
@@ -355,6 +355,7 @@
     "description": "根据正则转发通知到其他WeChat应用。",
     "labels": "消息通知",
     "version": "2.7",
+    "v3": false,
     "icon": "Wechat_A.png",
     "author": "thsrite",
     "level": 1,

--- a/package.json
+++ b/package.json
@@ -752,6 +752,7 @@
     "description": "监控未上线影视作品，自动添加订阅。",
     "labels": "订阅",
     "version": "1.1",
+    "v3": false,
     "icon": "https://raw.githubusercontent.com/thsrite/MoviePilot-Plugins/main/icons/mediarelease.png",
     "author": "thsrite",
     "level": 1,


### PR DESCRIPTION
## 背景

V3 迁移完成后，部分已有 V3 实现仍允许市场从旧代索引回退，可能继续加载旧实现；`SyncCookieCloud` 则已由官方插件仓继续维护。

## 调整

- 为 `ShortPlayMonitor`、`CloudLinkMonitor`、`WeChatForward`、`SubscribeGroup`、`EmbyMetaRefresh`、`EmbyMetaTag`、`HomePage`、`MediaRelease` 的旧代条目补充 `v3: false`，确保 V3 只使用对应的 `plugins.v3` 实现。
- 为 `SyncCookieCloud` 补充 `v3: false`，避免个人仓旧实现与官方维护版本在 V3 市场重复回退。
- 不修改插件源码、版本号或发布历史。

经维护者确认，`SiteUnreadMsg`、`PluginAutoUpdate`、`PluginReInstall`、`PluginUnInstall`、`DirMonitorEnhanced`、`SqlExecute` 暂不迁移，继续保留旧代 V3 兼容回退。

## 验证

- 三份 package JSON 解析通过
- 插件版本门禁通过
- CI 与根合同测试：`6 passed`
- 旧代/V3 联合索引盘点通过：除上述 6 个兼容例外外，无未迁移且未明确退出 V3 的旧代插件
- `git diff --check` 通过
