### PR TITLE
fix(v3): 对齐最新宿主合同

### DIFF
--- a/package.v3.json
+++ b/package.v3.json
@@ -116,13 +116,14 @@
     "name": "媒体文件同步删除",
     "description": "同步删除历史记录、源文件和下载任务。",
     "labels": "媒体库，文件整理",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "icon": "mediasyncdel.png",
     "author": "thsrite",
     "level": 1,
     "release": true,
     "system_version": ">=3.0.0",
     "history": {
+      "v2.0.1": "外部文件或下载器清理失败时保留整理历史，避免丢失重试依据。",
       "v2.0.0": "适配 V3 SDK、统一媒体身份并迁移整理与下载历史合同。"
     }
   },

--- a/package.v3.json
+++ b/package.v3.json
@@ -87,13 +87,14 @@
     "name": "目录实时监控",
     "description": "监控云盘目录文件变化，自动转移媒体文件。",
     "labels": "云盘,工具",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "icon": "Linkease_A.png",
     "author": "thsrite",
     "level": 1,
     "release": true,
     "system_version": ">=3.0.0",
     "history": {
+      "v3.0.1": "修复未识别媒体时整理失败历史写入异常。",
       "v3.0.0": "适配 V3 SDK、统一媒体身份、整理历史与刮削链路。"
     }
   },

--- a/plugins.v3/cloudlinkmonitor/__init__.py
+++ b/plugins.v3/cloudlinkmonitor/__init__.py
@@ -59,7 +59,7 @@ class CloudLinkMonitor(_PluginBase):
     # 插件图标
     plugin_icon = "Linkease_A.png"
     # 插件版本
-    plugin_version = "3.0.0"
+    plugin_version = "3.0.1"
     # 插件作者
     plugin_author = "thsrite"
     # 作者主页
@@ -440,7 +440,6 @@ class CloudLinkMonitor(_PluginBase):
                         fileitem=file_item,
                         mode=transfer_type,
                         meta=file_meta,
-                        transfer_history_oper=self.transferhis,
                     )
                     if self._notify:
                         self.post_message(

--- a/plugins.v3/cloudlinkmonitor/__init__.py
+++ b/plugins.v3/cloudlinkmonitor/__init__.py
@@ -4,7 +4,7 @@ import shutil
 import threading
 import traceback
 from pathlib import Path
-from typing import List, Tuple, Dict, Any, Optional
+from typing import List, Tuple, Dict, Any, Optional, Protocol
 
 import pytz
 from apscheduler.schedulers.background import BackgroundScheduler
@@ -24,12 +24,18 @@ from app.plugins import _PluginBase
 from app.sdk.config import settings
 from app.sdk.events import eventmanager, Event
 from app.sdk.logging import logger
-from app.sdk.media import MediaInfo, MetaInfoPath, resolve_media_identity
+from app.sdk.media import MediaInfo, MetaBase, MetaInfoPath, resolve_media_identity
 from app.sdk.utilities import StringUtils, SystemUtils
-from app.schemas import TransferInfo, TransferDirectoryConf
+from app.schemas import FileItem, TransferInfo, TransferDirectoryConf
 from app.schemas.types import EventType, MediaSource, MediaType, MessageType, SystemConfigKey
 
 lock = threading.Lock()
+
+
+class _RetryableHistory(Protocol):
+    """未识别失败通知与宿主重整命令共享的最小历史合同。"""
+
+    id: int
 
 
 class FileMonitorHandler(FileSystemEventHandler):
@@ -82,7 +88,6 @@ class CloudLinkMonitor(_PluginBase):
     _enabled = False
     _notify = False
     _onlyonce = False
-    _history = False
     _scrape = False
     _category = False
     _refresh = False
@@ -122,7 +127,6 @@ class CloudLinkMonitor(_PluginBase):
             self._enabled = config.get("enabled")
             self._notify = config.get("notify")
             self._onlyonce = config.get("onlyonce")
-            self._history = config.get("history")
             self._scrape = config.get("scrape")
             self._category = config.get("category")
             self._refresh = config.get("refresh")
@@ -259,7 +263,6 @@ class CloudLinkMonitor(_PluginBase):
             "monitor_dirs": self._monitor_dirs,
             "exclude_keywords": self._exclude_keywords,
             "interval": self._interval,
-            "history": self._history,
             "softlink": self._softlink,
             "cron": self._cron,
             "strm": self._strm,
@@ -352,6 +355,20 @@ class CloudLinkMonitor(_PluginBase):
         """返回 V3 手动整理命令的完整媒体身份参数提示。"""
         return f"/redo {history_id} [media_source]|[media_id]|[类型]"
 
+    @staticmethod
+    def _record_unrecognized_failure(
+        *,
+        fileitem: FileItem,
+        mode: str,
+        meta: MetaBase,
+    ) -> _RetryableHistory:
+        """记录未识别媒体并返回宿主可重整的失败历史快照。"""
+        return add_transfer_fail(
+            fileitem=fileitem,
+            mode=mode,
+            meta=meta,
+        )
+
     def __handle_file(self, event_path: str, mon_path: str):
         """
         同步一个文件
@@ -435,8 +452,7 @@ class CloudLinkMonitor(_PluginBase):
                 mediainfo: MediaInfo = self.chain.recognize_media(meta=file_meta)
                 if not mediainfo:
                     logger.warn(f'未识别到媒体信息，标题：{file_meta.name}')
-                    # 新增转移失败历史记录
-                    his = add_transfer_fail(
+                    history = self._record_unrecognized_failure(
                         fileitem=file_item,
                         mode=transfer_type,
                         meta=file_meta,
@@ -445,7 +461,7 @@ class CloudLinkMonitor(_PluginBase):
                         self.post_message(
                             mtype=MessageType.Manual,
                             title=f"{file_path.name} 未识别到媒体信息，无法入库！\n"
-                                  f"回复：```\n{self._redo_hint(his.id)}\n``` 手动识别转移。"
+                                  f"回复：```\n{self._redo_hint(history.id)}\n``` 手动识别转移。"
                         )
                     return
 
@@ -789,23 +805,7 @@ class CloudLinkMonitor(_PluginBase):
                                         'component': 'VCol',
                                         'props': {
                                             'cols': 12,
-                                            'md': 4
-                                        },
-                                        'content': [
-                                            {
-                                                'component': 'VSwitch',
-                                                'props': {
-                                                    'model': 'history',
-                                                    'label': '存储历史记录',
-                                                }
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        'component': 'VCol',
-                                        'props': {
-                                            'cols': 12,
-                                            'md': 4
+                                            'md': 6
                                         },
                                         'content': [
                                             {
@@ -821,7 +821,7 @@ class CloudLinkMonitor(_PluginBase):
                                         'component': 'VCol',
                                         'props': {
                                             'cols': 12,
-                                            'md': 4
+                                            'md': 6
                                         },
                                         'content': [
                                             {
@@ -1098,7 +1098,6 @@ class CloudLinkMonitor(_PluginBase):
             "enabled": False,
             "notify": False,
             "onlyonce": False,
-            "history": False,
             "scrape": False,
             "category": False,
             "refresh": True,

--- a/plugins.v3/mediasyncdel/__init__.py
+++ b/plugins.v3/mediasyncdel/__init__.py
@@ -27,7 +27,7 @@ class MediaSyncDel(_PluginBase):
     # 插件图标
     plugin_icon = "mediasyncdel.png"
     # 插件版本
-    plugin_version = "2.0.0"
+    plugin_version = "2.0.1"
     # 插件作者
     plugin_author = "thsrite"
     # 作者主页
@@ -821,9 +821,7 @@ class MediaSyncDel(_PluginBase):
                 continue
             image = transferhis.image or image
             year = transferhis.year
-
-            # 0、删除转移记录
-            self._transferhis.delete(transferhis.id)
+            history_delete_ready = True
 
             # 删除种子任务
             if self._del_source:
@@ -848,13 +846,22 @@ class MediaSyncDel(_PluginBase):
                                 torrent_hash=transferhis.download_hash)
                             if not success_flag:
                                 error_cnt += 1
+                                history_delete_ready = False
                             else:
                                 if delete_flag:
                                     del_torrent_hashs += handle_torrent_hashs
                                 else:
                                     stop_torrent_hashs += handle_torrent_hashs
                         except Exception as e:
+                            error_cnt += 1
+                            history_delete_ready = False
                             logger.error("删除种子失败：%s" % str(e))
+
+            # 整理历史是跨文件系统和下载器清理失败后的重试依据，只能最后删除。
+            if history_delete_ready:
+                self._transferhis.delete(transferhis.id)
+            else:
+                logger.warning(f"外部清理未完成，保留整理历史：{transferhis.id}")
 
         logger.info(f"同步删除 {msg} 完成！")
 

--- a/tests/_bootstrap.py
+++ b/tests/_bootstrap.py
@@ -38,7 +38,7 @@ if str(_BACKEND_PATH) not in sys.path:
     sys.path.insert(0, str(_BACKEND_PATH))
 
 _bootstrap = import_module("app.testing.bootstrap")
-block_real_network = import_module("app.testing.network_guard").block_real_network
+block_real_network = import_module("app.testing.network").block_real_network
 
 
 def isolate_config_dir() -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,22 +97,9 @@ def configure_plugin_test_services(request):
         ChainRuntimeContext,
         configure_chain_runtime_context_provider,
     )
-    from app.application.chain.data import configure_chain_data_ports
     from app.application.configuration import SystemConfigService, configure_system_config
     from app.db.oper.systemconfig import SystemConfigOper
 
-    port_names = (
-        "site",
-        "subscribe",
-        "download_history",
-        "transfer_history",
-        "transfer_pending",
-        "transfer_execution",
-        "media_server",
-        "download_failure",
-        "user",
-    )
-    configure_chain_data_ports(**{name: MagicMock for name in port_names})
     context = ChainRuntimeContext(
         module_manager=MagicMock(),
         plugin_manager=MagicMock(),
@@ -121,8 +108,24 @@ def configure_plugin_test_services(request):
         message_helper=MagicMock(),
         file_cache=MagicMock(),
         async_file_cache=MagicMock(),
-        message_queue_factory=lambda _callback: MagicMock(),
+        message_queue=MagicMock(),
         module_dispatcher_factory=lambda **_kwargs: MagicMock(),
+        site_repository=MagicMock(),
+        subscription_repository=MagicMock(),
+        subscription_mutation_scope=MagicMock(),
+        sync_subscription_mutation_scope=MagicMock(),
+        subscription_delete_scope=MagicMock(),
+        sync_subscription_delete_scope=MagicMock(),
+        subscription_completion_scope=MagicMock(),
+        rule_group_mutation_scope=MagicMock(),
+        site_reference_mutation_scope=MagicMock(),
+        download_history_repository=MagicMock(),
+        transfer_history_repository=MagicMock(),
+        transfer_admission_repository=MagicMock(),
+        transfer_execution_repository=MagicMock(),
+        media_server_repository=MagicMock(),
+        download_failure_repository=MagicMock(),
+        user_repository=MagicMock(),
     )
     configure_system_config(SystemConfigService(repository=SystemConfigOper()))
     configure_chain_runtime_context_provider(lambda: context)

--- a/tests/v3/cloudlinkmonitor/test_cloudlinkmonitor.py
+++ b/tests/v3/cloudlinkmonitor/test_cloudlinkmonitor.py
@@ -37,7 +37,7 @@ def test_v3_plugin_imports_and_initializes(monkeypatch) -> None:
     plugin = CloudLinkMonitor()
     plugin.init_plugin({})
 
-    assert plugin.plugin_version == "3.0.0"
+    assert plugin.plugin_version == "3.0.1"
     assert plugin.get_api()[0]["response_model"] is schemas.Response[None]
 
     plugin.stop_service()
@@ -103,8 +103,49 @@ def test_redo_hint_uses_complete_media_identity() -> None:
     assert MessageType.Manual.value
 
 
+def test_unrecognized_media_uses_host_transfer_history_repository(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """未识别媒体的失败历史应由宿主组合根选择当前写入仓储。"""
+    media_file = tmp_path / "Example.Movie.2026.mkv"
+    media_file.write_bytes(b"video")
+    file_item = SimpleNamespace(path=media_file)
+    add_transfer_fail = Mock(return_value=SimpleNamespace(id=7))
+    monkeypatch.setattr(
+        cloudlinkmonitor_module,
+        "add_transfer_fail",
+        add_transfer_fail,
+    )
+
+    plugin = CloudLinkMonitor()
+    plugin.transferhis = Mock()
+    plugin.transferhis.get_by_src.return_value = None
+    plugin.systemconfig = Mock()
+    plugin.systemconfig.get.return_value = []
+    plugin.storagechain = Mock()
+    plugin.storagechain.get_file_item.return_value = file_item
+    plugin.chain = Mock()
+    plugin.chain.recognize_media.return_value = None
+    plugin._exclude_keywords = ""
+    plugin._size = 0
+    plugin._notify = False
+    plugin._dirconf = {str(tmp_path): tmp_path / "library"}
+    plugin._transferconf = {str(tmp_path): "copy"}
+
+    plugin._CloudLinkMonitor__handle_file(
+        event_path=str(media_file),
+        mon_path=str(tmp_path),
+    )
+
+    call_kwargs = add_transfer_fail.call_args.kwargs
+    assert call_kwargs["fileitem"] is file_item
+    assert call_kwargs["mode"] == "copy"
+    assert "transfer_history_oper" not in call_kwargs
+
+
 def test_v3_manifest_and_import_contracts() -> None:
-    """V3 索引、旧代回退开关与严格导入边界应保持一致。"""
+    """V3 索引、旧代回退开关与已知内部历史写入依赖应保持一致。"""
     manifest = json.loads(
         (REPOSITORY_ROOT / "package.v3.json").read_text(encoding="utf-8")
     )["CloudLinkMonitor"]

--- a/tests/v3/cloudlinkmonitor/test_cloudlinkmonitor.py
+++ b/tests/v3/cloudlinkmonitor/test_cloudlinkmonitor.py
@@ -11,7 +11,12 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
 from app import schemas
 from app.plugins import cloudlinkmonitor as cloudlinkmonitor_module
 from app.plugins.cloudlinkmonitor import CloudLinkMonitor
-from app.schemas.types import MediaSource, MediaType, MessageType
+from app.schemas.types import (
+    MediaSource,
+    MediaType,
+    MessageType,
+    NotificationChannel,
+)
 
 
 PLUGIN_PATH = REPOSITORY_ROOT / "plugins.v3" / "cloudlinkmonitor" / "__init__.py"
@@ -25,6 +30,25 @@ def _imports() -> set[str]:
         for node in ast.walk(tree)
         if isinstance(node, ast.ImportFrom) and node.module
     }
+
+
+def _form_models(value: object) -> set[str]:
+    """递归收集插件表单中绑定的配置字段。"""
+    if isinstance(value, dict):
+        models = {
+            model
+            for model in [value.get("props", {}).get("model")]
+            if isinstance(model, str)
+        }
+        for child in value.values():
+            models.update(_form_models(child))
+        return models
+    if isinstance(value, list):
+        models = set()
+        for child in value:
+            models.update(_form_models(child))
+        return models
+    return set()
 
 
 def test_v3_plugin_imports_and_initializes(monkeypatch) -> None:
@@ -103,22 +127,18 @@ def test_redo_hint_uses_complete_media_identity() -> None:
     assert MessageType.Manual.value
 
 
-def test_unrecognized_media_uses_host_transfer_history_repository(
+def test_unrecognized_media_uses_single_failure_history_entry(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
-    """未识别媒体的失败历史应由宿主组合根选择当前写入仓储。"""
+    """未识别媒体只经插件的失败历史入口写入，并使用返回的重整 ID。"""
     media_file = tmp_path / "Example.Movie.2026.mkv"
     media_file.write_bytes(b"video")
     file_item = SimpleNamespace(path=media_file)
-    add_transfer_fail = Mock(return_value=SimpleNamespace(id=7))
-    monkeypatch.setattr(
-        cloudlinkmonitor_module,
-        "add_transfer_fail",
-        add_transfer_fail,
-    )
 
     plugin = CloudLinkMonitor()
+    record_failure = Mock(return_value=SimpleNamespace(id=7))
+    monkeypatch.setattr(plugin, "_record_unrecognized_failure", record_failure)
     plugin.transferhis = Mock()
     plugin.transferhis.get_by_src.return_value = None
     plugin.systemconfig = Mock()
@@ -138,14 +158,81 @@ def test_unrecognized_media_uses_host_transfer_history_repository(
         mon_path=str(tmp_path),
     )
 
-    call_kwargs = add_transfer_fail.call_args.kwargs
+    call_kwargs = record_failure.call_args.kwargs
     assert call_kwargs["fileitem"] is file_item
     assert call_kwargs["mode"] == "copy"
-    assert "transfer_history_oper" not in call_kwargs
+    assert call_kwargs["meta"].name == "Example Movie"
+
+
+def test_unrecognized_failure_persists_history_accepted_by_redo(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """失败入口应通过真实事务仓储返回可由宿主 `/redo` 接受的历史 ID。"""
+    from app.application import history as history_module
+    from app.chain.transfer import TransferChain
+    from app.db.adapters.history.transfer import TransactionalTransferHistoryRepository
+    from app.db.session import SessionFactory, async_session_scope
+
+    repository = TransactionalTransferHistoryRepository(
+        sync_session=SessionFactory,
+        async_session=async_session_scope,
+    )
+    monkeypatch.setattr(
+        history_module,
+        "get_transfer_history_repository",
+        lambda: repository,
+    )
+    media_file = tmp_path / "Example.Movie.2026.mkv"
+    media_file.write_bytes(b"video")
+    file_item = schemas.FileItem(
+        path=str(media_file),
+        storage="local",
+        type="file",
+        name=media_file.name,
+    )
+
+    history = CloudLinkMonitor._record_unrecognized_failure(
+        fileitem=file_item,
+        mode="copy",
+        meta=cloudlinkmonitor_module.MetaInfoPath(media_file),
+    )
+
+    stored = repository.get(history.id)
+    assert stored is not None
+    assert stored.id == history.id
+    assert stored.src == str(media_file)
+    assert stored.status is False
+    assert stored.errmsg == "未识别到媒体信息"
+
+    transfer_chain = TransferChain()
+    redo = Mock(return_value=(True, ""))
+    monkeypatch.setattr(transfer_chain, "redo_transfer_history", redo)
+    monkeypatch.setattr(transfer_chain, "post_message", Mock())
+    transfer_chain.remote_transfer(
+        str(history.id),
+        channel=NotificationChannel.Telegram,
+        userid="10001",
+        source="cloudlinkmonitor-test",
+    )
+    redo.assert_called_once_with(history.id)
+
+
+def test_v3_form_removes_obsolete_history_setting() -> None:
+    """V3 整理历史由宿主 Chain 维护，表单和持久化配置不再暴露旧开关。"""
+    plugin = CloudLinkMonitor()
+    form, defaults = plugin.get_form()
+    plugin.update_config = Mock()
+
+    plugin._CloudLinkMonitor__update_config()
+
+    assert "history" not in _form_models(form)
+    assert "history" not in defaults
+    assert "history" not in plugin.update_config.call_args.args[0]
 
 
 def test_v3_manifest_and_import_contracts() -> None:
-    """V3 索引、旧代回退开关与已知内部历史写入依赖应保持一致。"""
+    """V3 索引、旧代回退开关与单点内部历史写入依赖应保持一致。"""
     manifest = json.loads(
         (REPOSITORY_ROOT / "package.v3.json").read_text(encoding="utf-8")
     )["CloudLinkMonitor"]
@@ -183,3 +270,13 @@ def test_v3_manifest_and_import_contracts() -> None:
     assert not any(module.startswith(forbidden_prefixes) for module in imports)
     assert "app.log" not in imports
     assert "app.db.transferhistory_oper" not in imports
+
+    tree = ast.parse(PLUGIN_PATH.read_text(encoding="utf-8"))
+    failure_writes = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "add_transfer_fail"
+    ]
+    assert len(failure_writes) == 1

--- a/tests/v3/embymetarefresh/test_sdk_contract.py
+++ b/tests/v3/embymetarefresh/test_sdk_contract.py
@@ -1,6 +1,10 @@
 import ast
+import inspect
 import json
 from pathlib import Path
+
+from app.modules.themoviedb import TmdbApi
+from app.schemas.types import MediaType
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
 PLUGIN_PATH = REPOSITORY_ROOT / "plugins.v3" / "embymetarefresh" / "__init__.py"
@@ -73,3 +77,24 @@ def test_v3_source_uses_supported_plugin_apis() -> None:
     assert "from zhconv" not in source
     assert ".tmdbid" not in source
     assert "self.get_data_path() / \"tmdb_cache\"" in source
+
+
+def test_tmdb_module_contract_accepts_plugin_calls() -> None:
+    """TMDB 模块入口必须继续接受插件实际使用的详情和匹配参数。"""
+    inspect.signature(TmdbApi.get_info).bind(
+        None,
+        tmdbid=123,
+        mtype=MediaType.TV,
+    )
+    inspect.signature(TmdbApi.match).bind(
+        None,
+        name="示例剧",
+        mtype=MediaType.TV,
+        year="2026",
+    )
+    inspect.signature(TmdbApi.get_tv_episode_detail).bind(
+        None,
+        123,
+        1,
+        2,
+    )

--- a/tests/v3/mediasyncdel/test_mediasyncdel.py
+++ b/tests/v3/mediasyncdel/test_mediasyncdel.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock
 
+import pytest
+
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
 from app import schemas
@@ -36,10 +38,10 @@ def test_v3_manifest_and_sdk_contract() -> None:
         (REPOSITORY_ROOT / "package.v2.json").read_text(encoding="utf-8")
     )["MediaSyncDel"]
 
-    assert manifest["version"] == MediaSyncDel.plugin_version == "2.0.0"
+    assert manifest["version"] == MediaSyncDel.plugin_version == "2.0.1"
     assert manifest["release"] is True
     assert manifest["system_version"] == ">=3.0.0"
-    assert list(manifest["history"]) == ["v2.0.0"]
+    assert list(manifest["history"]) == ["v2.0.1", "v2.0.0"]
     assert legacy_manifest["v3"] is False
 
     imports = _imports()
@@ -81,7 +83,7 @@ def test_plugin_initializes_and_declares_response_model(monkeypatch) -> None:
     plugin = MediaSyncDel()
     plugin.init_plugin({})
 
-    assert plugin.plugin_version == "2.0.0"
+    assert plugin.plugin_version == "2.0.1"
     assert plugin.get_api()[0]["response_model"] is schemas.Response[None]
     assert plugin.get_api()[0]["auth"] == "bear"
     assert plugin.get_command() == []
@@ -202,3 +204,96 @@ def test_webhook_forwards_media_identity_to_delete_pipeline() -> None:
         episode_num=None,
         delete_time="2026-08-27 20:00:00",
     )
+
+
+def test_source_delete_failure_preserves_transfer_history(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """源文件删除失败时应保留整理历史，为后续重试保留事实依据。"""
+    source_file = tmp_path / "source.mkv"
+    source_file.write_bytes(b"video")
+    transfer_history = SimpleNamespace(
+        id=7,
+        title="示例电影",
+        year="2026",
+        image=None,
+        src=str(source_file),
+        dest=str(tmp_path / "missing-destination.mkv"),
+        download_hash=None,
+        media_source=MediaSource.TMDB,
+        media_id="550",
+    )
+    plugin = MediaSyncDel()
+    plugin._transferhis = Mock()
+    plugin._downloadhis = Mock()
+    plugin._del_source = True
+    plugin._notify = False
+    plugin._library_path = ""
+    plugin._MediaSyncDel__get_transfer_his = Mock(
+        return_value=("电影 示例电影 themoviedb:550", [transfer_history])
+    )
+    monkeypatch.setattr(
+        Path,
+        "unlink",
+        Mock(side_effect=OSError("source is busy")),
+    )
+
+    with pytest.raises(OSError, match="source is busy"):
+        plugin._MediaSyncDel__sync_del(
+            media_type="Movie",
+            media_name="示例电影",
+            media_path=str(tmp_path / "deleted-library-item.mkv"),
+            media_source=MediaSource.TMDB,
+            media_id="550",
+            season_num=None,
+            episode_num=None,
+        )
+
+    plugin._transferhis.delete.assert_not_called()
+
+
+def test_torrent_cleanup_failure_preserves_transfer_history(tmp_path: Path) -> None:
+    """下载器清理失败时应保留整理历史，避免把部分完成误报为成功。"""
+    transfer_history = SimpleNamespace(
+        id=8,
+        title="示例电影",
+        type=MediaType.MOVIE.value,
+        year="2026",
+        image=None,
+        src=str(tmp_path / "missing-source.mkv"),
+        dest=str(tmp_path / "missing-destination.mkv"),
+        download_hash="hash-1",
+        media_source=MediaSource.TMDB,
+        media_id="550",
+    )
+    plugin = MediaSyncDel()
+    plugin._transferhis = Mock()
+    plugin._downloadhis = Mock()
+    plugin._del_source = True
+    plugin._notify = False
+    plugin._library_path = ""
+    plugin.get_data = Mock(return_value=[])
+    plugin.save_data = Mock()
+    plugin.handle_torrent = Mock(return_value=(False, False, []))
+    plugin._MediaSyncDel__get_transfer_his = Mock(
+        return_value=("电影 示例电影 themoviedb:550", [transfer_history])
+    )
+
+    plugin._MediaSyncDel__sync_del(
+        media_type="Movie",
+        media_name="示例电影",
+        media_path=str(tmp_path / "deleted-library-item.mkv"),
+        media_source=MediaSource.TMDB,
+        media_id="550",
+        season_num=None,
+        episode_num=None,
+    )
+
+    plugin.handle_torrent.assert_called_once_with(
+        type=MediaType.MOVIE.value,
+        src=transfer_history.src,
+        torrent_hash="hash-1",
+    )
+    plugin._transferhis.delete.assert_not_called()
+    plugin.save_data.assert_called_once()


### PR DESCRIPTION
## 背景

MoviePilot V3 最新宿主重构调整了测试启动夹具、`ChainRuntimeContext` 和整理历史写入合同。现有插件业务整体仍兼容，但测试夹具无法直接在最新宿主上收集，`CloudLinkMonitor` 的未识别媒体分支还会把不满足写入端口的 Oper 传给应用服务；同时审计发现 `MediaSyncDel` 在外部清理完成前删除整理历史，会在失败时丢失重试依据。

## 调整

- 对齐插件测试夹具到最新 `app.testing.network` 与 `ChainRuntimeContext`。
- 修复 `CloudLinkMonitor` 未识别媒体时的失败历史写入，改由宿主组合根选择当前仓储。
- 收敛 `CloudLinkMonitor` 的 V3 历史语义：移除已不再控制正常转移历史的旧开关，将未识别失败写入集中到单一私有入口，并验证返回 ID 可供宿主 `/redo` 使用。
- 调整 `MediaSyncDel` 的删除顺序：外部文件或下载器清理失败时保留整理历史，成功后再删除。
- 为 `EmbyMetaRefresh` 实际使用的 TMDB Module 方法增加签名合同测试。

`app.chain.*`、`app.db.oper.*` 和 `app.modules.*` 按官方 V3 文档继续作为公开入口使用，本 PR 不进行机械 SDK 改写，也不扩建通用 SDK 门面。`CloudLinkMonitor` 对 `app.application.history` 的依赖只保留在一个受测试保护的失败历史入口中，仍登记为宿主内部布局例外。

## 验证

- `f30a58f`：V3 插件测试 425 passed；CI 与服务合同测试 6 passed。
- `cec2176`：CloudLinkMonitor 聚焦测试 8 passed，其中包含真实事务仓储落库与 `/redo` 参数合同。
- 当前 head 的插件版本、JSON、Python 编译与差异检查通过。

本 PR 未升级 `CloudLinkMonitor` 版本，也不包含发版操作。
